### PR TITLE
MySQL :: parameterized query

### DIFF
--- a/doc/mysql.md
+++ b/doc/mysql.md
@@ -37,8 +37,10 @@ Either `query` or `table` are required, both at the same time are not supported.
 
 * `domain`: str, required
 * `name`: str, required
-* `query`: str (not empty), required if `table` is not provided. 
+* `query`: str (not empty), required if `table` is not provided.
 * `table`: str (not empty), required if `query` is not provided, will read the whole table.
+* `follow_relations`: bool, default to true. Merges data from foreign key relations.
+* `parameters` dict, optional. Allow to parameterize the query.
 
 ```coffee
 DATA_SOURCES= [
@@ -47,6 +49,9 @@ DATA_SOURCES= [
   name:    '<name>'
   query:    '<query>'
   table:    '<table>'
+  follow_relations: <follow_relations>
+  parameters:
+    key: '<value>'
 ,
   ...
 ]

--- a/doc/mysql.md
+++ b/doc/mysql.md
@@ -47,11 +47,9 @@ DATA_SOURCES= [
   type:    'MySQL'
   domain:    '<domain>'
   name:    '<name>'
-  query:    '<query>'
-  table:    '<table>'
-  follow_relations: <follow_relations>
+  query:    'SELECT * FROM city WHERE country = %(country)s'
   parameters:
-    key: '<value>'
+    country: '<value>'
 ,
   ...
 ]

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 setup(name='toucan_connectors',
-      version='0.0.16',
+      version='0.0.17',
       description='Toucan Toco Connectors',
       author='Toucan Toco',
       author_email='dev@toucantoco.com',

--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -111,6 +111,26 @@ def test_get_df_db(mysql_connector):
     assert len(df[df['Population_City'] > 5000000]) == 24
 
 
+def test_get_df_db_nofollow(mysql_connector):
+    """" It should extract the table City without merges """
+    data_source_spec = {
+        'domain': 'MySQL test',
+        'type': 'external_database',
+        'name': 'Some MySQL provider',
+        'query': 'SELECT * FROM City WHERE Population > %(max_pop)s',
+        'follow_relations': False,
+        'parameters': {'max_pop': 5000000},
+    }
+
+    expected_columns = {'ID', 'Name', 'CountryCode', 'District', 'Population'}
+    data_source = MySQLDataSource(**data_source_spec)
+    df = mysql_connector.get_df(data_source)
+
+    assert not df.empty
+    assert set(df.columns) == expected_columns
+    assert df.shape == (24, 5)
+
+
 def test_clean_response():
     """ It should replace None by np.nan and decode bytes data """
     response = [{'name': 'fway', 'age': 13}, {'name': b'zbruh', 'age': None}]


### PR DESCRIPTION
Add 2 new datasource options (only for mysql connector for now) : 
- `parameters` (dict, default `None`) : parameterized query (you will need a query with `%(param_name)s`)
- `follow_relations` (bool, default `True`) : specific to mysql connector which merges data from foreign key relations → now you can disable this behaviour