### PR TITLE
feat(googlesheets2): Status check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.40.0',
+    version='0.41.0',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -49,11 +49,11 @@ FAKE_SHEET = {
 
 
 @pytest.mark.asyncio
-async def test_get_data(mocker, con):
+async def test_authentified_fetch(mocker, con):
     """It should return a result from fetch if all is ok."""
     mocker.patch(f'{import_path}.fetch', return_value=helpers.build_future(FAKE_SHEET))
 
-    result = await con._get_data('/foo', 'myaccesstoken')
+    result = await con._authentified_fetch('/foo', 'myaccesstoken')
 
     assert result == FAKE_SHEET
 
@@ -169,7 +169,7 @@ def test_set_columns(mocker, con_with_secrets, ds):
 def test__run_fetch(mocker, con):
     """It should return a result from loops if all is ok."""
     mocker.patch.object(
-        GoogleSheets2Connector, '_get_data', return_value=helpers.build_future(FAKE_SHEET)
+        GoogleSheets2Connector, '_authentified_fetch', return_value=helpers.build_future(FAKE_SHEET)
     )
 
     result = con._run_fetch('/fudge', 'myaccesstoken')

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -8,6 +8,7 @@ import pymongo.errors
 import pytest
 from bson.son import SON
 
+from toucan_connectors.common import ConnectorStatus
 from toucan_connectors.mongo.mongo_connector import (
     MongoConnector,
     MongoDataSource,
@@ -346,56 +347,56 @@ def test_normalize_query():
 
 
 def test_status_all_good(mongo_connector):
-    assert mongo_connector.get_status() == {
-        'status': True,
-        'details': [
+    assert mongo_connector.get_status() == ConnectorStatus(
+        status=True,
+        details=[
             ('Hostname resolved', True),
             ('Port opened', True),
             ('Host connection', True),
             ('Authenticated', True),
         ],
-        'error': None,
-    }
+        error=None,
+    )
 
 
 def test_status_bad_host(mongo_connector):
     mongo_connector.host = 'localhot'
     mongo_connector.port = 42
     status = mongo_connector.get_status()
-    assert status['status'] is False
-    assert status['details'] == [
+    assert status.status is False
+    assert status.details == [
         ('Hostname resolved', False),
         ('Port opened', None),
         ('Host connection', None),
         ('Authenticated', None),
     ]
-    assert len(status['error']) > 0
+    assert len(status.error) > 0
 
 
 def test_status_bad_port(mongo_connector):
     mongo_connector.port += 1
     status = mongo_connector.get_status()
-    assert status['status'] is False
-    assert status['details'] == [
+    assert status.status is False
+    assert status.details == [
         ('Hostname resolved', True),
         ('Port opened', False),
         ('Host connection', None),
         ('Authenticated', None),
     ]
-    assert 'Connection refused' in status['error']
+    assert 'Connection refused' in status.error
 
 
 def test_status_bad_port2(mongo_connector):
     mongo_connector.port = 123000
     status = mongo_connector.get_status()
-    assert status['status'] is False
-    assert status['details'] == [
+    assert status.status is False
+    assert status.details == [
         ('Hostname resolved', True),
         ('Port opened', False),
         ('Host connection', None),
         ('Authenticated', None),
     ]
-    assert 'port must be 0-65535.' in status['error']
+    assert 'port must be 0-65535.' in status.error
 
 
 def test_status_unreachable(mongo_connector, mocker):
@@ -403,29 +404,29 @@ def test_status_unreachable(mongo_connector, mocker):
         'pymongo.MongoClient.server_info',
         side_effect=pymongo.errors.ServerSelectionTimeoutError('qwe'),
     )
-    assert mongo_connector.get_status() == {
-        'status': False,
-        'details': [
+    assert mongo_connector.get_status() == ConnectorStatus(
+        status=False,
+        details=[
             ('Hostname resolved', True),
             ('Port opened', True),
             ('Host connection', False),
             ('Authenticated', None),
         ],
-        'error': 'qwe',
-    }
+        error='qwe',
+    )
 
 
 def test_status_bad_username(mongo_connector):
     mongo_connector.username = 'bibou'
     status = mongo_connector.get_status()
-    assert status['status'] is False
-    assert status['details'] == [
+    assert status.status is False
+    assert status.details == [
         ('Hostname resolved', True),
         ('Port opened', True),
         ('Host connection', True),
         ('Authenticated', False),
     ]
-    assert 'Authentication failed' in status['error']
+    assert 'Authentication failed' in status.error
 
 
 def test_get_form_empty_query(mongo_connector):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -230,4 +230,9 @@ def test_connector_status():
     """
     It should be exported as dict
     """
-    assert ConnectorStatus(status=True).to_dict() == {'status': True}
+    assert ConnectorStatus(status=True).to_dict() == {
+        'status': True,
+        'message': None,
+        'error': None,
+        'details': [],
+    }

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,6 +2,7 @@ import pytest
 from aiohttp import web
 
 from toucan_connectors.common import (
+    ConnectorStatus,
     NonValidVariable,
     apply_query_parameters,
     fetch,
@@ -223,3 +224,10 @@ async def test_fetch_bad_response(aiohttp_client, loop):
         await fetch('/hotels', client)
 
     assert str(err.value) == 'Aborting request due to error from the API: 401, Unauthorized'
+
+
+def test_connector_status():
+    """
+    It should be exported as dict
+    """
+    assert ConnectorStatus(status=True).to_dict() == {'status': True}

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -5,6 +5,7 @@ import pytest
 import tenacity as tny
 from pydantic import create_model
 
+from toucan_connectors.common import ConnectorStatus
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -111,11 +112,7 @@ def test_explain():
 
 
 def test_get_status():
-    assert DataConnector(name='my_name').get_status() == {
-        'status': None,
-        'details': [],
-        'error': None,
-    }
+    assert DataConnector(name='my_name').get_status() == ConnectorStatus()
 
 
 class UnreliableDataConnector(ToucanConnector):

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -1,7 +1,9 @@
 import ast
 import asyncio
+import dataclasses
 import re
 from copy import deepcopy
+from typing import List, Optional, Tuple
 
 import pyjq
 from aiohttp import ClientSession
@@ -221,3 +223,14 @@ class HttpError(Exception):
     """
     Raised when the response of an HTTP request has not a 200 status code.
     """
+
+
+@dataclasses.dataclass()
+class ConnectorStatus:
+    status: Optional[bool] = None
+    message: Optional[str] = None
+    error: Optional[str] = None
+    details: Optional[List[Tuple[str, Optional[bool]]]] = dataclasses.field(default_factory=list)
+
+    def to_dict(self):
+        return dataclasses.asdict(self)

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -211,7 +211,13 @@ async def fetch(url: str, session: ClientSession):
     """Fetch data from an API."""
     async with session.get(url) as res:
         if res.status != 200:
-            raise Exception(
+            raise HttpError(
                 f'Aborting request due to error from the API: {res.status}, {res.reason}'
             )
         return await res.json()
+
+
+class HttpError(Exception):
+    """
+    Raised when the response of an HTTP request has not a 200 status code.
+    """

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -67,7 +67,7 @@ class GoogleSheets2Connector(ToucanConnector):
 
     secrets: Optional[Secrets]
 
-    async def _get_data(self, url, access_token):
+    async def _authentified_fetch(self, url, access_token):
         """Build the final request along with headers."""
         headers = {'Authorization': f'Bearer {access_token}'}
 
@@ -81,7 +81,7 @@ class GoogleSheets2Connector(ToucanConnector):
     def _run_fetch(self, url, access_token):
         """Run loop."""
         loop = get_loop()
-        future = asyncio.ensure_future(self._get_data(url, access_token))
+        future = asyncio.ensure_future(self._authentified_fetch(url, access_token))
         return loop.run_until_complete(future)
 
     def _retrieve_data(self, data_source: GoogleSheets2DataSource) -> pd.DataFrame:

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -9,13 +9,8 @@ import pandas as pd
 from aiohttp import ClientSession
 from pydantic import Field, create_model
 
-from toucan_connectors.common import HttpError, fetch, get_loop
-from toucan_connectors.toucan_connector import (
-    ConnectorStatus,
-    ToucanConnector,
-    ToucanDataSource,
-    strlist_to_enum,
-)
+from toucan_connectors.common import ConnectorStatus, HttpError, fetch, get_loop
+from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
 class GoogleSheets2DataSource(ToucanDataSource):

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -9,10 +9,9 @@ from bson.son import SON
 from cached_property import cached_property
 from pydantic import Field, SecretStr, create_model, validator
 
-from toucan_connectors.common import nosql_apply_parameters_to_query
+from toucan_connectors.common import ConnectorStatus, nosql_apply_parameters_to_query
 from toucan_connectors.mongo.mongo_translator import MongoConditionTranslator
 from toucan_connectors.toucan_connector import (
-    ConnectorStatus,
     DataSlice,
     ToucanConnector,
     ToucanDataSource,

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -7,12 +7,8 @@ import pymysql
 from pydantic import Field, SecretStr, constr, create_model
 from pymysql.constants import CR, ER
 
-from toucan_connectors.toucan_connector import (
-    ConnectorStatus,
-    ToucanConnector,
-    ToucanDataSource,
-    strlist_to_enum,
-)
+from toucan_connectors.common import ConnectorStatus
+from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
 class MySQLDataSource(ToucanDataSource):

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -1,4 +1,3 @@
-import dataclasses
 import logging
 import operator
 import os
@@ -6,13 +5,13 @@ import socket
 from abc import ABCMeta, abstractmethod
 from enum import Enum
 from functools import reduce, wraps
-from typing import Iterable, List, NamedTuple, Optional, Tuple, Type
+from typing import Iterable, List, NamedTuple, Optional, Type
 
 import pandas as pd
 import tenacity as tny
 from pydantic import BaseModel
 
-from toucan_connectors.common import apply_query_parameters
+from toucan_connectors.common import ConnectorStatus, apply_query_parameters
 from toucan_connectors.pandas_translator import PandasConditionTranslator
 
 try:
@@ -166,17 +165,6 @@ def decorate_func_with_retry(func):
             return func(self, *args, **kwargs)
 
     return get_func_and_retry
-
-
-@dataclasses.dataclass()
-class ConnectorStatus:
-    status: Optional[bool] = None
-    message: Optional[str] = None
-    error: Optional[str] = None
-    details: Optional[List[Tuple[str, Optional[bool]]]] = dataclasses.field(default_factory=list)
-
-    def to_dict(self):
-        return dataclasses.asdict(self)
 
 
 class ToucanConnector(BaseModel, metaclass=ABCMeta):

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -3,9 +3,10 @@ import operator
 import os
 import socket
 from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass, field
 from enum import Enum
 from functools import reduce, wraps
-from typing import Iterable, List, NamedTuple, Optional, Type
+from typing import Iterable, List, NamedTuple, Optional, Tuple, Type
 
 import pandas as pd
 import tenacity as tny
@@ -167,6 +168,14 @@ def decorate_func_with_retry(func):
     return get_func_and_retry
 
 
+@dataclass
+class ConnectorStatus:
+    status: Optional[bool] = None
+    message: Optional[str] = None
+    error: Optional[str] = None
+    details: Optional[List[Tuple[str, Optional[bool]]]] = field(default_factory=list)
+
+
 class ToucanConnector(BaseModel, metaclass=ABCMeta):
     """Abstract base class for all toucan connectors.
 
@@ -283,7 +292,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.connect((host, port))
 
-    def get_status(self) -> dict:
+    def get_status(self) -> ConnectorStatus:
         """
         Check if connection can be made.
         Returns
@@ -291,6 +300,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
           'status': True/False/None  # the status of the connection (None if no check has been made)
           'details': [(< type of check >, True/False/None), (...), ...]
           'error': < error message >  # if a check raised an error, return it
+          'message': < status message > # optionally provides some additional info, such as the user account connected
         }
         e.g.
         {
@@ -304,4 +314,4 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
           'error': 'port must be 0-65535'
         }
         """
-        return {'status': None, 'details': [], 'error': None}
+        return ConnectorStatus()

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -1,9 +1,9 @@
+import dataclasses
 import logging
 import operator
 import os
 import socket
 from abc import ABCMeta, abstractmethod
-from dataclasses import dataclass, field
 from enum import Enum
 from functools import reduce, wraps
 from typing import Iterable, List, NamedTuple, Optional, Tuple, Type
@@ -168,12 +168,15 @@ def decorate_func_with_retry(func):
     return get_func_and_retry
 
 
-@dataclass
+@dataclasses.dataclass()
 class ConnectorStatus:
     status: Optional[bool] = None
     message: Optional[str] = None
     error: Optional[str] = None
-    details: Optional[List[Tuple[str, Optional[bool]]]] = field(default_factory=list)
+    details: Optional[List[Tuple[str, Optional[bool]]]] = dataclasses.field(default_factory=list)
+
+    def to_dict(self):
+        return dataclasses.asdict(self)
 
 
 class ToucanConnector(BaseModel, metaclass=ABCMeta):


### PR DESCRIPTION
## Change Summary
Implement the get_status method for the new google sheets connector, and returns the email account associated with the secrets in the status message.

Opportunistic improvement: introduce a dataclass `ConnectorStatus` to ease the implementation of future `get_status` methods in other connectors. 
This will only require a minor change if `get_status` consumers wants a dict instead: calling its `to_dict` method.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
