### PR TITLE
mongo :: change implementation of the query facetizing in get_slice()

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -8,6 +8,7 @@ isort
 pytest-cov >= 2.5.1
 pytest >= 3.4.2
 pytest-mock >= 1.9.0
+pytest-rerunfailures
 python-slugify >= 1.2.5
 PyYAML >= 3.12
 responses >= 0.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [flake8]
 exclude = __init__.py
+inline-quotes = single
+multiline-quotes = double
 max-line-length = 100
 ignore = E203, E266, E501, W503
 

--- a/tests/aircall/test_aircall.py
+++ b/tests/aircall/test_aircall.py
@@ -8,6 +8,7 @@ def con(bearer_auth_id):
     return AircallConnector(name='test_name', bearer_auth_id=bearer_auth_id)
 
 
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_aircall_params_default_limit(con, mocker):
     """It should retrieve 100 entries by default"""
     get_page_data_spy = mocker.spy(AircallConnector, '_get_page_data')
@@ -53,6 +54,7 @@ def test_aircall_params_negative_limit():
         )
 
 
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_aircall_params_limit_filter(con):
     """It should filter properly the retrieved data"""
     ds = AircallDataSource(


### PR DESCRIPTION
Before this PR, a $facet stage was added as the first step of the
mongo aggregationn pipeline of the datasource query. This lead to:

- bugs when the original query includes itself a $facet stage, as
  $facet stages cannot be nested

- performance downgrade as we execute twice the main query, instead
  of executing it once and facetizing the query at the end, as it is
  proposed in this PR