### PR TITLE
versioning :: bumping version to 0.37.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.37.3',
+    version='0.37.4',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Bumping version to 0.37.4 with a bug fix on validation in common function used by HTTP connector.

If a bogus variable is used, an exception is raised and will provide a comprehensible error message in the client.
