### PR TITLE
Feature :: Improve schemas

### DIFF
--- a/tests/google_analytics/test_google_analytics.py
+++ b/tests/google_analytics/test_google_analytics.py
@@ -19,10 +19,10 @@ def test_google_analytics(mocker):
             'private_key': 'test',
             'client_email': 'test',
             'client_id': 'test',
-            'auth_uri': 'test',
-            'token_uri': 'test',
-            'auth_provider_x509_cert_url': 'test',
-            'client_x509_cert_url': 'test',
+            'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
+            'token_uri': 'https://oauth2.googleapis.com/token',
+            'auth_provider_x509_cert_url': 'https://www.googleapis.com/oauth2/v1/certs',
+            'client_x509_cert_url': 'https://www.googleapis.com/robot/v1/metadata/x509/pika.com',
         },
     )
 

--- a/tests/google_big_query/test_google_big_query.py
+++ b/tests/google_big_query/test_google_big_query.py
@@ -19,10 +19,10 @@ def test_gbq(mocker):
         private_key='my_private_key',
         client_email='my_client_email',
         client_id='my_client_id',
-        auth_uri='my_auth_uri',
-        token_uri='my_token_uri',
-        auth_provider_x509_cert_url='my_provider',
-        client_x509_cert_url='my_cert',
+        auth_uri='https://accounts.google.com/o/oauth2/auth',
+        token_uri='https://oauth2.googleapis.com/token',
+        auth_provider_x509_cert_url='https://www.googleapis.com/oauth2/v1/certs',
+        client_x509_cert_url='https://www.googleapis.com/robot/v1/metadata/x509/pika.com',
     )
     connector = GoogleBigQueryConnector(
         name='MyGBQ',

--- a/tests/google_spreadsheet/test_google_spreadsheet.py
+++ b/tests/google_spreadsheet/test_google_spreadsheet.py
@@ -12,10 +12,10 @@ c = GoogleSpreadsheetConnector(
         'private_key': 'test',
         'client_email': 'test',
         'client_id': 'test',
-        'auth_uri': 'test',
-        'token_uri': 'test',
-        'auth_provider_x509_cert_url': 'test',
-        'client_x509_cert_url': 'test',
+        'auth_uri': 'https://test.com',
+        'token_uri': 'https://test.com',
+        'auth_provider_x509_cert_url': 'https://test.com',
+        'client_x509_cert_url': 'https://test.com',
     },
 )
 

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -375,7 +375,11 @@ def test_get_form_empty_query(mongo_connector):
         'type': 'string',
         'enum': ['admin', 'config', 'local', 'toucan'],
     }
-    assert form['properties']['collection'] == {'title': 'Collection', 'type': 'string'}
+    assert form['properties']['collection'] == {
+        'type': 'string',
+        'title': 'Collection',
+        'description': 'The name of the collection you want to query',
+    }
 
 
 def test_get_form_query_with_bad_database(mongo_connector):

--- a/tests/sap_hana/test_sap_hana.py
+++ b/tests/sap_hana/test_sap_hana.py
@@ -25,5 +25,5 @@ def test_saphana_get_df(mocker):
     ds = SapHanaDataSource(domain='test', name='test', query='my_query')
     saphana_connector.get_df(ds)
 
-    snock.assert_called_once_with('localhost', '22', 'ubuntu', 'truc')
+    snock.assert_called_once_with('localhost', 22, 'ubuntu', 'truc')
     reasq.assert_called_once_with('my_query', con=snock())

--- a/toucan_connectors/auth.py
+++ b/toucan_connectors/auth.py
@@ -3,7 +3,7 @@ from typing import List
 
 from jq import jq
 from oauthlib.oauth2 import BackendApplicationClient
-from pydantic import BaseModel
+from pydantic import BaseModel, Schema
 from requests import Session
 from requests.auth import AuthBase, HTTPBasicAuth, HTTPDigestAuth
 from requests_oauthlib import OAuth1, OAuth2Session
