### PR TITLE
added ci tests python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9.0-rc.2 - 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9.0-rc.2 - 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Change Summary
As requested during Backend retro, CI tests need to be performed with python 3.9 version.
[https://toucantoco.atlassian.net/wiki/spaces/TTA/pages/1943831153/R+trospective+team+tech+-+chapter+back+-+2020-10-06](url)


## Checklist

* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
