### PR TITLE
Fix(dependencies) : fixing bug in Github actions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ install_requires = [
     'jinja2',
     'pydantic',
     'pyjq',
-    'requests',
+    'requests<2.24.0',
     'tenacity',
     'toucan_data_sdk',
     'urllib3==1.24.3',


### PR DESCRIPTION
This PR fixes a bug that makes tests in GitHub actions fail: https://github.com/snowflakedb/snowflake-connector-python/issues/324

It sets the requests dependency version to less than 2.24.0
