### PR TITLE
feat(oauth): Modified Google Sheets

### DIFF
--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -1,0 +1,29 @@
+from pytest import fixture
+
+from toucan_connectors.google_sheets_2.google_sheets_2_connector import (
+    GoogleSheets2Connector,
+    GoogleSheets2DataSource,
+)
+
+
+@fixture
+def con():
+    return GoogleSheets2Connector(name='test_name', access_token='qweqwe-1111-1111-1111-qweqweqwe')
+
+
+@fixture
+def ds():
+    return GoogleSheets2DataSource(
+        name='test_name',
+        domain='test_domain',
+        sheet='Constants',
+        spreadsheet_id='1SMnhnmBm-Tup3SfhS03McCf6S4pS2xqjI6CAXSSBpHU',
+    )
+
+
+def test_spreadsheet(mocker, con, ds):
+    pass
+
+
+def test_set_columns(mocker, con, ds):
+    pass

--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -21,9 +21,5 @@ def ds():
     )
 
 
-def test_spreadsheet(mocker, con, ds):
-    pass
-
-
-def test_set_columns(mocker, con, ds):
+def test_retrieve_data():
     pass

--- a/toucan_connectors/__init__.py
+++ b/toucan_connectors/__init__.py
@@ -1,6 +1,5 @@
 import base64
 import mimetypes
-import os
 from contextlib import suppress
 from importlib import import_module
 from pathlib import Path
@@ -81,6 +80,11 @@ CONNECTORS_REGISTRY = {
         'label': 'Google Sheets',
         'logo': 'google_sheets/google-sheets.png',
     },
+    'GoogleSheets2': {
+        'connector': 'google_sheets_2.google_sheets_2_connector.GoogleSheets2Connector',
+        'label': 'Google Sheets Modified',
+        'logo': 'google_sheets/google-sheets.png',
+    },
     'GoogleSpreadsheet': {
         'connector': 'google_spreadsheet.google_spreadsheet_connector.GoogleSpreadsheetConnector',
         'label': 'Google Spreadsheet',
@@ -148,15 +152,6 @@ CONNECTORS_REGISTRY = {
         'logo': 'wootric/wootric.png',
     },
 }
-
-GS2_CONNECTOR = os.environ.get('GS2_CONNECTOR')
-
-if GS2_CONNECTOR:
-    CONNECTORS_REGISTRY['GoogleSheets2'] = {
-        'connector': 'google_sheets_2.google_sheets_2_connector.GoogleSheets2Connector',
-        'label': 'Google Sheets Modified',
-        'logo': 'google_sheets/google-sheets.png',
-    }
 
 
 def html_base64_image_src(image_path: str) -> str:

--- a/toucan_connectors/__init__.py
+++ b/toucan_connectors/__init__.py
@@ -1,5 +1,6 @@
 import base64
 import mimetypes
+import os
 from contextlib import suppress
 from importlib import import_module
 from pathlib import Path
@@ -80,11 +81,6 @@ CONNECTORS_REGISTRY = {
         'label': 'Google Sheets',
         'logo': 'google_sheets/google-sheets.png',
     },
-    'GoogleSheets2': {
-        'connector': 'google_sheets_2.google_sheets_2_connector.GoogleSheets2Connector',
-        'label': 'Google Sheets Modified',
-        'logo': 'google_sheets/google-sheets.png',
-    },
     'GoogleSpreadsheet': {
         'connector': 'google_spreadsheet.google_spreadsheet_connector.GoogleSpreadsheetConnector',
         'label': 'Google Spreadsheet',
@@ -152,6 +148,15 @@ CONNECTORS_REGISTRY = {
         'logo': 'wootric/wootric.png',
     },
 }
+
+GS2_CONNECTOR = os.environ.get('GS2_CONNECTOR')
+
+if GS2_CONNECTOR:
+    CONNECTORS_REGISTRY['GoogleSheets2'] = {
+        'connector': 'google_sheets_2.google_sheets_2_connector.GoogleSheets2Connector',
+        'label': 'Google Sheets Modified',
+        'logo': 'google_sheets/google-sheets.png',
+    }
 
 
 def html_base64_image_src(image_path: str) -> str:

