### PR TITLE
Fix :: cache validation should be proper to a given connector instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install:
 
 .PHONY: format
 format:
-	isort -rc -w 100 toucan_connectors tests setup.py
+	isort -rc toucan_connectors tests setup.py
 	black -S -l 100 --target-version py36 toucan_connectors tests setup.py
 
 .PHONY: lint

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,8 @@
 exclude = __init__.py
 max-line-length = 100
 ignore = E203, E266, E501, W503
+
+[isort]
+include_trailing_comma = True
+line_length = 100
+multi_line_output = 3

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -121,7 +121,7 @@ class MongoConnector(ToucanConnector):
         return f'mongodb://{user_pass}{self.host}:{self.port}'
 
     def __hash__(self):
-        return hash(self.uri)
+        return hash(id(self)) + hash(self.uri)
 
     def __enter__(self):
         return self


### PR DESCRIPTION
I had an issue on laputa where my test would be ok alone but ko with a test run before it.
In fact, it's because the previous collection was not considered as dropped in the new connector (because of the LRU cache key was the same) and it targetted the wrong one