### PR TITLE
chore: added auth_flow_id to Google Sheets 2

### DIFF
--- a/doc/connectors/google_sheets_2.md
+++ b/doc/connectors/google_sheets_2.md
@@ -15,7 +15,7 @@ The `baseroute` is fixed and is 'https://sheets.googleapis.com/v4/spreadsheets/'
 
 The `secrets` dictionary contains the `access_token` and a `refresh_token` (if there is one). Though `secrets` is optional during the initial creation of the connector, it is necessary for when the user wants to make requests to the connector. If there is no `access_token`, an Exception is thrown.
 
-The `auth_flow_id` property is like a identifier that is used to identify the connector.
+The `auth_flow_id` property is like an identifier that is used to identify the secrets associated with the connector.
 
 
 ```coffee

--- a/doc/connectors/google_sheets_2.md
+++ b/doc/connectors/google_sheets_2.md
@@ -5,6 +5,7 @@
 * `type`: `"GoogleSheets2"`
 * `name`: str, required
 * `auth_flow`: str
+* `auth_flow_id`: str
 * `baseroute`: str
 * `secrets`: dict
 
@@ -13,6 +14,8 @@ The `auth_flow` property marks this as being a connector that uses the connector
 The `baseroute` is fixed and is 'https://sheets.googleapis.com/v4/spreadsheets/'.
 
 The `secrets` dictionary contains the `access_token` and a `refresh_token` (if there is one). Though `secrets` is optional during the initial creation of the connector, it is necessary for when the user wants to make requests to the connector. If there is no `access_token`, an Exception is thrown.
+
+The `auth_flow_id` property is like a identifier that is used to identify the connector.
 
 
 ```coffee

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.41.0',
+    version='0.41.1',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -61,6 +61,8 @@ class GoogleSheets2Connector(ToucanConnector):
 
     auth_flow = 'oauth2'
 
+    auth_flow_id: Optional[str]
+
     # The following should be hidden properties
 
     baseroute = 'https://sheets.googleapis.com/v4/spreadsheets/'


### PR DESCRIPTION
## Change Summary

This adds a new property to the Google Sheets 2 connector : `auth_flow_id`, which behaves a lot like the old `bearer_auth_id`. It's used as an identifier for the Google Sheets 2 connector instead of the connector's name, which can be modified by the user.

This renders the oauth dance more robust because 1) we no longer rely on a property that can be changed at any moment by the user and 2) it prevents fan out throw several collections when a user updates their connector's name.

