### PR TITLE
 Hotfix :: mongo with divide

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ classifiers = [
 ]
 
 setup(name='toucan_connectors',
-      version='0.5.4',
+      version='0.5.5',
       description='Toucan Toco Connectors',
       author='Toucan Toco',
       author_email='dev@toucantoco.com',

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -149,8 +149,10 @@ def test_handle_missing_param():
 
     query = [
         {'$match': {'country': '%(country)s', 'city': 'Test'}},
-        {'$match': {'b': 1}},
         {'$project': {'b': {'$divide': ['__VOID__', '$a']}}}
     ]
 
-    assert handle_missing_params(query, params) == query
+    assert handle_missing_params(query, params) == [
+        {'$match': {'city': 'Test'}},
+        {'$project': {'b': {'$divide': ['__VOID__', '$a']}}}
+    ]

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -150,7 +150,7 @@ def test_handle_missing_param():
     query = [
         {'$match': {'country': '%(country)s', 'city': 'Test'}},
         {'$match': {'b': 1}},
-        {'$project': {'$divide' : ['__VOID__', '$a']}}
+        {'$project': {'b': {'$divide': ['__VOID__', '$a']}}}
     ]
 
     assert handle_missing_params(query, params) == query

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -146,3 +146,11 @@ def test_handle_missing_param():
 
     query = {'code': '%(city)s_%(country)s', 'domain': 'Test'}
     assert handle_missing_params(query, params) == {'domain': 'Test'}
+
+    query = [
+        {'$match': {'country': '%(country)s', 'city': 'Test'}},
+        {'$match': {'b': 1}},
+        {'$project': {'$divide' : ['__VOID__', '$a']}}
+    ]
+
+    assert handle_missing_params(query, params) == query

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -36,9 +36,11 @@ def handle_missing_params(d, params):
             e[k] = v
     return e
 
+
 @handle_missing_params.register(str)
 def handle_string(s, _):
     return s
+
 
 @handle_missing_params.register(list)
 def handle_multiple_steps(l, params):

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -36,6 +36,9 @@ def handle_missing_params(d, params):
             e[k] = v
     return e
 
+@handle_missing_params.register(str)
+def handle_multiple_steps(s, _):
+    return s
 
 @handle_missing_params.register(list)
 def handle_multiple_steps(l, params):

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -37,7 +37,7 @@ def handle_missing_params(d, params):
     return e
 
 @handle_missing_params.register(str)
-def handle_multiple_steps(s, _):
+def handle_string(s, _):
     return s
 
 @handle_missing_params.register(list)


### PR DESCRIPTION
For connector mongo, fix handle_missing_params for query like : 
```
{'$project': {'b':{'$divide' : ['$c', '$a']}}}
```