### PR TITLE
version bump :: 0.36.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.36.1',
+    version='0.36.2',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Change Summary

Bug fix when concepteur does not put in a top domain in url for HTTP connector

## Related issue number
[Trello card](https://trello.com/c/EuUpirXG/4119-as-an-app-builder-i-can-use-a-connector-with-an-url-with-no-top-level-domain)

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
