### PR TITLE
Handle backticks in permissions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ classifiers = [
 
 setup(
     name='toucan_connectors',
-    version='0.25.0',
+    version='0.25.1',
     description='Toucan Toco Connectors',
     author='Toucan Toco',
     author_email='dev@toucantoco.com',

--- a/tests/mongo/test_mongo_translator.py
+++ b/tests/mongo/test_mongo_translator.py
@@ -5,7 +5,7 @@ from toucan_connectors.mongo.mongo_translator import MongoExpression
 
 def test_mongo_expression():
     query = (
-        '"a b"=="1" or ((b not in ["la", 5, false]) and (c<1.5) '
+        '`a b`=="1" or ((`b` not in ["la", 5, false]) and (c<1.5) '
         'and (d != null) and (e == true)) or (f in [null, true])'
         'or (g>=2) or (h<=0) or (i>-3.5)'
     )

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -166,6 +166,9 @@ class AstTranslator(ABC):
         return self.resolve(elt)(elt)
 
     def parse(self, expr):
+        # Replace ` by " because pandas.query like expressions (e.g "(`a` == 1)")
+        # are not valid python expressions:
+        expr = expr.replace('`', '"')
         ex = ast.parse(expr, mode='eval')
         return self.translate(ex.body)
 


### PR DESCRIPTION
Permissions may contain backticks because they are pandas.query like expressions.