### PR TITLE
Google Sheets: retrieve unformatted values instead of formatted ones

### DIFF
--- a/doc/connectors/google_sheets_2.md
+++ b/doc/connectors/google_sheets_2.md
@@ -36,7 +36,7 @@ the url: https://docs.google.com/spreadsheets/d/<spreadsheet_id_is_here>/edit?pr
 * `sheet`: str. By default, the extractor returns the first sheet.
 * `header_row`: int, default to 0. Row of the header of the spreadsheet
 
-Values are retrieved with the parameter valueRenderOption=UNFORMATTED_VALUE to escape the rendering based on the locale defined in google sheets.
+Values are retrieved with the parameter [valueRenderOption](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values/get#body.QUERY_PARAMETERS.value_render_option) set to `UNFORMATTED_VALUE` to escape the rendering based on the locale defined in google sheets.
 
 ```coffee
 DATA_SOURCES: [

--- a/doc/connectors/google_sheets_2.md
+++ b/doc/connectors/google_sheets_2.md
@@ -36,6 +36,7 @@ the url: https://docs.google.com/spreadsheets/d/<spreadsheet_id_is_here>/edit?pr
 * `sheet`: str. By default, the extractor returns the first sheet.
 * `header_row`: int, default to 0. Row of the header of the spreadsheet
 
+Values are retrieved with the parameter valueRenderOption=UNFORMATTED_VALUE to escape the rendering based on the locale defined in google sheets.
 
 ```coffee
 DATA_SOURCES: [

--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -236,11 +236,11 @@ def test_get_status_api_down(mocker, con, fake_kwargs):
     assert con.get_status().status is False
 
 
-def test_get_decimal_separator(mocker, con, ds):
+def test_get_decimal_separator(mocker, con, ds, fake_kwargs):
     """
     It should returns number data in float type
     """
     fake_results = {'metadata': '...', 'values': [['Number'], [1.3], [1.2]]}
     mocker.patch.object(GoogleSheets2Connector, '_run_fetch', return_value=fake_results)
-    df = con.get_df(ds)
+    df = con.get_df(ds, **fake_kwargs)
     assert df.to_dict() == {'Number': {1: 1.3, 2: 1.2}}

--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -217,7 +217,7 @@ def test_get_status_no_secrets(mocker, con):
 
 def test_get_status_success(mocker, con_with_secrets):
     """
-    It should fail if no secrets are provided  
+    It should fail if no secrets are provided
     """
     fetch_mock: Mock = mocker.patch.object(
         GoogleSheets2Connector, '_run_fetch', return_value={'email': 'foo@bar.baz'}
@@ -239,6 +239,7 @@ def test_get_status_api_down(mocker, con_with_secrets):
     mocker.patch.object(GoogleSheets2Connector, '_run_fetch', side_effect=HttpError)
 
     assert con_with_secrets.get_status().status is False
+
 
 def test_get_decimal_separator(mocker, con_with_secrets, ds):
     """

--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -236,7 +236,7 @@ def test_get_status_api_down(mocker, con, fake_kwargs):
     assert con.get_status().status is False
 
 
-def test_get_decimal_separator(mocker, con_with_secrets, ds):
+def test_get_decimal_separator(mocker, con, ds):
     """
     It should returns number data in float type
     """

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -107,7 +107,7 @@ class GoogleSheets2Connector(ToucanConnector):
 
         # https://developers.google.com/sheets/api/samples/reading
         read_sheet_endpoint = f'{data_source.spreadsheet_id}/values/{data_source.sheet}?valueRenderOption=UNFORMATTED_VALUE'
-        full_url = f'{self.baseroute}{read_sheet_endpoint}'
+        full_url = f'{self._baseroute}{read_sheet_endpoint}'
         # Rajouter le param FORMATTED_VALUE pour le séparateur de décimal dans la Baseroute
 
         data = self._run_fetch(full_url, access_token)['values']

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -106,9 +106,9 @@ class GoogleSheets2Connector(ToucanConnector):
             data_source.sheet = available_sheets[0]
 
         # https://developers.google.com/sheets/api/samples/reading
-        read_sheet_endpoint = f'{data_source.spreadsheet_id}/values/{data_source.sheet}'
+        read_sheet_endpoint = f'{data_source.spreadsheet_id}/values/{data_source.sheet}?valueRenderOption=UNFORMATTED_VALUE'
         full_url = f'{self.baseroute}{read_sheet_endpoint}'
-
+        # Rajouter le param FORMATTED_VALUE pour le séparateur de décimal dans la Baseroute
         data = self._run_fetch(full_url, access_token)['values']
         df = pd.DataFrame(data)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

By default google sheets applies the decimal separator defined in the gsheet locale. 
We want values such as "," to be correctly interpreted so we added the parameter valueRenderOption=UNFORMATTED_VALUE' to the URL used to retrieve data in the connector

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
