### PR TITLE
features :: HttpAPI connector

### DIFF
--- a/doc/connectors.md
+++ b/doc/connectors.md
@@ -14,6 +14,8 @@
 
 * [HiveConnector](hive.md)
 
+* [HttpAPIConnector](http_api.md)
+
 * [MSSQLConnector](mssql.md)
 
 * [MicroStrategyConnector](micro_strategy.md)

--- a/doc/http_api.md
+++ b/doc/http_api.md
@@ -1,0 +1,53 @@
+module 'toucan_connectors' has no attribute 'HttpApiConnector'
+module 'toucan_connectors' has no attribute 'ToucanTocoConnector'
+# HttpAPI connector
+
+## Data provider configuration
+
+* `type`: `"HttpAPI"`
+* `name`: str, required
+* `baseroute`: str, required
+* `auth`: `{type: "basic|digest|oauth1", args: [...]}` 
+    cf. [requests auth](http://docs.python-requests.org/en/master/) doc. 
+
+```coffee
+DATA_PROVIDERS= [
+  type:    'HttpAPI'
+  name:    '<name>'
+  baseroute:    '<baseroute>'
+  auth:    '<auth>'
+,
+  ...
+]
+```
+
+
+## Data source configuration
+
+* `domain`: str, required
+* `name`: str, required
+* `url`: str, required
+* `method`: Method, default to GET
+* `headers`: dict
+* `params`: dict
+* `data`: str
+* `filter`: str, [`jq` filter](https://stedolan.github.io/jq/manual/), default to `"."
+* `auth`: Auth
+* `parameters`: dict
+
+```coffee
+DATA_SOURCES= [
+  domain:    '<domain>'
+  name:    '<name>'
+  url:    '<url>'
+  method:    '<method>'
+  headers:    '<headers>'
+  params:    '<params>'
+  data:    '<data>'
+  filter:    '<filter>'
+  auth:    '<auth>'
+  parameters:    '<parameters>'
+,
+  ...
+]
+```

--- a/doc/http_api.md
+++ b/doc/http_api.md
@@ -1,5 +1,14 @@
 # HttpAPI connector
 
+This is a generic connector to get data from any HTTP APIs (REST style APIs).
+
+This type of data source combines the features of Python’s [requests](http://docs.python-requests.org/) 
+library to get data from any API with the filtering langage [jq](https://stedolan.github.io/jq/) for
+flexbile transformations of the responses.
+
+Please see our [complete tutorial](https://docs.toucantoco.com/concepteur/tutorials/18-jq.html) for 
+an example of advanced use of this connector.
+
 ## Data provider configuration
 
 * `type`: `"HttpAPI"`

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ extras_require = {
     'google_analytics': ['google-api-python-client'],
     'adobe': ['adobe_analytics'],
     'toucan_toco': ['toucan_client'],
-    'hive': ['pyhive[hive]']
+    'hive': ['pyhive[hive]'],
+    'http_api': ['requests', 'requests_oauthlib', 'jq']
 }
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 
@@ -32,7 +33,7 @@ classifiers = [
 ]
 
 setup(name='toucan_connectors',
-      version='0.4.1',
+      version='0.5.0',
       description='Toucan Toco Connectors',
       author='Toucan Toco',
       author_email='dev@toucantoco.com',

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -1,0 +1,64 @@
+from toucan_connectors.http_api.http_api_connector import (
+    HttpAPIConnector,
+    HttpAPIDataSource,
+    transform_with_jq,
+    Auth,
+    HTTPBasicAuth
+)
+
+HC = HttpAPIConnector(name="myHttpConnector", type="HttpAPI",
+                      baseroute="https://jsonplaceholder.typicode.com")
+HD = HttpAPIDataSource(name="myHttpDataSource", domain="my_domain", url="/comments")
+AT = Auth(type="basic", args=["username", "password"])
+
+
+def test_transform_with_jq():
+    assert transform_with_jq(data=[1, 2, 3], jq_filter='.[]+1') == [2, 3, 4]
+    assert transform_with_jq([[1, 2, 3]], '.[]') == [1, 2, 3]
+    assert transform_with_jq(
+        [{'col1': [1, 2], 'col2': [3, 4]}], '.') == [{'col1': [1, 2], 'col2': [3, 4]}]
+
+
+def test_get_df():
+    df = HC.get_df(HD)
+    assert df.shape == (500,5)
+
+
+def test_get_df_with_auth(mocker):
+    HD.auth = AT
+    mocke = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
+    mocke.return_value.json.return_value = []
+
+    HC.get_df(HD)
+    _, ke = mocke.call_args
+
+    assert ke["auth"].username == 'username'
+    assert isinstance(ke["auth"], HTTPBasicAuth)
+
+
+def test_get_df_with_parameters(mocker):
+    HD.auth = None
+    HD.parameters = {"first_name" : "raphael"}
+    HD.headers = {"name":"%(first_name)s"}
+
+    mocke = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
+    mocke.return_value.json.return_value = []
+
+    HC.get_df(HD)
+    _, ke = mocke.call_args
+
+    assert ke["headers"] == {"name":"raphael"}
+
+
+def test_get_df_with_parameters_and_auth(mocker):
+    HD.auth = AT
+    HD.parameters = {"first_name": "raphael"}
+    HD.headers = {"name": "%(first_name)s"}
+
+    mocke = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
+    mocke.return_value.json.return_value = []
+
+    HC.get_df(HD)
+    _, ke = mocke.call_args
+
+    assert ke["headers"] == {"name": "raphael"}

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -78,7 +78,7 @@ def test_get_df_with_parameters_and_auth(connector, data_source, auth, mocker):
 
 def test_exceptions_not_json():
     connector = HttpAPIConnector(name="myHttpConnector", type="HttpAPI",
-                          baseroute="https://demo.toucantoco.com")
+                                 baseroute="https://demo.toucantoco.com")
     data_source = HttpAPIDataSource(name="myHttpDataSource", domain="my_domain", url="/")
 
     with pytest.raises(ValueError):

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -21,7 +21,7 @@ def test_transform_with_jq():
 
 def test_get_df():
     df = HC.get_df(HD)
-    assert df.shape == (500,5)
+    assert df.shape == (500, 5)
 
 
 def test_get_df_with_auth(mocker):
@@ -38,8 +38,8 @@ def test_get_df_with_auth(mocker):
 
 def test_get_df_with_parameters(mocker):
     HD.auth = None
-    HD.parameters = {"first_name" : "raphael"}
-    HD.headers = {"name":"%(first_name)s"}
+    HD.parameters = {"first_name": "raphael"}
+    HD.headers = {"name": "%(first_name)s"}
 
     mocke = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
     mocke.return_value.json.return_value = []
@@ -47,7 +47,7 @@ def test_get_df_with_parameters(mocker):
     HC.get_df(HD)
     _, ke = mocke.call_args
 
-    assert ke["headers"] == {"name":"raphael"}
+    assert ke["headers"] == {"name": "raphael"}
 
 
 def test_get_df_with_parameters_and_auth(mocker):

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -1,3 +1,5 @@
+import pytest
+
 from toucan_connectors.http_api.http_api_connector import (
     HttpAPIConnector,
     HttpAPIDataSource,
@@ -6,10 +8,21 @@ from toucan_connectors.http_api.http_api_connector import (
     HTTPBasicAuth
 )
 
-HC = HttpAPIConnector(name="myHttpConnector", type="HttpAPI",
-                      baseroute="https://jsonplaceholder.typicode.com")
-HD = HttpAPIDataSource(name="myHttpDataSource", domain="my_domain", url="/comments")
-AT = Auth(type="basic", args=["username", "password"])
+
+@pytest.fixture(scope='function')
+def connector():
+    return HttpAPIConnector(name="myHttpConnector", type="HttpAPI",
+                            baseroute="https://jsonplaceholder.typicode.com")
+
+
+@pytest.fixture(scope='function')
+def data_source():
+    return HttpAPIDataSource(name="myHttpDataSource", domain="my_domain", url="/comments")
+
+
+@pytest.fixture(scope='function')
+def auth():
+    return Auth(type="basic", args=["username", "password"])
 
 
 def test_transform_with_jq():
@@ -19,46 +32,61 @@ def test_transform_with_jq():
         [{'col1': [1, 2], 'col2': [3, 4]}], '.') == [{'col1': [1, 2], 'col2': [3, 4]}]
 
 
-def test_get_df():
-    df = HC.get_df(HD)
+def test_get_df(connector, data_source):
+    df = connector.get_df(data_source)
     assert df.shape == (500, 5)
 
 
-def test_get_df_with_auth(mocker):
-    HD.auth = AT
+def test_get_df_with_auth(connector, data_source, auth, mocker):
+    data_source.auth = auth
     mocke = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
     mocke.return_value.json.return_value = []
 
-    HC.get_df(HD)
+    connector.get_df(data_source)
     _, ke = mocke.call_args
 
     assert ke["auth"].username == 'username'
     assert isinstance(ke["auth"], HTTPBasicAuth)
 
 
-def test_get_df_with_parameters(mocker):
-    HD.auth = None
-    HD.parameters = {"first_name": "raphael"}
-    HD.headers = {"name": "%(first_name)s"}
+def test_get_df_with_parameters(connector, data_source, mocker):
+    data_source.parameters = {"first_name": "raphael"}
+    data_source.headers = {"name": "%(first_name)s"}
 
-    mocke = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
-    mocke.return_value.json.return_value = []
+    mock = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
+    mock.return_value.json.return_value = []
 
-    HC.get_df(HD)
-    _, ke = mocke.call_args
+    connector.get_df(data_source)
+    _, ke = mock.call_args
+
+    assert ke["headers"] == {"name": "raphael"}
+
+
+def test_get_df_with_parameters_and_auth(connector, data_source, auth, mocker):
+    data_source.auth = auth
+    data_source.parameters = {"first_name": "raphael"}
+    data_source.headers = {"name": "%(first_name)s"}
+
+    mock = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
+    mock.return_value.json.return_value = []
+
+    connector.get_df(data_source)
+    _, ke = mock.call_args
 
     assert ke["headers"] == {"name": "raphael"}
 
 
-def test_get_df_with_parameters_and_auth(mocker):
-    HD.auth = AT
-    HD.parameters = {"first_name": "raphael"}
-    HD.headers = {"name": "%(first_name)s"}
+def test_exceptions_not_json():
+    connector = HttpAPIConnector(name="myHttpConnector", type="HttpAPI",
+                          baseroute="https://demo.toucantoco.com")
+    data_source = HttpAPIDataSource(name="myHttpDataSource", domain="my_domain", url="/")
 
-    mocke = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
-    mocke.return_value.json.return_value = []
+    with pytest.raises(ValueError):
+        connector.get_df(data_source)
 
-    HC.get_df(HD)
-    _, ke = mocke.call_args
 
-    assert ke["headers"] == {"name": "raphael"}
+def test_exceptions_wrong_filter(connector, data_source):
+    data_source.filter = "bla"
+
+    with pytest.raises(ValueError):
+        connector.get_df(data_source)

--- a/toucan_connectors/__init__.py
+++ b/toucan_connectors/__init__.py
@@ -32,5 +32,7 @@ with suppress(ImportError):
     from .google_analytics.google_analytics_connector import GoogleAnalyticsConnector
 with suppress(ImportError):
     from .hive.hive_connector import HiveConnector
+with suppress(ImportError):
+    from .http_api.http_api_connector import HttpAPIConnector
 
 from .toucan_connector import ToucanDataSource, ToucanConnector

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -17,10 +17,10 @@ def transform_with_jq(data: object, jq_filter: str) -> list:
     data = jq(jq_filter).transform(data, multiple_output=True)
 
     # jq "multiple outout": the data is already presented as a list of rows
-    multiple_output = len(data) == 1 and (isinstance(data[0], list))
+    multiple_output = len(data) == 1 and isinstance(data[0], list)
 
     # another valid datastructure:  [{col1:[value, ...], col2:[value, ...]}]
-    single_cols_dict = (isinstance(data[0], dict) and isinstance(list(data[0].values())[0], list))
+    single_cols_dict = isinstance(data[0], dict) and isinstance(list(data[0].values())[0], list)
 
     if multiple_output or single_cols_dict:
         return data[0]
@@ -89,7 +89,7 @@ class HttpAPIConnector(ToucanConnector):
         available_params = ['url', 'method', 'params', 'data', 'json', 'headers', "auth"]
 
         jq_filter = query['filter']
-        query = {k: v for k, v in list(query.items()) if k in available_params}
+        query = {k: v for k, v in query.items() if k in available_params}
         query['url'] = '/'.join([self.baseroute.rstrip('/'), query['url'].lstrip('/')])
         query['auth'] = auth
 

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -1,0 +1,122 @@
+from enum import Enum
+
+import pandas as pd
+from pydantic import BaseModel
+from typing import List
+from jq import jq
+
+from requests import request
+from requests.auth import HTTPBasicAuth, HTTPDigestAuth
+from requests_oauthlib import OAuth1
+
+from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
+from toucan_connectors.common import nosql_apply_parameters_to_query
+
+
+def transform_with_jq(data: object, jq_filter: str) -> list:
+    data = jq(jq_filter).transform(data, multiple_output=True)
+
+    # jq "multiple outout": the data is already presented as a list of rows
+    multiple_output = len(data) == 1 and (isinstance(data[0], list))
+
+    # another valid datastructure:  [{col1:[value, ...], col2:[value, ...]}]
+    single_cols_dict = (isinstance(data[0], dict) and isinstance(list(data[0].values())[0], list))
+
+    if multiple_output or single_cols_dict:
+        return data[0]
+
+    return data
+
+
+class AuthType(Enum):
+    basic = "basic"
+    digest = "digest"
+    oauth1 = "oauth1"
+
+
+class Auth(BaseModel):
+    type: AuthType
+    args: List[str]
+
+    def get_auth(self):
+        auth_class = {
+            'basic': HTTPBasicAuth,
+            'digest': HTTPDigestAuth,
+            'oauth1': OAuth1,
+        }.get(self.type.value)
+
+        return auth_class(*self.args)
+
+
+class Method(BaseModel):
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+
+
+class HttpAPIDataSource(ToucanDataSource):
+    url: str
+    method: Method = "GET"
+    headers: dict = None
+    params: dict = None
+    _json: dict = None
+    data: str = None
+    filter: str = "."
+    auth: Auth = None
+    parameters: dict = None
+
+    class Config:
+        fields = {'_json': {'alias': 'json'}}
+
+
+class HttpAPIConnector(ToucanConnector):
+    type = "HttpAPI"
+    data_source_model: HttpAPIDataSource
+
+    baseroute: str
+    auth: Auth = None
+
+    def do_request(self, query, auth):
+        """
+        Get some json data with an HTTP request and run a jq filter on it.
+        Args:
+            query (dict): specific infos about the request (url, http headers, etc.)
+        Returns:
+            data (list): The response from the API in the form of a list of dict
+        """
+
+        available_params = ['url', 'method', 'params', 'data', 'json', 'headers', "auth"]
+
+        jq_filter = query['filter']
+        query = {k: v for k, v in list(query.items()) if k in available_params}
+        query['url'] = '/'.join([self.baseroute.rstrip('/'), query['url'].lstrip('/')])
+        query['auth'] = auth
+
+        res = request(**query)
+
+        try:
+            data = res.json()
+        except ValueError:
+            HttpAPIConnector.logger.error(f'Could not decode "{res.content}"')
+            raise
+
+        try:
+            return transform_with_jq(data, jq_filter)
+        except ValueError:
+            HttpAPIConnector.logger.error(f'Could not transform {data} using {jq_filter}')
+            raise
+
+    def get_df(self, data_source: HttpAPIDataSource) -> pd.DataFrame:
+
+        # generate the request auth object
+        if data_source.auth:
+            auth = data_source.auth.get_auth()
+            data_source.auth = None
+        else:
+            auth = None
+
+        query = nosql_apply_parameters_to_query(
+            data_source.dict(),
+            data_source.parameters)
+
+        return pd.DataFrame(self.do_request(query, auth))

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -81,6 +81,7 @@ class HttpAPIConnector(ToucanConnector):
         Get some json data with an HTTP request and run a jq filter on it.
         Args:
             query (dict): specific infos about the request (url, http headers, etc.)
+            auth: one of request Auth objects
         Returns:
             data (list): The response from the API in the form of a list of dict
         """


### PR DESCRIPTION
Avant : HttpAPI connector était dans Laputa, ne supportait pas le passage de paramètres de la front config
Maintenant : HttpAPI connector est dans Laputa et dans toucan-connector, support le passage de paramètres par le frontend

https://trello.com/c/dagMAgpV/1084-migrer-le-connecteur-httpapi-dans-toucan-connectors-et-le-rendre-utilisable-dans-la-front-05