### PR TITLE
fix(mongo): fix status error format

### DIFF
--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -417,16 +417,15 @@ def test_status_unreachable(mongo_connector, mocker):
 
 def test_status_bad_username(mongo_connector):
     mongo_connector.username = 'bibou'
-    assert mongo_connector.get_status() == {
-        'status': False,
-        'details': [
-            ('Hostname resolved', True),
-            ('Port opened', True),
-            ('Host connection', True),
-            ('Authenticated', False),
-        ],
-        'error': 'Authentication failed.',
-    }
+    status = mongo_connector.get_status()
+    assert status['status'] is False
+    assert status['details'] == [
+        ('Hostname resolved', True),
+        ('Port opened', True),
+        ('Host connection', True),
+        ('Authenticated', False),
+    ]
+    assert 'Authentication failed' in status['error']
 
 
 def test_get_form_empty_query(mongo_connector):


### PR DESCRIPTION
## Change Summary
Mongo error format seems to differ in some local setups and in the CI (https://github.com/ToucanToco/toucan-connectors/pull/186/checks?check_run_id=941369017)

## Related issue number
Fixes #187 

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* ~[ ] Documentation reflects the changes where applicable~
