### PR TITLE
fix(gbq): use standard SQL as default query syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 .DEFAULT_GOAL := all
+isort = isort toucan_connectors tests setup.py
+black = black -S -l 100 --target-version py36 toucan_connectors tests setup.py
 
 .PHONY: clean
 clean:
@@ -14,13 +16,14 @@ install:
 
 .PHONY: format
 format:
-	isort -rc toucan_connectors tests setup.py
-	black -S -l 100 --target-version py36 toucan_connectors tests setup.py
+	$(isort)
+	$(black)
 
 .PHONY: lint
 lint:
 	flake8 toucan_connectors tests setup.py
-	black -S -l 100 --target-version py36 --check toucan_connectors tests setup.py
+	$(isort) --check-only
+	$(black) --check
 
 .PHONY: test
 test:

--- a/tests/google_big_query/test_google_big_query.py
+++ b/tests/google_big_query/test_google_big_query.py
@@ -27,7 +27,6 @@ def test_gbq(mocker):
     connector = GoogleBigQueryConnector(
         name='MyGBQ',
         credentials=my_credentials,
-        dialect='standard',
         scopes=[
             'https://www.googleapis.com/auth/bigquery',
             'https://www.googleapis.com/auth/drive',
@@ -36,7 +35,7 @@ def test_gbq(mocker):
     datasource = GoogleBigQueryDataSource(
         name='MyGBQ',
         domain='wiki',
-        query='SELECT * FROM [bigquery-public-data:samples.wikipedia] LIMIT 1000',
+        query='SELECT * FROM bigquery-public-data:samples.wikipedia LIMIT 1000',
     )
     assert connector.get_df(datasource).equals(mydf)
 
@@ -48,7 +47,7 @@ def test_gbq(mocker):
         'https://www.googleapis.com/auth/drive',
     ]
     assert kwargs == {
-        'query': 'SELECT * FROM [bigquery-public-data:samples.wikipedia] LIMIT 1000',
+        'query': 'SELECT * FROM bigquery-public-data:samples.wikipedia LIMIT 1000',
         'project_id': 'my_project_id',
         'dialect': 'standard',
     }

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -37,7 +37,7 @@ class GoogleBigQueryConnector(ToucanConnector):
         'to use when authenticating on behalf of a service or application',
     )
     dialect: Dialect = Field(
-        Dialect.legacy,
+        Dialect.standard,
         description='BigQuery allows you to choose between standard and legacy SQL as query syntax. '
         'The preferred query syntax is the default standard SQL. You can find more information on this '
         '<a href="https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax">documentation</a>',


### PR DESCRIPTION
We used to have legacy SQL syntax by default for google big query, which was confusing as the official documentation and most of conceptors are used to writing standard SQL.
This PR changes this by setting standard SQL as the default dialect. Conceptors can still manually select legacy syntax if needed