### PR TITLE
Mongo :: instantiate MongoClient with kwargs instead of building a connection string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ classifiers = [
 
 setup(
     name='toucan_connectors',
-    version='0.26.1',
+    version='0.27.0',
     description='Toucan Toco Connectors',
     author='Toucan Toco',
     author_email='dev@toucantoco.com',

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -281,7 +281,6 @@ def test_normalize_query():
 
 
 def test_status_all_good(mongo_connector):
-    # import ipdb; ipdb.set_trace();
     assert mongo_connector.get_status() == {
         'status': True,
         'details': [

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -1,7 +1,6 @@
 import json
 from functools import _lru_cache_wrapper, lru_cache
 from typing import Optional, Pattern, Union
-from urllib.parse import quote_plus
 
 import pandas as pd
 import pymongo

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -130,9 +130,8 @@ class MongoConnector(ToucanConnector):
 
     def _get_mongo_client_kwargs(self):
         mongo_client_kwargs = self.dict().copy()
-        mongo_client_kwargs.pop('name')
-        mongo_client_kwargs.pop('retry_policy')
-        mongo_client_kwargs.pop('type')
+        for field in ToucanConnector.schema()['properties']:
+            mongo_client_kwargs.pop(field)
         return mongo_client_kwargs
 
     def get_status(self):


### PR DESCRIPTION
Instantiate `MongoClient` with kwargs rather than with a connection string built from the connector parameters.

It means that it will be easier to add any supported `MongoClient` kwargs at the `MongoConnector` level.

It also means that we can use a connection string in the `host` field and leave out all the other parameters. In the end we can natively support a lot more connections options than we cover with the few parameters that we have explicitly listed in `MongoConnector`. cf. https://docs.mongodb.com/manual/reference/connection-string/

And more specifically this means that when you create a new MongoDB Atlas cluster, you can just copy and paste the connection string that is given by Atlas into our configurations files. 