### PR TITLE
Hotfix :: httpAPI connector, add support for template and fix json

### DIFF
--- a/doc/http_api.md
+++ b/doc/http_api.md
@@ -16,6 +16,7 @@ an example of advanced use of this connector.
 * `baseroute`: str, required
 * `auth`: `{type: "basic|digest|oauth1", args: [...]}` 
     cf. [requests auth](http://docs.python-requests.org/en/master/) doc. 
+* `template`: dict, required. See below.
 
 ```coffee
 DATA_PROVIDERS= [
@@ -23,10 +24,23 @@ DATA_PROVIDERS= [
   name:    '<name>'
   baseroute:    '<baseroute>'
   auth:    '<auth>'
+  template:
+    <headers|json|params>:
+        <header key>: '<header value>'
 ,
   ...
 ]
 ```
+
+### Template
+
+You can use this object to avoid repetition in data sources. 
+The values of the three attributes will be used or overided by 
+all data sources using this provider.
+
+* `json`: dict
+* `headers`: dict
+* `params`: dict
 
 
 ## Data source configuration
@@ -35,6 +49,7 @@ DATA_PROVIDERS= [
 * `name`: str, required
 * `url`: str, required
 * `method`: Method, default to GET
+* `json`: dict
 * `headers`: dict
 * `params`: dict
 * `data`: str
@@ -58,3 +73,88 @@ DATA_SOURCES= [
   ...
 ]
 ```
+
+## Complete example:
+
+The complete spec of an HttpAPI entry in DATA_SOURCES is as follows:
+
+```coffee
+    DATA_PROVIDERS: [
+        name: "open-data-paris"
+        type: "HttpAPI"
+        baseroute: 'https://opendata.paris.fr/api/'
+        template:
+            headers:
+                requested-by: 'toucantoco'
+    ]
+```
+
+```coffee
+    DATA_SOURCES: [
+      domain: "books"
+      type: "HttpAPI"
+      name: "open-data-paris"
+      method: "GET"
+      url: "records/1.0/search/"
+      params:
+        dataset: 'les-1000-titres-les-plus-reserves-dans-les-bibliotheques-de-pret'
+        facet: 'auteur'
+      filter: ".records[].fields"
+    ]
+```
+
+The JSON response looks like this:
+
+```json
+{
+  "nhits": 1000,
+  "parameters": { ... },
+  "records": [
+    {
+      "datasetid": "les-1000-titres-les-plus-reserves-dans-les-bibliotheques-de-pret",
+      "recordid": "4b950c1ac5459379633d74ed2ef7f1c7f5cc3a10",
+      "fields": {
+        "nombre_de_reservations": 1094,
+        "url_de_la_fiche_de_l_oeuvre": "https://bibliotheques.paris.fr/Default/doc/SYRACUSE/1009613",
+        "url_de_la_fiche_de_l_auteur": "https://bibliotheques.paris.fr/Default/doc/SYRACUSE/1009613",
+        "support": "indéterminé",
+        "auteur": "Enders, Giulia",
+        "titre": "Le charme discret de l'intestin [Texte imprimé] : tout sur un organe mal aimé"
+      },
+      "record_timestamp": "2017-01-26T11:17:33+00:00"
+    },
+    {
+      "datasetid":"les-1000-titres-les-plus-reserves-dans-les-bibliotheques-de-pret",
+      "recordid":"3df76bd20ab5dc902d0c8e5219dbefe9319c5eef",
+      "fields":{
+        "nombre_de_reservations":746,
+        "url_de_la_fiche_de_l_oeuvre":"https://bibliotheques.paris.fr/Default/doc/SYRACUSE/1016593",
+        "url_de_la_fiche_de_l_auteur":"https://bibliotheques.paris.fr/Default/doc/SYRACUSE/1016593",
+        "support":"Bande dessinée pour adulte",
+        "auteur":"Sattouf, Riad",
+        "titre":"L'Arabe du futur [Texte imprimé]. 2. Une jeunesse au Moyen-Orient, 1984-1985"
+      },
+      "record_timestamp":"2017-01-26T11:17:33+00:00"
+    },
+    ...
+  ]
+}
+```
+
+We apply the filter `.records[].fields` which means that for
+every entries in the `records` properity it will extract all the
+properties of the `fields` object. So the we end up with a table of
+results looking like this (I'm skipping columns in this example but you
+see the point):
+
+| nombre_de_reservations | auteur             | skipped columns... |
+|------------------------|--------------------|--------------------|
+| 1094                   |  Enders, Giulia    | ...                |
+| 746                    |  Sattouf, Riad     | ...                |
+
+
+Note: the reason to have a `filter` option is to allow you to take any
+API response and transfom it into something that fits into a column
+based data frame. jq is designed to be concise and easy to use for simple
+tasks, but if you dig a little deeper you'll find a featureful
+functional programming language hiding underneath.

--- a/doc/http_api.md
+++ b/doc/http_api.md
@@ -35,7 +35,7 @@ DATA_PROVIDERS= [
 ### Template
 
 You can use this object to avoid repetition in data sources. 
-The values of the three attributes will be used or overriden by 
+The values of the three attributes will be used or overridden by 
 all data sources using this provider.
 
 * `json`: dict

--- a/doc/http_api.md
+++ b/doc/http_api.md
@@ -16,7 +16,7 @@ an example of advanced use of this connector.
 * `baseroute`: str, required
 * `auth`: `{type: "basic|digest|oauth1", args: [...]}` 
     cf. [requests auth](http://docs.python-requests.org/en/master/) doc. 
-* `template`: dict, required. See below.
+* `template`: dict. See below.
 
 ```coffee
 DATA_PROVIDERS= [
@@ -35,7 +35,7 @@ DATA_PROVIDERS= [
 ### Template
 
 You can use this object to avoid repetition in data sources. 
-The values of the three attributes will be used or overided by 
+The values of the three attributes will be used or overriden by 
 all data sources using this provider.
 
 * `json`: dict
@@ -142,8 +142,8 @@ The JSON response looks like this:
 ```
 
 We apply the filter `.records[].fields` which means that for
-every entries in the `records` properity it will extract all the
-properties of the `fields` object. So the we end up with a table of
+every entry in the `records` properity it will extract all the
+properties of the `fields` object. So we end up with a table of
 results looking like this (I'm skipping columns in this example but you
 see the point):
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ classifiers = [
 ]
 
 setup(name='toucan_connectors',
-      version='0.5.4',
+      version='0.5.5',
       description='Toucan Toco Connectors',
       author='Toucan Toco',
       author_email='dev@toucantoco.com',

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -152,4 +152,3 @@ def test_get_df_with_template_overide(data_source, mocker):
     assert ke['headers']['Authorization'] == data_source.headers['Authorization']
     assert 'B' in ke['headers'] and ke['headers']['B']
     assert 'A' in ke['json'] and ke['json']['A']
-

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -5,8 +5,7 @@ from toucan_connectors.http_api.http_api_connector import (
     HttpAPIDataSource,
     transform_with_jq,
     Auth,
-    HTTPBasicAuth,
-    Template
+    HTTPBasicAuth
 )
 
 


### PR DESCRIPTION
- [X] fix passing `json` in a config 
- [X] add support for the missing `template` option at the provider level
- [X] regenerate doc

After removing the 'template' option at the provider level, we realised it was used.