### PR TITLE
features :: HttpAPI connector

### DIFF
--- a/doc/connectors.md
+++ b/doc/connectors.md
@@ -14,6 +14,8 @@
 
 * [HiveConnector](hive.md)
 
+* [HttpAPIConnector](http_api.md)
+
 * [MSSQLConnector](mssql.md)
 
 * [MicroStrategyConnector](micro_strategy.md)

--- a/doc/http_api.md
+++ b/doc/http_api.md
@@ -1,0 +1,53 @@
+module 'toucan_connectors' has no attribute 'HttpApiConnector'
+module 'toucan_connectors' has no attribute 'ToucanTocoConnector'
+# HttpAPI connector
+
+## Data provider configuration
+
+* `type`: `"HttpAPI"`
+* `name`: str, required
+* `baseroute`: str, required
+* `auth`: `{type: "basic|digest|oauth1", args: [...]}` 
+    cf. [requests auth](http://docs.python-requests.org/en/master/) doc. 
+
+```coffee
+DATA_PROVIDERS= [
+  type:    'HttpAPI'
+  name:    '<name>'
+  baseroute:    '<baseroute>'
+  auth:    '<auth>'
+,
+  ...
+]
+```
+
+
+## Data source configuration
+
+* `domain`: str, required
+* `name`: str, required
+* `url`: str, required
+* `method`: Method, default to GET
+* `headers`: dict
+* `params`: dict
+* `data`: str
+* `filter`: str, [`jq` filter](https://stedolan.github.io/jq/manual/), default to `"."
+* `auth`: Auth
+* `parameters`: dict
+
+```coffee
+DATA_SOURCES= [
+  domain:    '<domain>'
+  name:    '<name>'
+  url:    '<url>'
+  method:    '<method>'
+  headers:    '<headers>'
+  params:    '<params>'
+  data:    '<data>'
+  filter:    '<filter>'
+  auth:    '<auth>'
+  parameters:    '<parameters>'
+,
+  ...
+]
+```

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
     'adobe': ['adobe_analytics'],
     'toucan_toco': ['toucan_client'],
     'hive': ['pyhive[hive]'],
-    'http_api':['requests', 'requests_oauthlib']
+    'http_api': ['requests', 'requests_oauthlib', 'jq']
 }
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ extras_require = {
     'google_analytics': ['google-api-python-client'],
     'adobe': ['adobe_analytics'],
     'toucan_toco': ['toucan_client'],
-    'hive': ['pyhive[hive]']
+    'hive': ['pyhive[hive]'],
+    'http_api':['requests', 'requests_oauthlib']
 }
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 
@@ -32,7 +33,7 @@ classifiers = [
 ]
 
 setup(name='toucan_connectors',
-      version='0.4.0',
+      version='0.5.0',
       description='Toucan Toco Connectors',
       author='Toucan Toco',
       author_email='dev@toucantoco.com',

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -1,14 +1,14 @@
 from toucan_connectors.http_api.http_api_connector import (
-    HttpAPIConnector, 
-    HttpAPIDataSource, 
-    transform_with_jq, 
-    Auth, 
+    HttpAPIConnector,
+    HttpAPIDataSource,
+    transform_with_jq,
+    Auth,
     HTTPBasicAuth
 )
 
-HC = HttpAPIConnector(name = "myHttpConnector", 
-    type ="HttpAPI", baseroute = "https://jsonplaceholder.typicode.com")
-HD = HttpAPIDataSource(name = "myHttpDataSource", domain = "my_domain", url= "/comments")
+HC = HttpAPIConnector(name="myHttpConnector", type="HttpAPI",
+                      baseroute="https://jsonplaceholder.typicode.com")
+HD = HttpAPIDataSource(name="myHttpDataSource", domain="my_domain", url="/comments")
 AT = Auth(type="basic", args=["username", "password"])
 
 
@@ -29,7 +29,7 @@ def test_get_df_with_auth(mocker):
     mocke = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
     mocke.return_value.json.return_value = []
 
-    df = HC.get_df(HD)
+    HC.get_df(HD)
     _, ke = mocke.call_args
 
     assert ke["auth"].username == 'username'
@@ -44,22 +44,21 @@ def test_get_df_with_parameters(mocker):
     mocke = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
     mocke.return_value.json.return_value = []
 
-    df = HC.get_df(HD)
-    _, ke = mocke.call_args    
+    HC.get_df(HD)
+    _, ke = mocke.call_args
 
     assert ke["headers"] == {"name":"raphael"}
-
 
 
 def test_get_df_with_parameters_and_auth(mocker):
     HD.auth = AT
-    HD.parameters = {"first_name" : "raphael"}
-    HD.headers = {"name":"%(first_name)s"}
+    HD.parameters = {"first_name": "raphael"}
+    HD.headers = {"name": "%(first_name)s"}
 
     mocke = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
     mocke.return_value.json.return_value = []
 
-    df = HC.get_df(HD)
-    _, ke = mocke.call_args    
+    HC.get_df(HD)
+    _, ke = mocke.call_args
 
-    assert ke["headers"] == {"name":"raphael"}
+    assert ke["headers"] == {"name": "raphael"}

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -1,0 +1,10 @@
+from toucan_connectors.http_api.http_api_connector import HttpAPIConnector, HttpAPIDataSource
+
+def test_get_df():
+
+    HC = HttpAPIConnector(name = "myHttpConnector", type ="HttpAPI", baseroute = "https://jsonplaceholder.typicode.com")
+    HD = HttpAPIDataSource(name = "myHttpDataSource", domain = "my_domain", url= "/posts", )
+
+    df = HC.get_df(HD)
+    
+    assert df.shape == (100,4)

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -1,10 +1,65 @@
-from toucan_connectors.http_api.http_api_connector import HttpAPIConnector, HttpAPIDataSource
+from toucan_connectors.http_api.http_api_connector import (
+    HttpAPIConnector, 
+    HttpAPIDataSource, 
+    transform_with_jq, 
+    Auth, 
+    HTTPBasicAuth
+)
+
+HC = HttpAPIConnector(name = "myHttpConnector", 
+    type ="HttpAPI", baseroute = "https://jsonplaceholder.typicode.com")
+HD = HttpAPIDataSource(name = "myHttpDataSource", domain = "my_domain", url= "/comments")
+AT = Auth(type="basic", args=["username", "password"])
+
+
+def test_transform_with_jq():
+    assert transform_with_jq(data=[1, 2, 3], jq_filter='.[]+1') == [2, 3, 4]
+    assert transform_with_jq([[1, 2, 3]], '.[]') == [1, 2, 3]
+    assert transform_with_jq(
+        [{'col1': [1, 2], 'col2': [3, 4]}], '.') == [{'col1': [1, 2], 'col2': [3, 4]}]
+
 
 def test_get_df():
+    df = HC.get_df(HD)
+    assert df.shape == (500,5)
 
-    HC = HttpAPIConnector(name = "myHttpConnector", type ="HttpAPI", baseroute = "https://jsonplaceholder.typicode.com")
-    HD = HttpAPIDataSource(name = "myHttpDataSource", domain = "my_domain", url= "/posts", )
+
+def test_get_df_with_auth(mocker):
+    HD.auth = AT
+    mocke = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
+    mocke.return_value.json.return_value = []
 
     df = HC.get_df(HD)
-    
-    assert df.shape == (100,4)
+    _, ke = mocke.call_args
+
+    assert ke["auth"].username == 'username'
+    assert isinstance(ke["auth"], HTTPBasicAuth)
+
+
+def test_get_df_with_parameters(mocker):
+    HD.auth = None
+    HD.parameters = {"first_name" : "raphael"}
+    HD.headers = {"name":"%(first_name)s"}
+
+    mocke = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
+    mocke.return_value.json.return_value = []
+
+    df = HC.get_df(HD)
+    _, ke = mocke.call_args    
+
+    assert ke["headers"] == {"name":"raphael"}
+
+
+
+def test_get_df_with_parameters_and_auth(mocker):
+    HD.auth = AT
+    HD.parameters = {"first_name" : "raphael"}
+    HD.headers = {"name":"%(first_name)s"}
+
+    mocke = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
+    mocke.return_value.json.return_value = []
+
+    df = HC.get_df(HD)
+    _, ke = mocke.call_args    
+
+    assert ke["headers"] == {"name":"raphael"}

--- a/toucan_connectors/__init__.py
+++ b/toucan_connectors/__init__.py
@@ -32,5 +32,7 @@ with suppress(ImportError):
     from .google_analytics.google_analytics_connector import GoogleAnalyticsConnector
 with suppress(ImportError):
     from .hive.hive_connector import HiveConnector
+with suppress(ImportError):
+    from .http_api.http_api_connector import HttpAPIConnector
 
 from .toucan_connector import ToucanDataSource, ToucanConnector

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -1,0 +1,111 @@
+import pandas as pd
+
+from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
+from pydantic import BaseModel, Schema
+from typing import List
+import requests
+from collections import defaultdict
+from jq import jq
+
+
+def transform_with_jq(data: object, jq_filter: str) -> list:
+    """
+    Our standard way to apply a jq filter on data before it's passed to a pd.DataFrame
+    """
+    data = jq(jq_filter).transform(data, multiple_output=True)
+
+    # If the data is already presented as a list of rows,
+    # then undo the nesting caused by "multiple_output" jq option
+    if len(data) == 1 and (isinstance(data[0], list)
+        # detects another valid datastructure [{col1:[value, ...], col2:[value, ...]}]
+        or (isinstance(data[0], dict) and isinstance(list(data[0].values())[0],list))):
+        return data[0]
+
+    return data
+
+
+class AuthType(BaseModel):
+    basic = "basic"
+    digest = "digest"
+    oauth1 = "oauth1"
+
+
+class Auth(BaseModel):
+    type: AuthType
+    args: List[str]
+
+
+class Method(BaseModel):
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+
+
+class HttpAPIDataSource(ToucanDataSource):
+    url: str
+    method: Method = "GET"
+    headers: dict = None
+    params: dict = None
+    _json: dict = Schema(None, alias = 'json')
+    data: str = None
+    filter: str = "."
+
+
+class HttpAPIConnector(ToucanConnector):
+    type = "HttpAPI"
+    data_source_model: HttpAPIDataSource
+    
+    
+    baseroute: str
+    auth : Auth = None
+
+    def _query(self, query):
+        """
+        Get some json data with an HTTP request and run a jq filter on it.
+        Args:
+            query (dict): specific infos about the request (url, http headers, etc.)
+        Returns:
+            data (list): The response from the API in the form of a list of dict
+        """
+
+        REQUESTS_PARAMS = ['url', 'method', 'params', 'data', 'json', 'headers']
+
+        jq_filter = query['filter']
+        query = {k: v for k, v in list(query.items()) if k in REQUESTS_PARAMS}
+        query['url'] = '/'.join([
+            self.baseroute.rstrip('/'),
+            query['url'].lstrip('/')
+        ])
+        # query['auth'] = self.get_auth()
+        res = requests.request(**query)
+
+        try:
+            data = res.json()
+        except ValueError:
+            logger.error(f'Could not decode "{res.content}"')
+            raise
+
+        try:
+            return transform_with_jq(data, jq_filter)
+        except ValueError:
+            logger.error(f'Could not transform {data} using {jq_filter}')
+            raise
+
+
+    def get_df(self, data_source: HttpAPIDataSource) -> pd.DataFrame:
+
+        query = data_source.dict()
+        
+        if hasattr(self, 'template'):
+            for k, v in list(self.template.items()):
+                query[k].update(v)
+                if k in config:
+                    query[k].update(config[k])
+        data = self._query(query)
+
+
+
+
+
+
+        return pd.DataFrame(data)


### PR DESCRIPTION
Avant : HttpAPI connector était dans Laputa, ne supportait pas le passage de paramètres de la front config
Maintenant : HttpAPI connector est dans Laputa et dans toucan-connector, support le passage de paramètres par le frontend