### PR TITLE
fix(error message) :: ETL validation crash in HTTP connector

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,7 +1,7 @@
 import pytest
 
 from toucan_connectors.common import (
-    NonValidEndpointVariable,
+    NonValidVariable,
     apply_query_parameters,
     nosql_apply_parameters_to_query,
 )
@@ -187,6 +187,7 @@ def test_bad_variable_in_query():
     """It should thrown a NonValidEndpointVariable exception if bad variable in endpoint"""
     query = {'url': '/stuff/%(thing)s/foo'}
     params = {}
-    with pytest.raises(NonValidEndpointVariable) as err:
-        nosql_apply_parameters_to_query(query, params)
-    assert str(err.value) == 'Non valid variable thing in endpoint'
+    nosql_apply_parameters_to_query(query, params)
+    with pytest.raises(NonValidVariable) as err:
+        nosql_apply_parameters_to_query(query, params, handle_errors=True)
+    assert str(err.value) == 'Non valid variable thing'

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,4 +1,10 @@
-from toucan_connectors.common import apply_query_parameters, nosql_apply_parameters_to_query
+import pytest
+
+from toucan_connectors.common import (
+    NonValidEndpointVariable,
+    apply_query_parameters,
+    nosql_apply_parameters_to_query,
+)
 
 
 def test_apply_parameter_to_query_do_nothing():
@@ -175,3 +181,12 @@ def test_render_raw_permission():
         '(indic0 == "0" or indic1 == 1) and ' 'indic2 == "yo_2" and indic_list == [\'0\', 1, \'2\']'
     )
     assert apply_query_parameters(query, params) == expected
+
+
+def test_bad_variable_in_query():
+    """It should thrown a NonValidEndpointVariable exception if bad variable in endpoint"""
+    query = {'url': '/stuff/%(thing)s/foo'}
+    params = {}
+    with pytest.raises(NonValidEndpointVariable) as err:
+        nosql_apply_parameters_to_query(query, params)
+    assert str(err.value) == 'Non valid variable thing in endpoint'

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -23,17 +23,16 @@ RE_SET_KEEP_TYPE = r'{{__keep_type__\1}}\2'
 RE_GET_KEEP_TYPE = r'{{(__keep_type__[^({{)}]*)}}'
 
 
-class NonValidEndpointVariable(Exception):
+class NonValidVariable(Exception):
     """ Error thrown for a non valid variable in endpoint """
 
 
-def nosql_apply_parameters_to_query(query, parameters):
+def nosql_apply_parameters_to_query(query, parameters, handle_errors=False):
     """
     WARNING : DO NOT USE THIS WITH VARIANTS OF SQL
     Instead use your client library parameter substitution method.
     https://www.owasp.org/index.php/Query_Parameterization_Cheat_Sheet
     """
-    print('first query ', query)
 
     def _has_parameters(query):
         t = Environment().parse(query)
@@ -91,7 +90,7 @@ def nosql_apply_parameters_to_query(query, parameters):
         else:
             return query
 
-    def _handle_missing_params(elt, params):
+    def _handle_missing_params(elt, params, handle_errors):
         """
         Remove a dictionary key if its value has a missing parameter.
         This is used to support the __VOID__ syntax, specific at Toucan Toco :
@@ -107,24 +106,22 @@ def nosql_apply_parameters_to_query(query, parameters):
                         try:
                             Template('{{ %s }}' % m, undefined=StrictUndefined).render(params)
                         except Exception:
+                            if handle_errors:
+                                raise NonValidVariable(f'Non valid variable {m}')
                             missing_params.append(m)
-                            if k == 'url':
-                                raise NonValidEndpointVariable(
-                                    f'Non valid variable {m} in endpoint'
-                                )
                     if any(missing_params):
                         continue
                     else:
                         e[k] = v
                 else:
-                    e[k] = _handle_missing_params(v, params)
+                    e[k] = _handle_missing_params(v, params, handle_errors)
             return e
         elif isinstance(elt, list):
-            return [_handle_missing_params(e, params) for e in elt]
+            return [_handle_missing_params(e, params, handle_errors) for e in elt]
         else:
             return elt
 
-    query = _handle_missing_params(query, parameters)
+    query = _handle_missing_params(query, parameters, handle_errors)
 
     if parameters is None:
         return query

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -23,12 +23,17 @@ RE_SET_KEEP_TYPE = r'{{__keep_type__\1}}\2'
 RE_GET_KEEP_TYPE = r'{{(__keep_type__[^({{)}]*)}}'
 
 
+class NonValidEndpointVariable(Exception):
+    """ Error thrown for a non valid variable in endpoint """
+
+
 def nosql_apply_parameters_to_query(query, parameters):
     """
     WARNING : DO NOT USE THIS WITH VARIANTS OF SQL
     Instead use your client library parameter substitution method.
     https://www.owasp.org/index.php/Query_Parameterization_Cheat_Sheet
     """
+    print('first query ', query)
 
     def _has_parameters(query):
         t = Environment().parse(query)
@@ -103,6 +108,10 @@ def nosql_apply_parameters_to_query(query, parameters):
                             Template('{{ %s }}' % m, undefined=StrictUndefined).render(params)
                         except Exception:
                             missing_params.append(m)
+                            if k == 'url':
+                                raise NonValidEndpointVariable(
+                                    f'Non valid variable {m} in endpoint'
+                                )
                     if any(missing_params):
                         continue
                     else:

--- a/toucan_connectors/elasticsearch/elasticsearch_connector.py
+++ b/toucan_connectors/elasticsearch/elasticsearch_connector.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 import pandas as pd
 from elasticsearch import Elasticsearch
 from pandas.io.json import json_normalize
-from pydantic import Field, BaseModel, SecretStr
+from pydantic import BaseModel, Field, SecretStr
 
 from toucan_connectors.common import nosql_apply_parameters_to_query
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -133,7 +133,7 @@ class HttpAPIConnector(ToucanConnector):
             session = Session()
 
         query = nosql_apply_parameters_to_query(
-            data_source.dict(by_alias=True), data_source.parameters
+            data_source.dict(by_alias=True), data_source.parameters, handle_errors=True
         )
 
         if self.template:


### PR DESCRIPTION
## Change Summary

Proposes error message for bad variable in endpoint while configuring datasets retrieved from an HTTP connector

This PR makes the error message more explicit.

## Screen shot

![Capture d’écran de 2020-06-30 11-06-54](https://user-images.githubusercontent.com/15613045/86119236-634b5000-bad2-11ea-9518-208c05355c59.png)

NOTE: wording has been changed a little in the error message proposed in this PR.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
