### PR TITLE
Hotfix :: OData connector

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 setup(name='toucan_connectors',
-      version='0.17.0',
+      version='0.17.1',
       description='Toucan Toco Connectors',
       author='Toucan Toco',
       author_email='dev@toucantoco.com',

--- a/toucan_connectors/odata/odata_connector.py
+++ b/toucan_connectors/odata/odata_connector.py
@@ -1,8 +1,20 @@
 import pandas as pd
 from odata import ODataService
+from odata.metadata import MetaData
 
 from toucan_connectors.common import Auth
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
+
+
+# monkey patch MetaData's __init__
+# (cf. https://github.com/tuomur/python-odata/issues/22)
+def metadata_init_patched(self, service):
+    self._original_init(service)
+    self.url = service.url.rstrip('/') + '/$metadata'
+
+
+MetaData._original_init = MetaData.__init__
+MetaData.__init__ = metadata_init_patched
 
 
 class ODataDataSource(ToucanDataSource):


### PR DESCRIPTION
cf. #z-connexion-odata and https://github.com/tuomur/python-odata/issues/22

The bug happened on https://demos.shuttle-cloud.com/MASTER.DataAPI/shut_repo-odata-en-service/ : 
- https://demos.shuttle-cloud.com/MASTER.DataAPI/shut_repo-odata-en-service/$metadata works :heavy_check_mark: 
- https://demos.shuttle-cloud.com/MASTER.DataAPI/shut_repo-odata-en-service/$metadata/ doesnt (500 error) :x: