### PR TITLE
Add sonar analysis to the repository

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,6 @@
+[run]
+relative_files = True
+
 [report]
 # Regexes for lines to exclude from consideration
 exclude_lines =

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
       run: pip install codecov && codecov --token=3e56598d-bfe8-4741-a973-f4b70bd2c280
 
     - name: SonarCloud Scan
+      # Only executed for one of the tested python version
+      if: ${{ always() && matrix['python-version'] == 3.6 }}
       uses: sonarsource/sonarcloud-github-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: CI
 
-on: [push]
+on:
+  # Trigger analysis when pushing in master or pull requests, and when creating
+  # a pull request.
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   run:
@@ -12,6 +19,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Disabling shallow clone is recommended for improving relevancy of sonar reporting
+        fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
@@ -56,3 +66,9 @@ jobs:
 
     - name: coverage
       run: pip install codecov && codecov --token=3e56598d-bfe8-4741-a973-f4b70bd2c280
+
+    - name: SonarCloud Scan
+      uses: sonarsource/sonarcloud-github-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 .coverage*
 coverage.xml
 test-report.xml
+.scannerwork
 
 # pyenv
 .python-version

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ dist/
 # Unit test / coverage reports
 .pytest_cache/
 .coverage*
+coverage.xml
+test-report.xml
 
 # pyenv
 .python-version

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ lint:
 
 .PHONY: test
 test:
-	pytest --cov=toucan_connectors --cov-report term-missing
+	pytest --junitxml=test-report.xml --cov=toucan_connectors --cov-report xml
 
 .PHONY: all
 all: test lint

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Pypi-l](https://img.shields.io/pypi/l/toucan-connectors.svg)](https://pypi.python.org/pypi/toucan-connectors)
 [![Pypi-wheel](https://img.shields.io/pypi/wheel/toucan-connectors.svg)](https://pypi.python.org/pypi/toucan-connectors)
 [![GitHub Actions](https://github.com/ToucanToco/toucan-connectors/workflows/CI/badge.svg)](https://github.com/ToucanToco/toucan-connectors/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/ToucanToco/toucan-connectors/branch/master/graph/badge.svg)](https://codecov.io/gh/ToucanToco/toucan-connectors)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ToucanToco_toucan-connectors&metric=coverage)](https://sonarcloud.io/dashboard?id=ToucanToco_toucan-connectors)
 
 # Toucan Connectors
 [Toucan Toco](https://toucantoco.com/fr/) data connectors are plugins to the Toucan Toco platform,
-configured with dictionaries (cf. `DataSource` classe) and returning
+configured with dictionaries (cf. `DataSource` class) and returning
 [Pandas DataFrames](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).
 
 ## Setup

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,17 @@
+sonar.projectKey=ToucanToco_toucan-connectors
+sonar.organization=toucantoco
+
+# This is the name and version displayed in the SonarCloud UI.
+# sonar.projectName=toucan-connectors
+sonar.projectVersion=0.39.2
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.sources=./toucan_connectors
+sonar.coverage.exclusions=./toucan_connectors/install_scripts
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8
+
+# Tests reports
+sonar.python.coverage.reportPaths=./coverage.xml
+sonar.python.xunit.reportPath=./test-report.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=ToucanToco_toucan-connectors
 sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
-# sonar.projectName=toucan-connectors
+sonar.projectName=Toucan Connectors
 sonar.projectVersion=0.39.2
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,6 +8,7 @@ sonar.projectVersion=0.39.2
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors
 sonar.coverage.exclusions=./toucan_connectors/install_scripts
+sonar.test.inclusions=./tests
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Change Summary
To get more insights than just coverage metrics, add Sonar analyser.
Results will be visible on sonarcloud

## Related issue number
None