### PR TITLE
install_scripts :: oracle - add missing wget

### DIFF
--- a/toucan_connectors/install_scripts/oracle.sh
+++ b/toucan_connectors/install_scripts/oracle.sh
@@ -7,7 +7,7 @@ if [[ -e ~/oracle-installed ]]; then
 fi
 
 apt-get update
-apt-get install -fyq libaio1 curl
+apt-get install -fyq libaio1 curl wget
 mkdir -p /opt/oracle
 curl -s 'https://raw.githubusercontent.com/circulosmeos/gdown.pl/master/gdown.pl' -o /tmp/gdown.pl
 chmod +x /tmp/gdown.pl


### PR DESCRIPTION
## Change Summary

currently unable to launch `install_scripts/oracle.sh`:

```
...
Preparing to unpack .../libcurl4_7.64.0-4+deb10u1_amd64.deb ...
Unpacking libcurl4:amd64 (7.64.0-4+deb10u1) ...
Selecting previously unselected package curl.
Preparing to unpack .../curl_7.64.0-4+deb10u1_amd64.deb ...
Unpacking curl (7.64.0-4+deb10u1) ...
Selecting previously unselected package libaio1:amd64.
Preparing to unpack .../libaio1_0.3.112-3_amd64.deb ...
Unpacking libaio1:amd64 (0.3.112-3) ...
Setting up libcurl4:amd64 (7.64.0-4+deb10u1) ...
Setting up curl (7.64.0-4+deb10u1) ...
Setting up libaio1:amd64 (0.3.112-3) ...
sh: 1: wget: not found                                 >>>>>>>>>>>>>>>>>>>>>> !!
Couldn't download the file :-(
```
It's related to the [perl script](https://raw.githubusercontent.com/circulosmeos/gdown.pl/master/gdown.pl) used in the `install_scripts/oracle.sh` which explicitly uses `wget`.

## Related issue number

:x: 

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