--- a/toucan_connectors/__init__.py
+++ b/toucan_connectors/__init__.py
@@ -80,6 +80,11 @@ CONNECTORS_REGISTRY = {
         'label': 'Google Sheets',
         'logo': 'google_sheets/google-sheets.png',
     },
+    'GoogleSheets2': {
+        'connector': 'google_sheets_2.google_sheets_2_connector.GoogleSheets2Connector',
+        'label': 'Google Sheets Modified',
+        'logo': 'google_sheets/google-sheets.png',
+    },
     'GoogleSpreadsheet': {
         'connector': 'google_spreadsheet.google_spreadsheet_connector.GoogleSpreadsheetConnector',
         'label': 'Google Spreadsheet',
@@ -170,6 +175,8 @@ for connector_type, connector_infos in CONNECTORS_REGISTRY.items():
         connector_infos['connector'] = connector_cls
         with suppress(AttributeError):
             connector_infos['bearer_integration'] = connector_cls.bearer_integration
+        with suppress(AttributeError):
+            connector_infos['auth_flow'] = connector_cls.auth_flow
         # check if connector implements `get_status`,
         # which is hence different from `ToucanConnector.get_status`
         connector_infos['hasStatusCheck'] = (

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -1,0 +1,34 @@
+"""Google Sheets connector with oauth-manager setup."""
+
+# This will replace the old Google Sheets connector that works with the Bearer API
+from typing import Optional
+
+import pandas as pd
+from pydantic import Field
+
+from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
+
+
+class GoogleSheets2DataSource(ToucanDataSource):
+    spreadsheet_id: str = Field(
+        ...,
+        title='ID of the spreadsheet',
+        description='Can be found in your URL: '
+        'https://docs.google.com/spreadsheets/d/<ID of the spreadsheet>/...',
+    )
+    sheet: Optional[str] = Field(
+        None, title='Sheet title', description='Title of the desired sheet'
+    )
+    header_row: int = Field(
+        0, title='Header row', description='Row of the header of the spreadsheet'
+    )
+
+
+class GoogleSheets2Connector(ToucanConnector):
+    data_source_model: GoogleSheets2DataSource
+
+    auth_flow = 'oauth2'
+    access_token: str
+
+    def _retrieve_data(self, data_source: GoogleSheets2DataSource) -> pd.DataFrame:
+        pass

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -23,12 +23,46 @@ class GoogleSheets2DataSource(ToucanDataSource):
         0, title='Header row', description='Row of the header of the spreadsheet'
     )
 
+    @classmethod
+    def get_form(cls, connector: 'GoogleSheetsConnector', current_config):
+        # Always add the suggestions for the available sheets
+        constraints = {}
+        with suppress(Exception):
+            data = connector.bearer_oauth_get_endpoint(current_config['spreadsheet_id'])
+            available_sheets = [str(x['properties']['title']) for x in data['sheets']]
+            constraints['sheet'] = strlist_to_enum('sheet', available_sheets)
+
+        return create_model('FormSchema', **constraints, __base__=cls).schema()
+
 
 class GoogleSheets2Connector(ToucanConnector):
     data_source_model: GoogleSheets2DataSource
 
     auth_flow = 'oauth2'
-    access_token: str
 
     def _retrieve_data(self, data_source: GoogleSheets2DataSource) -> pd.DataFrame:
-        pass
+        if data_source.sheet is None:
+            # Get spreadsheet informations and retrieve all the available sheets
+            # https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/get
+            data = self.bearer_oauth_get_endpoint(data_source.spreadsheet_id)
+            available_sheets = [str(x['properties']['title']) for x in data['sheets']]
+            data_source.sheet = available_sheets[0]
+
+        # https://developers.google.com/sheets/api/samples/reading
+        read_sheet_endpoint = f'{data_source.spreadsheet_id}/values/{data_source.sheet}'
+        data = self.bearer_oauth_get_endpoint(read_sheet_endpoint)['values']
+        df = pd.DataFrame(data)
+
+        # Since `data` is a list of lists, the columns are not set properly
+        # df =
+        #         0            1           2
+        #  0  animateur                  week
+        #  1    pika                      W1
+        #  2    bulbi                     W2
+        #
+        # We set the first row as the header by default and replace empty value by the index
+        # to avoid having errors when trying to jsonify it (two columns can't have the same value)
+        df.columns = [name or index for index, name in enumerate(df.iloc[data_source.header_row])]
+        df = df[data_source.header_row + 1 :]
+
+        return df

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -23,46 +23,12 @@ class GoogleSheets2DataSource(ToucanDataSource):
         0, title='Header row', description='Row of the header of the spreadsheet'
     )
 
