### PR TITLE
Mongo :: get_df_with_regex method

### DIFF
--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -247,6 +247,14 @@ def test_get_df_with_regex(mongo_connector, mongo_datasource):
     pd.testing.assert_series_equal(df['country'], pd.Series(['France', 'Germany'], name='country'))
 
 
+def test_get_df_with_regex_with_limit(mongo_connector, mongo_datasource):
+    datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
+    df = mongo_connector.get_df_with_regex(
+        datasource, field='country', regex=re.compile('r.*a'), limit=1
+    )
+    pd.testing.assert_series_equal(df['country'], pd.Series(['France'], name='country'))
+
+
 def test_explain(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
     res = mongo_connector.explain(datasource)


### PR DESCRIPTION
Implement a `get_df_with_regex` method, to be able to search in data.

---
Before discussions (https://github.com/ToucanToco/toucan-connectors/pull/115#issuecomment-536872924): 

Implements a `search` method, based on these rules:
https://jeremymikkola.com/posts/2019_03_19_rules_for_autocomplete.html
- [x] Exact matches (e.g.: "ab" => "ab")
- [x] Prefix matches (e.g.: "ab" => "ab.")
- [x] Substring matches (e.g.: "ab" => ".ab.")
- [x] Subsequence start matches (e.g.: "ab" => "a.b.")
- [x] Subsequence middle matches (e.g.: "ab" => ".a.b")
- [x] Alphabetical order
- [x] Shortest match first
- [x] Case insensitive

Search proceeds using one query for each rule. It stops as soon as the number of required results (`limit`) has been reached.

This will be useful for database discovery with autocomplete.
