### PR TITLE
GitHub connector

### DIFF
--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -12,6 +12,7 @@ def test_no_user():
 
 
 def test_get_df():
+    # please, put your own github token here ;) it will need the following authorization for this test: 'public_repo'
     connector = GithubConnector(name="github", token='...')
     df = connector.get_df(GithubDataSource(name='test', domain='test',
                                            mapping=[['data', 'repositoryOwner', 'repositories', 'nodes']],

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -1,8 +1,33 @@
+import pandas
 import pytest
+from pydantic import ValidationError
 
 from toucan_connectors.github.github_connector import GithubConnector, GithubDataSource
 
 
-def test_get_df():
-    pass
+def test_no_user():
+    """ It should raise an error as no token is given """
+    with pytest.raises(ValidationError):
+        GithubConnector()
 
+
+def test_get_df():
+    pandas.set_option('display.max_colwidth', -1)
+    connector = GithubConnector(name="github", token='b566c86b169ecde44a0304cfe56590d794ef833e')
+    df = connector.get_df(GithubDataSource(name='test', domain='test',
+                                           mapping=[['data', 'repositoryOwner', 'repositories', 'nodes']],
+                                           query='''
+    query{
+        repositoryOwner(login: "toucanToco") {
+            repositories(first:100){
+                nodes{
+                    name,
+                    pullRequests(states:OPEN){
+                        totalCount
+                }
+            }
+        }
+  }
+}'''))
+    # print(df.sort_values(['pullRequests.totalCount'], ascending=False).head(10))
+    assert list(df.columns) == ['name', 'pullRequests.totalCount']

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -1,0 +1,8 @@
+import pytest
+
+from toucan_connectors.github.github_connector import GithubConnector, GithubDataSource
+
+
+def test_get_df():
+    pass
+

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -12,8 +12,7 @@ def test_no_user():
 
 
 def test_get_df():
-    pandas.set_option('display.max_colwidth', -1)
-    connector = GithubConnector(name="github", token='b566c86b169ecde44a0304cfe56590d794ef833e')
+    connector = GithubConnector(name="github", token='...')
     df = connector.get_df(GithubDataSource(name='test', domain='test',
                                            mapping=[['data', 'repositoryOwner', 'repositories', 'nodes']],
                                            query='''

--- a/toucan_connectors/github/github_connector.py
+++ b/toucan_connectors/github/github_connector.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from pydantic import Field, constr
+
+from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
+
+
+class GithubDataSource(ToucanDataSource):
+    query: constr(min_length=1) = Field(
+        ..., description='You can write your SQL query here', widget='graphql'
+    )
+
+
+class GithubConnector(ToucanConnector):
+    data_source_model: GithubDataSource
+
+    graphql_endpoint: str = Field(
+        None,
+        default='https://api.github.com/graphql',
+        description='The graphql endpoint for github',
+    )
+    token: str = Field(
+        None,
+        description='A token that has read access',
+    )
+
+    def _retrieve_data(self, data_source: GithubDataSource) -> pd.DataFrame:
+        pass
+

--- a/toucan_connectors/github/github_connector.py
+++ b/toucan_connectors/github/github_connector.py
@@ -11,7 +11,7 @@ from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 class GithubDataSource(ToucanDataSource):
     query: constr(min_length=1) = Field(
-        ..., description='You can write your graphQL query here', widget='graphql'
+        ..., description='You can write your graphQL query here'
     )
     mapping: List[List[str]] = Field(
         [],

--- a/toucan_connectors/github/github_connector.py
+++ b/toucan_connectors/github/github_connector.py
@@ -1,12 +1,22 @@
+import json
+
 import pandas as pd
+import requests
 from pydantic import Field, constr
+from pandas import json_normalize
+from typing import Dict, List, Any
 
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 
 class GithubDataSource(ToucanDataSource):
     query: constr(min_length=1) = Field(
-        ..., description='You can write your SQL query here', widget='graphql'
+        ..., description='You can write your graphQL query here', widget='graphql'
+    )
+    mapping: List[List[str]] = Field(
+        [],
+        description="the mapping in the response json. Used to flatten the response. "
+                    "Should point to an array in the json. You can have more than one"
     )
 
 
@@ -14,7 +24,6 @@ class GithubConnector(ToucanConnector):
     data_source_model: GithubDataSource
 
     graphql_endpoint: str = Field(
-        None,
         default='https://api.github.com/graphql',
         description='The graphql endpoint for github',
     )
@@ -24,5 +33,8 @@ class GithubConnector(ToucanConnector):
     )
 
     def _retrieve_data(self, data_source: GithubDataSource) -> pd.DataFrame:
-        pass
+        result = requests.post("https://api.github.com/graphql",
+                               json={"query": data_source.query}, headers={"Authorization": "bearer " + self.token})
+        df = pd.json_normalize(data=result.json(), record_path=data_source.mapping)
+        return df
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
Comme discuté avec David lors de mon entretien technique avec lui, voila mon connecteur a l'API graphQL de github. La classe est assezs brute d'utilisation. La principale difficulté a été de transformer un json nested en structure à plat, pour pouvoir travailler dessus avec pandas. J'ai utilisé à cet effet pandas.json_normalize, en laissant à l'utilisateur de la classe le soin de fournir les mappings. D'apres internet, cela peut poser des soucis de performance pour les tres gros json. jq aurait peut-etre sa place ici ?

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%. I was not able to test all packages, but since i did not modify any existing files, there should not be any problems.

