### PR TITLE
Feature :: decode bytes columns for MySQL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ classifiers = [
 ]
 
 setup(name='toucan_connectors',
-      version='0.4.0',
+      version='0.4.1',
       description='Toucan Toco Connectors',
       author='Toucan Toco',
       author_email='dev@toucantoco.com',

--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -174,3 +174,7 @@ def test_decode_df():
     assert res['date'].tolist() == ['2013-08-01', '2013-08-02']
     assert res['other'].tolist() == ['pikka', 'chuuu']
     assert res[['country', 'number', 'random']].equals(df[['country', 'number', 'random']])
+
+    df2 = df[['number', 'random']]
+    res = MySQLConnector.decode_df(df2)
+    assert res.equals(df2)

--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -1,6 +1,7 @@
 import collections
 
 import numpy as np
+import pandas as pd
 import pymysql
 import pytest
 
@@ -160,3 +161,16 @@ def test_clean_response():
     assert len(res) == 2
     assert res[1]['name'] == 'zbruh'
     assert np.isnan(res[1]['age'])
+
+
+def test_decode_df():
+    """It should decode the bytes columns"""
+    df = pd.DataFrame({'date': [b'2013-08-01', b'2013-08-02'],
+                       'country': ['France', 'Germany'],
+                       'number': [1, 2],
+                       'other': [b'pikka', b'chuuu'],
+                       'random': [3, 4]})
+    res = MySQLConnector.decode_df(df)
+    assert res['date'].tolist() == ['2013-08-01', '2013-08-02']
+    assert res['other'].tolist() == ['pikka', 'chuuu']
+    assert res[['country', 'number', 'random']].equals(df[['country', 'number', 'random']])

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -239,11 +239,14 @@ class MySQLConnector(ToucanConnector):
         The string columns become nan columns so we remove them from the result,
         we keep the rest and insert it back to the dataframe
         """
-        str_df = (df.select_dtypes([np.object])
-                    .stack()
-                    .str.decode('utf8')
-                    .unstack()
-                    .dropna(axis=1, how='all'))
+        str_df = df.select_dtypes([np.object])
+        if str_df.empty:
+            return df
+
+        str_df = (str_df.stack()
+                        .str.decode('utf8')
+                        .unstack()
+                        .dropna(axis=1, how='all'))
         for col in str_df.columns:
             df[col] = str_df[col]
         return df


### PR DESCRIPTION
Used for `marques-avenue`. Before we used to the method `_clean_response` defined [here](https://github.com/ToucanToco/laputa/blob/marques-avenue/app/connectors/mysql_connector.py#L42) and called [here](https://github.com/ToucanToco/laputa/blob/marques-avenue/app/connectors/sql_connector.py#L68)

Since we want to remove the `follow_relations`, I decided to create a proper method (which may be moved to all dfs in the future if needed)