### PR TITLE
Prevent mongo connector to count more than 1M rows

### DIFF
--- a/doc/connectors/mongo.md
+++ b/doc/connectors/mongo.md
@@ -49,7 +49,9 @@ DATA_SOURCES: [
 ]
 ```
 
-## Note
+## Notes
+
+### Context manager usage
 
 The Mongo connector can be used as a context manager to avoid opening
 and closing a connection to a same database.
@@ -68,3 +70,9 @@ with MongoConnector(name='mycon', host='myhost', port=27017) as con:
         datasource = MongoDataSource(collection='test_col', query=query)
         con.get_df(datasource)
 ```
+
+### Document count limit
+
+The Mongo connectors limits the number of counted documents to one million, to
+avoid scanning all results of a very large query at each `get_slice` call.
+A count of 1M and 1 means that there is more than one million results.

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -20,6 +20,8 @@ from toucan_connectors.toucan_connector import (
     strlist_to_enum,
 )
 
+MAX_COUNTED_ROWS = 1000001
+
 
 def normalize_query(query, parameters):
     query = nosql_apply_parameters_to_query(query, parameters)
@@ -226,7 +228,8 @@ class MongoConnector(ToucanConnector):
                 df_facet.append({'$limit': limit})
             facet = {
                 '$facet': {
-                    'count': [{'$count': 'value'}],
+                    # counting more than 1M values can be really slow, and the exact number is not that much relevant
+                    'count': [{'$limit': MAX_COUNTED_ROWS}, {'$count': 'value'}],
                     'df': df_facet,  # df_facet is never empty
                 }
             }


### PR DESCRIPTION
## Change Summary
Trying to `get_slice` on a very large collection (25M rows) was _very_ slow (1min30).
This is caused by the count facet, which forces mongo to scan all docs regardless of the limit.

I suggest we limit this to a somewhat high value, but that doesn't impact too much performance.

I choose 1M, because it took 3s on my local mongo, and seems a nice threshold above which the exact count is not very relevant.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
