### PR TITLE
introduce `tcc_mark` decorator for connector methods

### DIFF
--- a/tests/test_retry_policy.py
+++ b/tests/test_retry_policy.py
@@ -1,13 +1,34 @@
 import pytest
 from time import time
 
-from toucan_connectors.toucan_connector import RetryPolicy
+from toucan_connectors.toucan_connector import RetryPolicy, is_tcc_marked, tcc_mark
 
 
 def assert_elapsed(start, stop, expected, error_margin=None):
     if error_margin is None:
         error_margin = min(0.1 * expected, 0.1)
     assert (expected - error_margin) <= stop - start <= (expected + error_margin)
+
+
+def test_no_tcc_markers():
+    def f():
+        pass
+    assert not is_tcc_marked(f, 'foo')
+
+
+def test_tcc_markers_new_prop():
+    @tcc_mark('foo')
+    def f():
+        pass
+    assert is_tcc_marked(f, 'foo')
+
+
+def test_tcc_markers_multiple_props():
+    @tcc_mark('foo', 'bar')
+    def f():
+        pass
+    assert is_tcc_marked(f, 'foo')
+    assert is_tcc_marked(f, 'bar')
 
 
 def test_defaut_retry_policy_is_noop():


### PR DESCRIPTION
This introduces a generic way to "mark" a method in the base connector
class. It can then be used, for instance in `__init_subclass__` to
decide what to do with these markers, e.g:

```python
if callable(attrvalue) and is_tcc_marked('require-permission'):
    setattr(cls, attrname, cls.apply_permissions(attrvalue))

```

The only use case we know of, for now, is to tag a base method for later
decoration. Therefore, we might want later to simply decorate the
methods with:

```
@wrap_subclass_implem(apply_permissions)
@wrap_subclass_implem(retry)
def explain(...):
    pass
```

where `retry` and `apply_permissions` would be decorator-like functions.