### PR TITLE
Add shell install scripts for some connectors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,28 +6,19 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install sytem dependencies
+          name: Install system dependencies
           command: |
             sudo apt-get update
             sudo apt-get install freetds-dev libsasl2-dev libpq-dev
       - run:
           name: Install oracle dependencies
-          command: |
-            sudo apt-get install libaio1
-            sudo mkdir -p /opt/oracle
-            curl -s 'https://raw.githubusercontent.com/circulosmeos/gdown.pl/master/gdown.pl' -o /tmp/gdown.pl
-            chmod +x /tmp/gdown.pl
-            /tmp/gdown.pl 'https://drive.google.com/uc?export=download&id=1prPWRnaVMxDsIiSGJqz0TkFT7wXrCgaO' '/tmp/oracle_client_lib.zip'
-            sudo unzip /tmp/oracle_client_lib.zip -d /opt/oracle
-            sudo sh -c "echo /opt/oracle/instantclient_12_2 > /etc/ld.so.conf.d/oracle-instantclient.conf"
-            sudo ldconfig
+          command: sudo bash toucan_connectors/install_scripts/oracle.sh
+      - run:
+          name: Install databricks dependencies
+          command: sudo bash toucan_connectors/install_scripts/databricks.sh
       - run:
           name: Install azure_mssql dependencies
