### PR TITLE
http api connector :: Add support for oauth2 "backend application flow"

### DIFF
--- a/doc/http_api.md
+++ b/doc/http_api.md
@@ -14,8 +14,9 @@ an example of advanced use of this connector.
 * `type`: `"HttpAPI"`
 * `name`: str, required
 * `baseroute`: str, required
-* `auth`: `{type: "basic|digest|oauth1", args: [...]}` 
-    cf. [requests auth](http://docs.python-requests.org/en/master/) doc. 
+* `auth`: `{type: "basic|digest|oauth1|oauth2_backend", args: [...]}` 
+    cf. [requests auth](http://docs.python-requests.org/en/master/) and 
+    [requests oauthlib](https://requests-oauthlib.readthedocs.io/en/latest/oauth2_workflow) doc. 
 * `template`: dict. See below.
 
 ```coffee

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
     'google_cloud_mysql': ['PyMySQL>=0.8.0'],
     'google_spreadsheet': ['gspread>=3', 'oauth2client'],
     'hive': ['pyhive[hive]'],
-    'http_api': ['requests', 'requests_oauthlib', 'jq'],
+    'http_api': ['requests', 'requests_oauthlib', 'jq', 'oauthlib'],
     'micro_strategy': ['requests'],
     'mongo': ['pymongo>=3.6.1'],
     'mssql': ['pymssql>=2.1.3'],
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 setup(name='toucan_connectors',
-      version='0.6.3',
+      version='0.7.0',
       description='Toucan Toco Connectors',
       author='Toucan Toco',
       author_email='dev@toucantoco.com',

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -152,3 +152,29 @@ def test_get_df_with_template_overide(data_source, mocker):
     assert ke['headers']['Authorization'] == data_source.headers['Authorization']
     assert 'B' in ke['headers'] and ke['headers']['B']
     assert 'A' in ke['json'] and ke['json']['A']
+
+
+@pytest.mark.skip(reason="This uses an real api")
+def test_get_df_oauth2_backend():
+
+    data_provider = {
+        'name': 'test',
+        'type': 'HttpAPI',
+        'baseroute': 'https://gateway.eu1.mindsphere.io/api/im/v3',
+        'auth': {
+            'type': 'oauth2_backend',
+            'args': ['https://mscenter.piam.eu1.mindsphere.io/oauth/token',
+                     '<client_id>',
+                     '<client_secret>']
+        }
+    }
+
+    users = {
+        'domain': 'test',
+        'name': 'test',
+        'url': '/Users',
+        'filter': '.resources'}
+
+    co = HttpAPIConnector(**data_provider)
+    df = co.get_df(HttpAPIDataSource(**users))
+    assert "userName" in df


### PR DESCRIPTION

Context: https://trello.com/c/pNyoVpRs/1220-etq-skf-je-peux-connecter-%C3%A0-mes-donn%C3%A9es-via-une-api-avec-une-0aut2-authentication-05

- [x] test with a mock (my test atm is on a real api)
- [x] make sure we have the requirements
- [x] bump version