### PR TITLE
Fix ::: HTTP connector ::: no top level domain

### DIFF
--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Union
 
 import pandas as pd
-from pydantic import BaseModel, Field, FilePath, HttpUrl
+from pydantic import BaseModel, Field, FilePath, AnyHttpUrl
 from requests import Session
 
 from toucan_connectors.auth import Auth
@@ -84,7 +84,7 @@ class HttpAPIDataSource(ToucanDataSource):
 class HttpAPIConnector(ToucanConnector):
     data_source_model: HttpAPIDataSource
 
-    baseroute: HttpUrl = Field(..., title='Baseroute URL', description='Baseroute URL')
+    baseroute: AnyHttpUrl = Field(..., title='Baseroute URL', description='Baseroute URL')
     cert: List[FilePath] = Field(
         None, title='Certificate', description='File path of your certificate if any'
     )


### PR DESCRIPTION
## Change Summary

Replaces the strict baseroute validation in the HTTP connector with a more permissive one. This allows a user to create a connector that has no top domain.

## Related issue number

Please see [https://trello.com/c/EuUpirXG/4119-as-an-app-builder-i-can-use-a-connector-with-an-url-with-no-top-level-domain](https://trello.com/c/EuUpirXG/4119-as-an-app-builder-i-can-use-a-connector-with-an-url-with-no-top-level-domain)

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
