### PR TITLE
feat(gsheets2): added hidden properties

### DIFF
--- a/doc/connectors/google_sheets_2.md
+++ b/doc/connectors/google_sheets_2.md
@@ -4,16 +4,16 @@
 
 * `type`: `"GoogleSheets2"`
 * `name`: str, required
-* `auth_flow`: str
+* `_auth_flow`: str
 * `auth_flow_id`: str
-* `baseroute`: str
-* `secrets`: dict
+* `_baseroute`: str
+* `hidden_properties`: GoogleSheets2HiddenProperties
 
-The `auth_flow` property marks this as being a connector that uses the connector_oauth_manager for the oauth dance.
+The `_auth_flow` property marks this as being a connector that uses the connector_oauth_manager for the oauth dance. It is hidden from being rendered in the front but appears in the front as a flag for initiating the oauth dance. It is a static *flag*.
 
-The `baseroute` is fixed and is 'https://sheets.googleapis.com/v4/spreadsheets/'.
+The `_baseroute` is fixed and is 'https://sheets.googleapis.com/v4/spreadsheets/'. It too is hidden from being rendered in the front. It is a static *non-flag*
 
-The `secrets` dictionary contains the `access_token` and a `refresh_token` (if there is one). Though `secrets` is optional during the initial creation of the connector, it is necessary for when the user wants to make requests to the connector. If there is no `access_token`, an Exception is thrown.
+The `hidden_properties` propertie contains the `access_token` and a `refresh_token` (if there is one) in a class called `GoogleSheets2HiddenProperties`. Though `hidden_properties` is optional during the initial creation of the connector, it is necessary for when the user wants to make requests to the connector. If there is no `access_token`, an Exception is thrown. This is a dynamic *non-flag* property.
 
 The `auth_flow_id` property is like an identifier that is used to identify the secrets associated with the connector.
 
@@ -22,6 +22,7 @@ The `auth_flow_id` property is like an identifier that is used to identify the s
 DATA_PROVIDERS: [
   type:    'GoogleSheets'
   name:    '<name>'
+  auth_flow_id: '<auth_flow_id>'
 ,
   ...
 ]

--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -110,8 +110,8 @@ def test_get_form_no_secrets(mocker, con, ds):
     assert not get_columns_in_schema(result)
 
 
-def test_set_secrets(mocker, con):
-    """It should set secrets and auth_flow_id in the connector's hidden properties."""
+def test_set_hidden_properties(mocker, con):
+    """It should set secrets in the connector's hidden properties."""
     spy = mocker.spy(GoogleSheets2HiddenProperties, 'set_hidden_properties')
     fake_secrets = {
         'access_token': 'myaccesstoken',

--- a/toucan_connectors/__init__.py
+++ b/toucan_connectors/__init__.py
@@ -194,7 +194,7 @@ for connector_type, connector_infos in CONNECTORS_REGISTRY.items():
         with suppress(AttributeError):
             connector_infos['bearer_integration'] = connector_cls.bearer_integration
         with suppress(AttributeError):
-            connector_infos['auth_flow'] = connector_cls.auth_flow
+            connector_infos['_auth_flow'] = connector_cls._auth_flow
         # check if connector implements `get_status`,
         # which is hence different from `ToucanConnector.get_status`
         connector_infos['hasStatusCheck'] = (

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -204,8 +204,8 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
             raise TypeError(f'{cls.__name__} has no {e} attribute.')
         if 'bearer_integration' in cls.__fields__:
             cls.bearer_integration = cls.__fields__['bearer_integration'].default
-        if 'auth_flow' in cls.__fields__:
-            cls.auth_flow = cls.__fields__['auth_flow'].default
+        if '_auth_flow' in cls.__fields__:
+            cls._auth_flow = cls.__fields__['_auth_flow'].default
 
     def bearer_oauth_get_endpoint(
         self,

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -204,8 +204,6 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
             raise TypeError(f'{cls.__name__} has no {e} attribute.')
         if 'bearer_integration' in cls.__fields__:
             cls.bearer_integration = cls.__fields__['bearer_integration'].default
-        if '_auth_flow' in cls.__fields__:
-            cls._auth_flow = cls.__fields__['_auth_flow'].default
 
     def bearer_oauth_get_endpoint(
         self,


### PR DESCRIPTION
## Change Summary

We added a class to hide certain properties from the user. These can be divided into two main categories: flags and non-flags.

Flags are properties that are required by the front to do something. In this case `auth_flow_id` is for initiating the oauth dance.

Non-flags are everything else. Non-flags can be divided into two categories: static and dynamic. Static non-flags are kept on the connector itself and have a '_' at the front of their name. Dynamic ones are kept on the new class. The reason why we put the static non-flags is so that we don't have to return them if we don't want to when we fetch hidden properties from the class that contains them.

On the front-end, we will eventually want to hide all properties that are stored in 'hidden_properties' on the connector. Those properties that begin with a '_' are hidden automatically.

Dynamic properties cannot be hidden with a '_' in front of their variable name because we can't set them afterwards.

## Related issue number

[https://github.com/ToucanToco/toucan-connectors/issues/206](https://github.com/ToucanToco/toucan-connectors/issues/206)

## Checklist

* [X] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
