### PR TITLE
Feature :: support missing parameters in mongo connector

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 setup(name='toucan_connectors',
-      version='0.2.0',
+      version='0.2.1',
       description='Toucan Toco Connectors',
       author='Toucan Toco',
       author_email='dev@toucantoco.com',

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,18 +1,14 @@
-from toucan_connectors.common import apply_parameters_to_query
+from toucan_connectors.common import nosql_apply_parameters_to_query
 
 
 def test_apply_parameter_to_query():
     parameters = {'param1': 'yo', 'param2': 1}
-    query = "SELECT * FROM blah WHERE name == %(param1)s and %(param2)s"
-    expected = 'SELECT * FROM blah WHERE name == "yo" and 1'
-    res = apply_parameters_to_query(query, parameters)
-    assert res == expected
 
     query = [{'$match': {'domain': '%(param1)s', 'cat': '%(param2)s'}}]
     expected = [{'$match': {'domain': 'yo', 'cat': 1}}]
-    res = apply_parameters_to_query(query, parameters)
+    res = nosql_apply_parameters_to_query(query, parameters)
     assert res == expected
 
     query = [{'$match': {'domain': 'yo', 'cat': 1}}]
-    res = apply_parameters_to_query(query, None)
+    res = nosql_apply_parameters_to_query(query, None)
     assert res == query

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -19,7 +19,7 @@ class GoogleCredentials(BaseModel):
 
 def nosql_apply_parameters_to_query(query, parameters):
     """
-    WARNIING : DO NOT USE THIS WITH VARIANTS OF SQL
+    WARNING : DO NOT USE THIS WITH VARIANTS OF SQL
     Instead use your client library parameter substitution method.
     https://www.owasp.org/index.php/Query_Parameterization_Cheat_Sheet
     """

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel
 import json
 import re
+
+from pydantic import BaseModel
 
 
 class GoogleCredentials(BaseModel):

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -16,7 +16,12 @@ class GoogleCredentials(BaseModel):
     client_x509_cert_url: str
 
 
-def apply_parameters_to_query(query, parameters):
+def nosql_apply_parameters_to_query(query, parameters):
+    """
+    WARNIING : DO NOT USE THIS WITH VARIANTS OF SQL
+    Instead use your client library parameter substitution method.
+    https://www.owasp.org/index.php/Query_Parameterization_Cheat_Sheet
+    """
     if parameters is None:
         return query
     parameters = {key: json.dumps(val) for key, val in parameters.items()}

--- a/toucan_connectors/google_analytics/google_analytics_connector.py
+++ b/toucan_connectors/google_analytics/google_analytics_connector.py
@@ -6,7 +6,7 @@ import pandas as pd
 from pydantic import BaseModel
 
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
-from toucan_connectors.common import GoogleCredentials, apply_parameters_to_query
+from toucan_connectors.common import GoogleCredentials, nosql_apply_parameters_to_query
 
 API = 'analyticsreporting'
 SCOPE = 'https://www.googleapis.com/auth/analytics.readonly'
@@ -170,7 +170,7 @@ class GoogleAnalyticsConnector(ToucanConnector):
             self.credentials.dict(), self.scope
         )
         service = build(API, VERSION, credentials=credentials)
-        report_request = ReportRequest(**apply_parameters_to_query(
+        report_request = ReportRequest(**nosql_apply_parameters_to_query(
             data_source.report_request.dict(),
             data_source.parameters
         ))

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -1,3 +1,5 @@
+from functools import singledispatch
+import re
 from typing import Union
 from urllib.parse import quote_plus
 
@@ -7,6 +9,40 @@ from pydantic import validator
 
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 from toucan_connectors.common import nosql_apply_parameters_to_query
+
+
+PARAM_PATTERN = '%\(\w*\)s'
+
+
+@singledispatch
+def handle_missing_params(d, params):
+    """
+    Remove a dictionary key if it's value has a missing parameter.
+    This is used to support the __VOID__ syntax, wich specific to
+    Toucan Toco use of mongo : cf. https://bit.ly/2Ln6rcf
+    """
+    e = {}
+    for k, v in d.items():
+        if isinstance(v, str):
+            matches = re.findall(PARAM_PATTERN, v)
+            missing_params = [m[2:-2] not in params.keys() for m in matches]
+            if any(missing_params):
+                continue
+            else:
+                e[k] = v
+        elif isinstance(v, dict) or isinstance(v, list):
+            e[k] = handle_missing_params(v, params)
+        else:
+            e[k] = v
+    return e
+
+
+@handle_missing_params.register(list)
+def handle_multiple_steps(l, params):
+    """
+    Handle missing parameters in multiple queries and aggregations
+    """
+    return [handle_missing_params(e, params) for e in l]
 
 
 class MongoDataSource(ToucanDataSource):
@@ -48,12 +84,14 @@ class MongoConnector(ToucanConnector):
         client = pymongo.MongoClient(self.uri)
 
         col = client[self.database][data_source.collection]
-        data = None
+
+        if isinstance(data_source.query, str):
+            data_source.query = {'domain': data_source.query}
+        data_source.query = handle_missing_params(data_source.query, data_source.parameters)
         data_source.query = nosql_apply_parameters_to_query(data_source.query,
                                                             data_source.parameters)
-        if isinstance(data_source.query, str):
-            data = col.find({'domain': data_source.query})
-        elif isinstance(data_source.query, dict):
+        data = []
+        if isinstance(data_source.query, dict):
             data = col.find(data_source.query)
         elif isinstance(data_source.query, list):
             data = col.aggregate(data_source.query)

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -6,7 +6,7 @@ import pymongo
 from pydantic import validator
 
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
-from toucan_connectors.common import apply_parameters_to_query
+from toucan_connectors.common import nosql_apply_parameters_to_query
 
 
 class MongoDataSource(ToucanDataSource):
@@ -49,8 +49,8 @@ class MongoConnector(ToucanConnector):
 
         col = client[self.database][data_source.collection]
         data = None
-        data_source.query = apply_parameters_to_query(data_source.query,
-                                                      data_source.parameters)
+        data_source.query = nosql_apply_parameters_to_query(data_source.query,
+                                                            data_source.parameters)
         if isinstance(data_source.query, str):
             data = col.find({'domain': data_source.query})
         elif isinstance(data_source.query, dict):

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -17,9 +17,9 @@ PARAM_PATTERN = '%\(\w*\)s'
 @singledispatch
 def handle_missing_params(d, params):
     """
-    Remove a dictionary key if it's value has a missing parameter.
-    This is used to support the __VOID__ syntax, wich specific to
-    Toucan Toco use of mongo : cf. https://bit.ly/2Ln6rcf
+    Remove a dictionary key if its value has a missing parameter.
+    This is used to support the __VOID__ syntax, which is specific to
+    the use of mongo at Toucan Toco : cf. https://bit.ly/2Ln6rcf
     """
     e = {}
     for k, v in d.items():


### PR DESCRIPTION
Remove a dictionary key if it's value has a missing parameter.
    This is used to support the `__VOID__` syntax, wich specific to
    Toucan Toco use of mongo : cf. https://bit.ly/2Ln6rcf