### PR TITLE
Set up cache for docker images in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Cache docker images
+      id: cache-docker-images
+      uses: actions/cache@v1
+      with:
+        path: /var/lib/docker/overlay2
+        key: ${{ runner.os }}-docker-images
+
     - name: Install system dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
## Change Summary
CI build is a bit slow due to the `docker pull` of all the required images.
They should be cached to avoid re-pulling them at each build.

## Related issue number
None