### PR TITLE
Snowflake :: fix with use warehouse

### DIFF
--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -21,6 +21,10 @@ def test_snowflake(mocker):
 
     sc.get_df(sd)
 
+    snock.return_value.cursor.return_value.execute.assert_called_once_with(
+        'USE WAREHOUSE test_warehouse'
+    )
+
     snock.assert_called_once_with(
         user='test_user',
         password='test_password',

--- a/toucan_connectors/snowflake/snowflake_connector.py
+++ b/toucan_connectors/snowflake/snowflake_connector.py
@@ -47,6 +47,9 @@ class SnowflakeConnector(ToucanConnector):
             ocsp_response_cache_filename=self.ocsp_response_cache_filename,
         )
 
+        # https://docs.snowflake.net/manuals/sql-reference/sql/use-warehouse.html
+        connection.cursor().execute(f'USE WAREHOUSE {data_source.warehouse}')
+
         df = pd.read_sql(data_source.query, con=connection)
 
         connection.close()


### PR DESCRIPTION
Need to execute a special instruction before queries.

` A warehouse must be specified for a session and the warehouse must be running before queries and other DML statements can be executed in the session.`

source : https://docs.snowflake.net/manuals/sql-reference/sql/use-warehouse.html