### PR TITLE
Mongo connector :: apply permissions early

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ classifiers = [
 
 setup(
     name='toucan_connectors',
-    version='0.26.0',
+    version='0.26.1',
     description='Toucan Toco Connectors',
     author='Toucan Toco',
     author_email='dev@toucantoco.com',

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -168,8 +168,7 @@ def test_get_df_with_permissions(mongo_connector, mongo_datasource):
     df = mongo_connector.get_df(datasource, permissions='country=="France"')
     expected = pd.DataFrame({'country': ['France'], 'language': ['French'], 'value': [20]})
     assert datasource.query == [
-        {'$match': {'domain': 'domain1'}},
-        {'$match': {'country': 'France'}},
+        {'$match': {'$and': [{'domain': 'domain1'}, {'country': 'France'}]}}
     ]
     assert df.shape == (1, 5)
     assert set(df.columns) == {'_id', 'country', 'domain', 'language', 'value'}

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -41,7 +41,7 @@ def apply_permissions(query, permissions):
         if isinstance(query, dict):
             query = {'$and': [query, permissions]}
         else:
-            query.append({'$match': permissions})
+            query[0]['$match'] = {'$and': [query[0]['$match'], permissions]}
     return query
 
 


### PR DESCRIPTION
For mongo connector, apply permissions in the first `$match` of the pipeline.