@@ -60,9 +60,25 @@ class AuthType(str, Enum):
 
 
 class Auth(BaseModel):
-    type: AuthType
-    args: List[str]
-    kwargs: dict = None
+    type: AuthType = Schema(
+        ...,
+        description='As we rely on the python request lirary, we suggest that you '
+        'refer to the dedicated '
+        '<a href="https://2.python-requests.org//en/master/user/authentication/">documentation</a> '
+        'for more details.',
+        description_mimetype='text/html',
+    )
+    args: List[str] = Schema(
+        ...,
+        title='Positionnal arguments',
+        description='For example for a basic authentication, you can provide '
+        'your username and password here',
+    )
+    kwargs: dict = Schema(
+        None,
+        title='Named arguments',
+        description='A JSON object with argument name as key and corresponding value as value',
+    )
 
     def get_session(self) -> Session:
         auth_class = {

--- a/toucan_connectors/dataiku/dataiku_connector.py
+++ b/toucan_connectors/dataiku/dataiku_connector.py
@@ -2,6 +2,7 @@ from io import StringIO
 
 import dataikuapi
 import pandas as pd
+from pydantic import Schema
 
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
@@ -18,8 +19,12 @@ class DataikuConnector(ToucanConnector):
 
     data_source_model: DataikuDataSource
 
-    host: str
-    apiKey: str
+    host: str = Schema(
+        ...,
+        description='The domain name (preferred option as more dynamic) or '
+        'the hardcoded IP address of your Dataiku server',
+    )
+    apiKey: str = Schema(..., title='API key')
     project: str
 
     def _retrieve_data(self, data_source: DataikuDataSource) -> pd.DataFrame:

--- a/toucan_connectors/google_analytics/google_analytics_connector.py
+++ b/toucan_connectors/google_analytics/google_analytics_connector.py
@@ -3,7 +3,7 @@ from typing import List
 import pandas as pd
 from apiclient.discovery import build
 from oauth2client.service_account import ServiceAccountCredentials
-from pydantic import BaseModel
+from pydantic import BaseModel, Schema
 
 from toucan_connectors.common import nosql_apply_parameters_to_query
 from toucan_connectors.google_credentials import GoogleCredentials
@@ -115,7 +115,6 @@ class ReportRequest(BaseModel):
 
 
 def get_dict_from_response(report, request_date_ranges):
-
     columnHeader = report.get('columnHeader', {})
     dimensionHeaders = columnHeader.get('dimensions', [])
     metricHeaders = columnHeader.get('metricHeader', {}).get('metricHeaderEntries', [])
@@ -159,14 +158,33 @@ def get_query_results(service, report_request):
 
 
 class GoogleAnalyticsDataSource(ToucanDataSource):
-    report_request: ReportRequest
+    report_request: ReportRequest = Schema(
+        ...,
+        title='Report request',
+        description='See the complete '
+        '<a href="https://developers.google.com/analytics/devguides/reporting/core/v4/rest/v4/reports/batchGet#reportrequest">Google documentation</a>',
+    )
 
 
 class GoogleAnalyticsConnector(ToucanConnector):
     data_source_model: GoogleAnalyticsDataSource
 
-    credentials: GoogleCredentials
-    scope: List[str] = [SCOPE]
+    credentials: GoogleCredentials = Schema(
+        ...,
+        title='Google Credentials',
+        description='For authentication, download an authentication file from your '
+        '<a href="https://console.developers.google.com/apis/credentials">Google Console</a> '
+        'and use the values here. This is an oauth2 credential file. For more information see this '
+        '<a href="https://gspread.readthedocs.io/en/latest/oauth2.html">documentation</a>. '
+        'You should use "service_account" credentials, which is the preferred type of credentials '
+        'to use when authenticating on behalf of a service or application',
+    )
+    scope: List[str] = Schema(
+        [SCOPE],
+        description='OAuth 2.0 scopes define the level of access you need to '
+        'request the Google APIs. For more information, see this '
+        '<a href="https://developers.google.com/identity/protocols/googlescopes">documentation</a>',
+    )
 
     def _retrieve_data(self, data_source: GoogleAnalyticsDataSource) -> pd.DataFrame:
         credentials = ServiceAccountCredentials.from_json_keyfile_dict(

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -3,6 +3,7 @@ from typing import List
 
 import pandas as pd
 import pandas_gbq
+from pydantic import Schema
 
 from toucan_connectors.google_credentials import GoogleCredentials, get_google_oauth2_credentials
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
@@ -14,15 +15,40 @@ class Dialect(str, Enum):
 
 
 class GoogleBigQueryDataSource(ToucanDataSource):
-    query: str
+    query: str = Schema(
+        ...,
+        description='You can find details on the query syntax '
+        '<a href="https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax">here</a>',
+        widget='sql',
+    )
 
 
 class GoogleBigQueryConnector(ToucanConnector):
     data_source_model: GoogleBigQueryDataSource
 
-    credentials: GoogleCredentials
-    dialect: Dialect = Dialect.legacy
-    scopes: List[str] = ['https://www.googleapis.com/auth/bigquery']
+    credentials: GoogleCredentials = Schema(
+        ...,
+        title='Google Credentials',
+        description='For authentication, download an authentication file from your '
+        '<a href="https://console.developers.google.com/apis/credentials">Google Console</a> and '
+        'use the values here. This is an oauth2 credential file. For more information see this '
+        '<a href="https://gspread.readthedocs.io/en/latest/oauth2.html">documentation</a>. '
+        'You should use "service_account" credentials, which is the preferred type of credentials '
+        'to use when authenticating on behalf of a service or application',
+    )
+    dialect: Dialect = Schema(
+        Dialect.legacy,
+        description='BigQuery allows you to choose between standard and legacy SQL as query syntax. '
+        'The preferred query syntax is the default standard SQL. You can find more information on this '
+        '<a href="https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax">documentation</a>',
+    )
+    scopes: List[str] = Schema(
+        ['https://www.googleapis.com/auth/bigquery'],
+        title='SQL dialect',
+        description='OAuth 2.0 scopes define the level of access you need to request '
+        'the Google APIs. For more information, see this '
+        '<a href="https://developers.google.com/identity/protocols/googlescopes">documentation</a>',
+    )
 
     def _retrieve_data(self, data_source: GoogleBigQueryDataSource) -> pd.DataFrame:
         """

--- a/toucan_connectors/google_credentials.py
+++ b/toucan_connectors/google_credentials.py
@@ -1,17 +1,44 @@
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, Schema, UrlStr, validator
+
+CREDENTIALS_INFO_MESSAGE = (
+    'This information is provided in your '
+    '<a href="https://gspread.readthedocs.io/en/latest/oauth2.html">authentication file</a> downloadable '
+    'from your <a href="https://console.developers.google.com/apis/credentials">Google Console</a>'
+)
 
 
 class GoogleCredentials(BaseModel):
-    type: str
-    project_id: str
-    private_key_id: str
-    private_key: str
-    client_email: str
-    client_id: str
-    auth_uri: str
-    token_uri: str
-    auth_provider_x509_cert_url: str
-    client_x509_cert_url: str
+    type: str = Schema(
+        'service_account', title='Service account', description=CREDENTIALS_INFO_MESSAGE
+    )
+    project_id: str = Schema(..., title='Project ID', description=CREDENTIALS_INFO_MESSAGE)
+    private_key_id: str = Schema(..., title='Private Key ID', description=CREDENTIALS_INFO_MESSAGE)
+    private_key: str = Schema(
+        ...,
+        title='Private Key',
+        description=f'A private key in the form '
+        f'"-----BEGIN PRIVATE KEY-----\\nXXX...XXX\\n-----END PRIVATE KEY-----\\n". {CREDENTIALS_INFO_MESSAGE}',
+    )
+    client_email: str = Schema(..., title='Client email', description=CREDENTIALS_INFO_MESSAGE)
+    client_id: str = Schema(..., title='Client ID', description=CREDENTIALS_INFO_MESSAGE)
+    auth_uri: UrlStr = Schema(
+        'https://accounts.google.com/o/oauth2/auth',
+        title='Authentication URI',
+        description=CREDENTIALS_INFO_MESSAGE,
+    )
+    token_uri: UrlStr = Schema(
+        'https://oauth2.googleapis.com/token',
+        title='Token URI',
+        description=f'{CREDENTIALS_INFO_MESSAGE}. You should not need to change the default value.',
+    )
+    auth_provider_x509_cert_url: UrlStr = Schema(
+        'https://www.googleapis.com/oauth2/v1/certs',
+        title='Authentication provider X509 certificate URL',
+        description=f'{CREDENTIALS_INFO_MESSAGE}. You should not need to change the default value.',
+    )
+    client_x509_cert_url: UrlStr = Schema(
+        ..., title='Client X509 certification URL', description=CREDENTIALS_INFO_MESSAGE,
+    )
 
     @validator('private_key')
     def unescape_break_lines(cls, v):

--- a/toucan_connectors/google_spreadsheet/google_spreadsheet_connector.py
+++ b/toucan_connectors/google_spreadsheet/google_spreadsheet_connector.py
@@ -3,15 +3,27 @@ from typing import List
 import gspread
 import pandas as pd
 from oauth2client.service_account import ServiceAccountCredentials
+from pydantic import Schema
 
 from toucan_connectors.google_credentials import GoogleCredentials
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 
 class GoogleSpreadsheetDataSource(ToucanDataSource):
-    spreadsheet_id: str
-    sheetname: str = None
-    skip_rows: int = 0
+    spreadsheet_id: str = Schema(
+        ...,
+        title='Spreadsheet ID',
+        description='You can find this ID in the URL of your spreadsheet, '
+        'just after the base path "https://docs.google.com/spreadsheets/d/"',
+    )
+    sheetname: str = Schema(
+        None, description='If not specified, the first sheet will be extracted by default'
+    )
+    skip_rows: int = Schema(
+        0,
+        title='Number of rows to skip',
+        description='If the first rows of your spreadsheet do not contain relevant data',
+    )
 
 
 class GoogleSpreadsheetConnector(ToucanConnector):
@@ -23,12 +35,26 @@ class GoogleSpreadsheetConnector(ToucanConnector):
 
     data_source_model: GoogleSpreadsheetDataSource
 
-    credentials: GoogleCredentials
-    scope: List[str] = [
-        'https://www.googleapis.com/auth/drive',
-        'https://www.googleapis.com/auth/spreadsheets',
-        'https://spreadsheets.google.com/feeds',
-    ]
+    credentials: GoogleCredentials = Schema(
+        ...,
+        title='Google Credentials',
+        description='For authentication, download an authentication file from your '
+        '<a href="https://console.developers.google.com/apis/credentials">Google Console</a> '
+        'and use the values here. This is an oauth2 credential file. For more information see this '
+        '<a href="https://gspread.readthedocs.io/en/latest/oauth2.html">documentation</a>. '
+        'You should use "service_account" credentials, which is the preferred type of credentials '
+        'to use when authenticating on behalf of a service or application',
+    )
+    scope: List[str] = Schema(
+        [
+            'https://www.googleapis.com/auth/drive',
+            'https://www.googleapis.com/auth/spreadsheets',
+            'https://spreadsheets.google.com/feeds',
+        ],
+        description='OAuth 2.0 scopes define the level of access you need to '
+        'request the Google APIs. For more information, see this '
+        '<a href="https://developers.google.com/identity/protocols/googlescopes">documentation</a>',
+    )
 
     def _retrieve_data(self, data_source):
         credentials = ServiceAccountCredentials.from_json_keyfile_dict(

--- a/toucan_connectors/mssql/mssql_connector.py
+++ b/toucan_connectors/mssql/mssql_connector.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import pymssql
-from pydantic import constr
+from pydantic import Schema, SecretStr, constr
 
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
@@ -8,8 +8,14 @@ from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 class MSSQLDataSource(ToucanDataSource):
     # By default SQL Server selects the database which is set
     # as default for specific user
-    database: str = None
-    query: constr(min_length=1)
+    database: str = Schema(
+        None,
+        description='The name of the database you want to query. '
+        "By default SQL Server selects the user's default database",
+    )
+    query: constr(min_length=1) = Schema(
+        ..., description='You can write your SQL query here', widget='sql'
+    )
 
 
 class MSSQLConnector(ToucanConnector):
@@ -19,18 +25,28 @@ class MSSQLConnector(ToucanConnector):
 
     data_source_model: MSSQLDataSource
 
-    host: str
-    user: str
-    password: str = None
-    port: int = None
-    connect_timeout: int = None
+    host: str = Schema(
+        ...,
+        description='The domain name (preferred option as more dynamic) or '
+        'the hardcoded IP address of your database server',
+    )
+
+    port: int = Schema(None, description='The listening port of your database server')
+    user: str = Schema(..., description='Your login username')
+    password: SecretStr = Schema(None, description='Your login password')
+    connect_timeout: int = Schema(
+        None,
+        title='Connection timeout',
+        description='You can set a connection timeout in seconds here, i.e. the maximum length '
+        'of time you want to wait for the server to respond. None by default',
+    )
 
     def get_connection_params(self, database):
         con_params = {
             'server': self.host,
             'user': self.user,
             'database': database,
-            'password': self.password,
+            'password': self.password.get_secret_value() if self.password else None,
             'port': self.port,
             'login_timeout': self.connect_timeout,
             'as_dict': True,

--- a/toucan_connectors/odata/odata_connector.py
+++ b/toucan_connectors/odata/odata_connector.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from odata import ODataService
 from odata.metadata import MetaData
+from pydantic import Schema, UrlStr
 
 from toucan_connectors.auth import Auth
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
@@ -18,15 +19,28 @@ MetaData.__init__ = metadata_init_patched
 
 
 class ODataDataSource(ToucanDataSource):
-    entity: str
-    query: dict
+    entity: str = Schema(
+        ...,
+        description='The entity path that will be appended to your baseroute URL. '
+        'For example "geo/countries". For more details, see this '
+        '<a href="https://www.odata.org/getting-started/basic-tutorial/">tutorial</a>',
+    )
+    query: dict = Schema(
+        ...,
+        description='JSON object of parameters with parameter name as key and value as value. '
+        'For example {"$filter": "my_value", "$skip": 100} '
+        '(equivalent to "$filter=my_value&$skip=100" in parameterized URL). '
+        'For more details on query parameters convention, see '
+        '<a href="https://www.odata.org/documentation/odata-version-2-0/uri-conventions/">this documentation</a>',
+        widget='json',
+    )
 
 
 class ODataConnector(ToucanConnector):
     data_source_model: ODataDataSource
 
-    baseroute: str
-    auth: Auth = None
+    baseroute: UrlStr = Schema(..., title='API endpoint', description='Baseroute URL')
+    auth: Auth = Schema(None, title='Authentication type')
 
     def _retrieve_data(self, data_source: ODataDataSource) -> pd.DataFrame:
 


### PR DESCRIPTION
Use `pydantic` to improve schemas to be used by a form builder.

This PR proposes to introduce 2 new custom elements:

-  a new 'sql' `widget` (next to the already implemented 'json' widget) and to be used as a SQL text editor in the UI
- an `examples` key to list example values and to be used as placeholder in the UI

At the moment it does not cover the following connectors:

- adobe
- adobe_analytics
- elasticsearch
- facebook_insights
- google_my_business
- toucan_toco
- trello
- wootric