-    @classmethod
-    def get_form(cls, connector: 'GoogleSheetsConnector', current_config):
-        # Always add the suggestions for the available sheets
-        constraints = {}
-        with suppress(Exception):
-            data = connector.bearer_oauth_get_endpoint(current_config['spreadsheet_id'])
-            available_sheets = [str(x['properties']['title']) for x in data['sheets']]
-            constraints['sheet'] = strlist_to_enum('sheet', available_sheets)
-
-        return create_model('FormSchema', **constraints, __base__=cls).schema()
-
 
 class GoogleSheets2Connector(ToucanConnector):
     data_source_model: GoogleSheets2DataSource
 
     auth_flow = 'oauth2'
+    access_token: str
 
     def _retrieve_data(self, data_source: GoogleSheets2DataSource) -> pd.DataFrame:
-        if data_source.sheet is None:
-            # Get spreadsheet informations and retrieve all the available sheets
-            # https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/get
-            data = self.bearer_oauth_get_endpoint(data_source.spreadsheet_id)
-            available_sheets = [str(x['properties']['title']) for x in data['sheets']]
-            data_source.sheet = available_sheets[0]
-
-        # https://developers.google.com/sheets/api/samples/reading
-        read_sheet_endpoint = f'{data_source.spreadsheet_id}/values/{data_source.sheet}'
-        data = self.bearer_oauth_get_endpoint(read_sheet_endpoint)['values']
-        df = pd.DataFrame(data)
-
-        # Since `data` is a list of lists, the columns are not set properly
-        # df =
-        #         0            1           2
-        #  0  animateur                  week
-        #  1    pika                      W1
-        #  2    bulbi                     W2
-        #
-        # We set the first row as the header by default and replace empty value by the index
-        # to avoid having errors when trying to jsonify it (two columns can't have the same value)
-        df.columns = [name or index for index, name in enumerate(df.iloc[data_source.header_row])]
-        df = df[data_source.header_row + 1 :]
-
-        return df
+        pass

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -84,8 +84,6 @@ class HttpAPIDataSource(ToucanDataSource):
 class HttpAPIConnector(ToucanConnector):
     data_source_model: HttpAPIDataSource
 
-    auth_flow = 'oauth2'
-
     baseroute: AnyHttpUrl = Field(..., title='Baseroute URL', description='Baseroute URL')
     cert: List[FilePath] = Field(
         None, title='Certificate', description='File path of your certificate if any'

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -84,6 +84,8 @@ class HttpAPIDataSource(ToucanDataSource):
 class HttpAPIConnector(ToucanConnector):
     data_source_model: HttpAPIDataSource
 
+    auth_flow = 'oauth2'
+
     baseroute: AnyHttpUrl = Field(..., title='Baseroute URL', description='Baseroute URL')
     cert: List[FilePath] = Field(
         None, title='Certificate', description='File path of your certificate if any'

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -204,6 +204,8 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
             raise TypeError(f'{cls.__name__} has no {e} attribute.')
         if 'bearer_integration' in cls.__fields__:
             cls.bearer_integration = cls.__fields__['bearer_integration'].default
+        if 'auth_flow' in cls.__fields__:
+            cls.auth_flow = cls.__fields__['auth_flow'].default
 
     def bearer_oauth_get_endpoint(
         self, endpoint: str, query: Optional[dict] = None,


### PR DESCRIPTION
Beginning of replacing Bearer API in Google Sheets

## Change Summary

- New temporary Google Sheets connector that does not work out-of-the-box yet

- CONNECTOR_REGISTRY now returns a Google Sheets API with auth_flow
property but only when a feature flag is on

- No tests yet ; no documentation yet since once this Google Sheets connector replaces the old one, we'll just modify the old document

- Has a feature flag necessary for Tucana

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
