### PR TITLE
README :: OracleSQL instructions

### DIFF
--- a/doc/connectors/oracle_sql.md
+++ b/doc/connectors/oracle_sql.md
@@ -1,6 +1,7 @@
 # OracleSQL connector
 
-⚠️ Using this connector requires the installation of [Oracle Instant client](http://www.oracle.com/technetwork/database/database-technologies/instant-client/overview/index.html) library. Please refer to Oracle [installation instructions](https://docs.oracle.com/en/database/oracle/oracle-database/12.2/lnoci/instant-client.html#GUID-7D65474A-8790-4E81-B535-409010791C2F) as it probably won't be available in your server current package manager.
+⚠️  Using this connector requires the installation of [Oracle Instant client](http://www.oracle.com/technetwork/database/database-technologies/instant-client/overview/index.html) library. The easiest way to install the package is to follow the different steps presents on the Oracle Github [installation instructions](https://oracle.github.io/odpi/doc/installation.html#).
+Alternatively, you can refer to the Oracle website [installation instructions](https://docs.oracle.com/en/database/oracle/oracle-database/12.2/lnoci/instant-client.html#GUID-7D65474A-8790-4E81-B535-409010791C2F) as it probably won't be available in your current server package manager.
 
 ## Data provider configuration
 


### PR DESCRIPTION
README:: OracleSQL connector instructions 

Description: 
Updated the readme to provide the easiest method to install oracle connector package