### PR TITLE
MANIFEST.IN :: add missing bash scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import find_packages, setup
+import glob
 
 auth_deps = ['oauthlib', 'requests_oauthlib']
 extras_require = {
@@ -46,7 +47,7 @@ classifiers = [
 
 setup(
     name='toucan_connectors',
-    version='0.28.0',
+    version='0.28.2',
     description='Toucan Toco Connectors',
     author='Toucan Toco',
     author_email='dev@toucantoco.com',
@@ -54,6 +55,7 @@ setup(
     license='BSD',
     classifiers=classifiers,
     packages=find_packages(include=['toucan_connectors', 'toucan_connectors.*']),
+    scripts=glob.glob('toucan_connectors/install_scripts/*.sh'),
     install_requires=install_requires,
     extras_require=extras_require,
     include_package_data=True,


### PR DESCRIPTION
The current package 0.28.0 does not include the bash scripts to install the connectors' system dependencies.

This PR should fix it.