### PR TITLE
Aircall :: Manage pagination and query parameters

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,11 @@ import glob
 from setuptools import find_packages, setup
 
 auth_deps = ['oauthlib', 'requests_oauthlib']
+bearer_deps = ['bearer']
+
 extras_require = {
     'adobe': ['adobe_analytics'],
-    'aircall': ['bearer'],
+    'aircall': bearer_deps,
     'azure_mssql': ['pyodbc'],
     'dataiku': ['dataiku-api-client'],
     'elasticsearch': ['elasticsearch'],
@@ -14,11 +16,11 @@ extras_require = {
     'google_big_query': ['pandas_gbq'],
     'google_cloud_mysql': ['PyMySQL>=0.8.0'],
     'google_my_business': ['google-api-python-client>=1.7.5'],
-    'google_sheets': ['bearer'],
+    'google_sheets': bearer_deps,
     'google_spreadsheet': ['gspread>=3', 'oauth2client'],
     'hive': ['pyhive[hive]'],
     'http_api': auth_deps,
-    'lightspeed': ['bearer'],
+    'lightspeed': bearer_deps,
     'mongo': ['pymongo>=3.6.1'],
     'mssql': ['pymssql>=2.1.3,<3.0'],
     'mysql': ['PyMySQL>=0.8.0'],

--- a/tests/aircall/test_aircall.py
+++ b/tests/aircall/test_aircall.py
@@ -1,26 +1,70 @@
-import os
+import pytest
 
 from toucan_connectors.aircall.aircall_connector import AircallConnector, AircallDataSource
 
-con = AircallConnector(name='test_name', bearer_auth_id='bearer-auth-id')
 
-ds = AircallDataSource(name='test_name', domain='test_domain', endpoint='/users/{{ myUser }}')
+@pytest.fixture
+def con(bearer_auth_id):
+    return AircallConnector(name='test_name', bearer_auth_id=bearer_auth_id)
 
 
-def test_aircall(mocker):
-    mocker.patch.dict(os.environ, {'BEARER_API_KEY': 'my_bearer_api_key'})
-    calls = {
-        'Eric': {'calls': [1, 2]},
-        'Pierre': {'calls': [3, 4]},
-    }
-    mocker.patch.object(
-        AircallConnector, 'bearer_oauth_get_endpoint', new=lambda self, x: calls[x.split('/')[-1]]
+def test_aircall_params_default_limit(con, mocker):
+    """It should retrieve 100 entries by default"""
+    get_page_data_spy = mocker.spy(AircallConnector, '_get_page_data')
+    ds = AircallDataSource(
+        name='test_name', domain='test_domain', endpoint='/calls', filter='.calls | map({id})',
     )
 
-    ds.parameters = {'myUser': 'Eric'}
     df = con.get_df(ds)
-    assert df.loc[0, 'calls'] == [1, 2]
+    assert len(df) == 100
+    assert get_page_data_spy.call_count == 2
 
-    ds.parameters = {'myUser': 'Pierre'}
+
+def test_aircall_params_with_no_limit(con, mocker):
+    """It should retrieve all entries if limit is -1"""
+    get_page_data_mock = mocker.patch.object(
+        AircallConnector,
+        '_get_page_data',
+        side_effect=[
+            ([{'a': 1}] * 50, False),
+            ([{'a': 1}] * 50, False),
+            ([{'a': 1}] * 50, False),
+            ([{'a': 1}] * 17, True),
+        ],
+    )
+
+    ds = AircallDataSource(
+        name='test_name',
+        domain='test_domain',
+        endpoint='/calls',
+        limit=-1,
+        filter='.calls | map({id})',
+    )
     df = con.get_df(ds)
-    assert df.loc[0, 'calls'] == [3, 4]
+    assert len(df) == 167
+    assert get_page_data_mock.call_count == 4
+
+
+def test_aircall_params_negative_limit():
+    """It should be forbidden to set a negative limit (except -1)"""
+    with pytest.raises(ValueError):
+        AircallDataSource(
+            name='test_name', domain='test_domain', endpoint='/calls', limit=-2,
+        )
+
+
+def test_aircall_params_limit_filter(con):
+    """It should filter properly the retrieved data"""
+    ds = AircallDataSource(
+        name='test_name',
+        domain='test_domain',
+        endpoint='/calls',
+        query={'order': 'asc', 'order_by': 'ended_at'},
+        limit=10,
+        filter='.calls | map({id, duration, ended_at})',
+    )
+
+    df = con.get_df(ds)
+    assert df.shape == (10, 3)
+    assert list(df.columns) == ['id', 'duration', 'ended_at']
+    assert df.ended_at.sort_values(ascending=True).equals(df.ended_at)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import socket
 import time
 from contextlib import suppress
-from os import environ, path
+from os import environ, getenv, path
 
 import pytest
 import yaml
@@ -136,3 +136,19 @@ def service_container(unused_port, container_starter):
         return container_starter(**params)
 
     return f
+
+
+@pytest.fixture
+def bearer_api_key():
+    bearer_api_key = getenv('BEARER_API_KEY')
+    if not bearer_api_key:
+        pytest.skip("'BEARER_API_KEY' is not set")
+    return bearer_api_key
+
+
+@pytest.fixture
+def bearer_auth_id(bearer_api_key):
+    bearer_auth_id = getenv('BEARER_AUTH_ID')
+    if not bearer_auth_id:
+        pytest.skip("'BEARER_AUTH_ID' is not set")
+    return bearer_auth_id

--- a/tests/google_sheets/test_google_sheets.py
+++ b/tests/google_sheets/test_google_sheets.py
@@ -31,7 +31,7 @@ def test_spreadsheet(mocker):
     integration_mock.assert_called_once_with('google_sheets')
     auth_mock.assert_called_once_with('qweqwe-1111-1111-1111-qweqweqwe')
     get_mock.assert_called_once_with(
-        '1SMnhnmBm-Tup3SfhS03McCf6S4pS2xqjI6CAXSSBpHU/values/Constants'
+        '1SMnhnmBm-Tup3SfhS03McCf6S4pS2xqjI6CAXSSBpHU/values/Constants', query=None
     )
     assert df.shape == (3, 2)
     assert df.columns.tolist() == [0, 1]

--- a/toucan_connectors/aircall/aircall_connector.py
+++ b/toucan_connectors/aircall/aircall_connector.py
@@ -1,9 +1,13 @@
+from typing import List, Optional, Tuple
+
 import pandas as pd
 from jq import jq
 from pydantic import Schema
 
 from toucan_connectors.common import FilterSchema, nosql_apply_parameters_to_query
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
+
+PER_PAGE = 50
 
 
 class AircallDataSource(ToucanDataSource):
@@ -13,6 +17,8 @@ class AircallDataSource(ToucanDataSource):
         description='See https://developer.aircall.io/api-references/#endpoints',
     )
     filter: str = FilterSchema
+    limit: int = Schema(100, description='Limit of entries (-1 for no limit)', ge=-1)
+    query: Optional[dict] = {}
 
 
 class AircallConnector(ToucanConnector):
@@ -25,10 +31,39 @@ class AircallConnector(ToucanConnector):
     bearer_integration = 'aircall_oauth'
     bearer_auth_id: str
 
+    def _get_page_data(
+        self, endpoint, query, jq_filter: str, page_number: int, per_page: int
+    ) -> Tuple[List[dict], bool]:
+        """Get the data for a single page and the information if the page is the last one"""
+        page_raw_data = self.bearer_oauth_get_endpoint(
+            endpoint, {**query, 'per_page': per_page, 'page': page_number}
+        )
+        is_last_page = page_raw_data['meta']['next_page_link'] is None
+        page_data = jq(jq_filter).transform(page_raw_data)
+        if isinstance(page_data, dict):
+            page_data = [page_data]
+        return page_data, is_last_page
+
     def _retrieve_data(self, data_source: AircallDataSource) -> pd.DataFrame:
         endpoint = nosql_apply_parameters_to_query(data_source.endpoint, data_source.parameters)
-        data = self.bearer_oauth_get_endpoint(endpoint)
-        data = jq(data_source.filter).transform(data)
-        if isinstance(data, dict):
-            data = [data]
+        query = nosql_apply_parameters_to_query(data_source.query, data_source.parameters)
+        limit = float('inf') if data_source.limit == -1 else data_source.limit
+
+        current_page = 1
+        is_last_page = False
+        data = []
+
+        while limit > 0 and not is_last_page:
+            per_page = PER_PAGE if limit > PER_PAGE else limit
+
+            # data = [], current_page = 1, limit = 60
+            page_data, is_last_page = self._get_page_data(
+                endpoint, query, data_source.filter, current_page, per_page
+            )
+
+            # data = [{...}, ..., {...}], current_page = 2, limit = 10
+            data += page_data
+            current_page += 1
+            limit -= per_page
+
         return pd.DataFrame(data)

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -204,13 +204,15 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         if 'bearer_integration' in cls.__fields__:
             cls.bearer_integration = cls.__fields__['bearer_integration'].default
 
-    def bearer_oauth_get_endpoint(self, endpoint: str):
+    def bearer_oauth_get_endpoint(
+        self, endpoint: str, query: Optional[dict] = None,
+    ):
         """Generic method to get an endpoint for an OAuth API integrated with Bearer"""
         return (
             Bearer(os.environ.get('BEARER_API_KEY'))
             .integration(self.bearer_integration)
             .auth(self.bearer_auth_id)
-            .get(endpoint)
+            .get(endpoint, query=query)
             .json()
         )
 


### PR DESCRIPTION
Improve Aircall Datasource:

- Manage pagination: loop over API pages
- Add a limit option to limit the number of results
- Add a query parameter to be able to add query parameters

For testing purposes, we add the expected BEARER_API_KEY environment variables in fixtures