-          command: |
-            curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-            curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
-            sudo apt-get update
-            sudo ACCEPT_EULA=Y apt-get -y install msodbcsql17 unixodbc-dev
+          command: sudo bash toucan_connectors/install_scripts/azure_mssql.sh
       - run:
           name: Install python 3.6
           command: |

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,9 @@ setup(
     url='https://github.com/ToucanToco/toucan-connectors',
     license='BSD',
     classifiers=classifiers,
-    packages=find_packages(),
+    packages=find_packages(include=['toucan_connectors', 'toucan_connectors.*']),
     install_requires=install_requires,
     extras_require=extras_require,
     include_package_data=True,
+    zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ classifiers = [
 
 setup(
     name='toucan_connectors',
-    version='0.27.2',
+    version='0.28.0',
     description='Toucan Toco Connectors',
     author='Toucan Toco',
     author_email='dev@toucantoco.com',

--- a/toucan_connectors/install_scripts/__init__.py
+++ b/toucan_connectors/install_scripts/__init__.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+
+def get_install_script_path(connector_name):
+    return Path(__file__).parent.resolve() / f'{connector_name}.sh'

--- a/toucan_connectors/install_scripts/azure_mssql.sh
+++ b/toucan_connectors/install_scripts/azure_mssql.sh
@@ -9,7 +9,9 @@ fi
 apt-get update
 apt-get install -fyq curl
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | tee /etc/apt/sources.list.d/mssql-release.list
+source /etc/os-release &&\
+    curl "https://packages.microsoft.com/config/${ID}/${VERSION_ID}/prod.list" \
+    | tee /etc/apt/sources.list.d/mssql-release.list
 apt-get update
 ACCEPT_EULA=Y apt-get -y install msodbcsql17 unixodbc-dev
 

--- a/toucan_connectors/install_scripts/azure_mssql.sh
+++ b/toucan_connectors/install_scripts/azure_mssql.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | tee /etc/apt/sources.list.d/mssql-release.list
 apt-get update

--- a/toucan_connectors/install_scripts/azure_mssql.sh
+++ b/toucan_connectors/install_scripts/azure_mssql.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 set -e
 
+if [[ -e ~/azure_mssql-installed ]]; then
+    echo "Azure MSSQL connector dependencies are already installed."
+    exit
+fi
+
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | tee /etc/apt/sources.list.d/mssql-release.list
 apt-get update
 ACCEPT_EULA=Y apt-get -y install msodbcsql17 unixodbc-dev
+
+touch ~/azure_mssql-installed

--- a/toucan_connectors/install_scripts/azure_mssql.sh
+++ b/toucan_connectors/install_scripts/azure_mssql.sh
@@ -6,6 +6,8 @@ if [[ -e ~/azure_mssql-installed ]]; then
     exit
 fi
 
+apt-get update
+apt-get install -fyq curl
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | tee /etc/apt/sources.list.d/mssql-release.list
 apt-get update

--- a/toucan_connectors/install_scripts/azure_mssql.sh
+++ b/toucan_connectors/install_scripts/azure_mssql.sh
@@ -1,0 +1,4 @@
+curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | tee /etc/apt/sources.list.d/mssql-release.list
+apt-get update
+ACCEPT_EULA=Y apt-get -y install msodbcsql17 unixodbc-dev

--- a/toucan_connectors/install_scripts/databricks.sh
+++ b/toucan_connectors/install_scripts/databricks.sh
@@ -1,0 +1,8 @@
+# The next link was extracted from an email received after
+# filling: https://databricks.com/spark/odbc-driver-download
+mkdir -p /tmp/databricks
+wget 'https://databricks.com/wp-content/uploads/2.6.4.1004/SimbaSparkODBC-2.6.4.1004-Debian-64bit.zip' \
+     -o /tmp/databricks/simbaspark.zip
+unzip /tmp/databricks/simbaspark.zip -d /tmp/databricks
+dpkg -i /tmp/databricks/SimbaSparkODBC-2.6.4.1004-Debian-64bit/simbaspark_2.6.4.1004-2_amd64.deb
+rm -rf /tmp/databricks

--- a/toucan_connectors/install_scripts/databricks.sh
+++ b/toucan_connectors/install_scripts/databricks.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [[ -e ~/databricks-installed ]]; then
+    echo "Databricks connector dependencies are already installed."
+    exit
+fi
+
 # The next link was extracted from an email received after
 # filling: https://databricks.com/spark/odbc-driver-download
 mkdir -p /tmp/databricks
@@ -9,3 +14,5 @@ wget 'https://databricks.com/wp-content/uploads/2.6.4.1004/SimbaSparkODBC-2.6.4.
 unzip /tmp/databricks/simbaspark.zip -d /tmp/databricks
 dpkg -i /tmp/databricks/SimbaSparkODBC-2.6.4.1004-Debian-64bit/simbaspark_2.6.4.1004-2_amd64.deb
 rm -rf /tmp/databricks
+
+touch ~/databricks-installed

--- a/toucan_connectors/install_scripts/databricks.sh
+++ b/toucan_connectors/install_scripts/databricks.sh
@@ -6,11 +6,13 @@ if [[ -e ~/databricks-installed ]]; then
     exit
 fi
 
+apt-get update
+apt-get install -fyq libsasl2-modules-gssapi-mit wget
+mkdir -p /tmp/databricks
 # The next link was extracted from an email received after
 # filling: https://databricks.com/spark/odbc-driver-download
-mkdir -p /tmp/databricks
 wget 'https://databricks.com/wp-content/uploads/2.6.4.1004/SimbaSparkODBC-2.6.4.1004-Debian-64bit.zip' \
-     -o /tmp/databricks/simbaspark.zip
+     -O /tmp/databricks/simbaspark.zip
 unzip /tmp/databricks/simbaspark.zip -d /tmp/databricks
 dpkg -i /tmp/databricks/SimbaSparkODBC-2.6.4.1004-Debian-64bit/simbaspark_2.6.4.1004-2_amd64.deb
 rm -rf /tmp/databricks

--- a/toucan_connectors/install_scripts/databricks.sh
+++ b/toucan_connectors/install_scripts/databricks.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
 # The next link was extracted from an email received after
 # filling: https://databricks.com/spark/odbc-driver-download
 mkdir -p /tmp/databricks

--- a/toucan_connectors/install_scripts/oracle.sh
+++ b/toucan_connectors/install_scripts/oracle.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [[ -e ~/oracle-installed ]]; then
+    echo "Oracle connector dependencies are already installed"
+    exit
+fi
+
 apt-get install -fyq libaio1 curl
 mkdir -p /opt/oracle
 curl -s 'https://raw.githubusercontent.com/circulosmeos/gdown.pl/master/gdown.pl' -o /tmp/gdown.pl
@@ -10,3 +15,5 @@ unzip /tmp/oracle_client_lib.zip -d /opt/oracle
 sh -c "echo /opt/oracle/instantclient_12_2 > /etc/ld.so.conf.d/oracle-instantclient.conf"
 ldconfig
 rm -rf /tmp/gdown.pl /tmp/oracle_client_lib.zip
+
+touch ~/oracle-installed

--- a/toucan_connectors/install_scripts/oracle.sh
+++ b/toucan_connectors/install_scripts/oracle.sh
@@ -6,6 +6,7 @@ if [[ -e ~/oracle-installed ]]; then
     exit
 fi
 
+apt-get update
 apt-get install -fyq libaio1 curl
 mkdir -p /opt/oracle
 curl -s 'https://raw.githubusercontent.com/circulosmeos/gdown.pl/master/gdown.pl' -o /tmp/gdown.pl

--- a/toucan_connectors/install_scripts/oracle.sh
+++ b/toucan_connectors/install_scripts/oracle.sh
@@ -1,0 +1,9 @@
+apt-get install -fyq libaio1 curl
+mkdir -p /opt/oracle
+curl -s 'https://raw.githubusercontent.com/circulosmeos/gdown.pl/master/gdown.pl' -o /tmp/gdown.pl
+chmod +x /tmp/gdown.pl
+/tmp/gdown.pl 'https://drive.google.com/uc?export=download&id=1prPWRnaVMxDsIiSGJqz0TkFT7wXrCgaO' '/tmp/oracle_client_lib.zip'
+unzip /tmp/oracle_client_lib.zip -d /opt/oracle
+sh -c "echo /opt/oracle/instantclient_12_2 > /etc/ld.so.conf.d/oracle-instantclient.conf"
+ldconfig
+rm -rf /tmp/gdown.pl /tmp/oracle_client_lib.zip

--- a/toucan_connectors/install_scripts/oracle.sh
+++ b/toucan_connectors/install_scripts/oracle.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
 apt-get install -fyq libaio1 curl
 mkdir -p /opt/oracle
 curl -s 'https://raw.githubusercontent.com/circulosmeos/gdown.pl/master/gdown.pl' -o /tmp/gdown.pl


### PR DESCRIPTION
The goal is to be able to run these scripts from within our docker image (at runtime or in a `RUN` dockerfile step) to install these extra dependencies.