### PR TITLE
fix(aircall) : for retrying Aircall API if error

### DIFF
--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Union
 
 import pandas as pd
-from pydantic import BaseModel, Field, FilePath, AnyHttpUrl
+from pydantic import AnyHttpUrl, BaseModel, Field, FilePath
 from requests import Session
 
 from toucan_connectors.auth import Auth


### PR DESCRIPTION
## Change Summary
Adds an async retry policy if an error is returned by Aircall.

- So far we have three tries that fire once every second
- If things keep going badly, an exception is raised
- Logging was also added to the Aircall calls

## Related issue number

[Trello Card](https://trello.com/c/2z20DaPa/506-5-etqc-je-peux-cr%C3%A9er-une-app-aircall-de-fa%C3%A7on-consistante)

## Checklist

* [X] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
