### PR TITLE
Fix :: pagination of get_slice connectors method

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -79,11 +79,17 @@ def test_get_slice():
         data_source_model = 'asd'
 
         def _retrieve_data(self, datasource):
-            return pd.DataFrame({'A': [1, 2]})
+            return pd.DataFrame({'A': [1, 2, 3, 4, 5]})
 
+    # without offset
     res = DataConnector(name='my_name').get_slice({}, limit=1)
     assert res.df.equals(pd.DataFrame({'A': [1]}))
-    assert res.total_count == 2
+    assert res.total_count == 5
+
+    # with offset
+    res = DataConnector(name='my_name').get_slice({}, offset=2, limit=2)
+    assert res.df.reset_index(drop=True).equals(pd.DataFrame({'A': [3, 4]}))
+    assert res.total_count == 5
 
 
 def test_explain():

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -227,7 +227,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         and the total size filtered with permissions
         """
         df = self.get_df(data_source, permissions)
-        return DataSlice(df[offset:limit], len(df))
+        return DataSlice(df[offset:offset+limit], len(df))
 
     def explain(self, data_source: ToucanDataSource, permissions: Optional[str] = None):
         """Method to give metrics about the query"""

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -225,6 +225,10 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         """
         Method to retrieve a part of the data as a pandas dataframe
         and the total size filtered with permissions
+
+        - offset is the index of the starting row
+        - limit is the number of rows to retrieve
+        Exemple: if offset = 5 and limit = 10 then 10 results are expected from 6th row
         """
         df = self.get_df(data_source, permissions)
         return DataSlice(df[offset:offset+limit], len(df))


### PR DESCRIPTION
# Description

Miswriting of the `offset` and `limit` option in `ToucanConnector.get_slice`:
```python
return result[offset:limit] 
```
Returned the correct result only when `offset=0`

👉  The `offset` option of `get_slice` was not tested 😱 