### PR TITLE
Hotfix :: auth on http api connector, not datasource

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ classifiers = [
 ]
 
 setup(name='toucan_connectors',
-      version='0.5.3',
+      version='0.5.4',
       description='Toucan Toco Connectors',
       author='Toucan Toco',
       author_email='dev@toucantoco.com',

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -38,7 +38,7 @@ def test_get_df(connector, data_source):
 
 
 def test_get_df_with_auth(connector, data_source, auth, mocker):
-    data_source.auth = auth
+    connector.auth = auth
     mocke = mocker.patch("toucan_connectors.http_api.http_api_connector.request")
     mocke.return_value.json.return_value = []
 
@@ -63,7 +63,7 @@ def test_get_df_with_parameters(connector, data_source, mocker):
 
 
 def test_get_df_with_parameters_and_auth(connector, data_source, auth, mocker):
-    data_source.auth = auth
+    connector.auth = auth
     data_source.parameters = {"first_name": "raphael"}
     data_source.headers = {"name": "%(first_name)s"}
 

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -62,7 +62,6 @@ class HttpAPIDataSource(ToucanDataSource):
     _json: dict = None
     data: str = None
     filter: str = "."
-    auth: Auth = None
     parameters: dict = None
 
     class Config:
@@ -110,9 +109,8 @@ class HttpAPIConnector(ToucanConnector):
     def get_df(self, data_source: HttpAPIDataSource) -> pd.DataFrame:
 
         # generate the request auth object
-        if data_source.auth:
-            auth = data_source.auth.get_auth()
-            data_source.auth = None
+        if self.auth:
+            auth = self.auth.get_auth()
         else:
             auth = None
 


### PR DESCRIPTION
Before : auth object is wrongly associated to the data source
After : auth object is associated to connector