### PR TITLE
Add a get_connector_config_form method to connectors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.43.0',
+    version='0.43.1',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -91,7 +91,7 @@ def test_get_form_with_secrets(mocker, con, ds):
     """It should return a list of spreadsheet titles."""
     mocker.patch.object(GoogleSheets2Connector, '_run_fetch', return_value=FAKE_SHEET_LIST_RESPONSE)
 
-    result = ds.get_form(
+    result = ds.get_connector_config_form(
         connector=con,
         current_config={'spreadsheet_id': '1SMnhnmBm-Tup3SfhS03McCf6S4pS2xqjI6CAXSSBpHU'},
     )
@@ -102,7 +102,7 @@ def test_get_form_with_secrets(mocker, con, ds):
 def test_get_form_no_secrets(mocker, con, ds, remove_secrets):
     """It should return no spreadsheet titles."""
     mocker.patch.object(GoogleSheets2Connector, '_run_fetch', return_value=Exception)
-    result = ds.get_form(
+    result = ds.get_connector_config_form(
         connector=con,
         current_config={'spreadsheet_id': '1SMnhnmBm-Tup3SfhS03McCf6S4pS2xqjI6CAXSSBpHU'},
     )

--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -91,7 +91,7 @@ def test_get_form_with_secrets(mocker, con, ds):
     """It should return a list of spreadsheet titles."""
     mocker.patch.object(GoogleSheets2Connector, '_run_fetch', return_value=FAKE_SHEET_LIST_RESPONSE)
 
-    result = ds.get_connector_config_form(
+    result = ds.get_form(
         connector=con,
         current_config={'spreadsheet_id': '1SMnhnmBm-Tup3SfhS03McCf6S4pS2xqjI6CAXSSBpHU'},
     )
@@ -102,7 +102,7 @@ def test_get_form_with_secrets(mocker, con, ds):
 def test_get_form_no_secrets(mocker, con, ds, remove_secrets):
     """It should return no spreadsheet titles."""
     mocker.patch.object(GoogleSheets2Connector, '_run_fetch', return_value=Exception)
-    result = ds.get_connector_config_form(
+    result = ds.get_form(
         connector=con,
         current_config={'spreadsheet_id': '1SMnhnmBm-Tup3SfhS03McCf6S4pS2xqjI6CAXSSBpHU'},
     )

--- a/tests/oauth2_connector/test_oauth2connector.py
+++ b/tests/oauth2_connector/test_oauth2connector.py
@@ -5,13 +5,13 @@ from unittest.mock import Mock
 import pytest
 
 from toucan_connectors.google_sheets_2.google_sheets_2_connector import GoogleSheets2Connector
+from toucan_connectors.http_api.http_api_connector import HttpAPIConnector
 from toucan_connectors.oauth2_connector.oauth2connector import (
     AuthFlowNotFound,
     NoOAuth2RefreshToken,
     OAuth2Connector,
     OAuth2ConnectorConfig,
 )
-from toucan_connectors.postgres.postgresql_connector import PostgresConnector
 from toucan_connectors.toucan_connector import is_oauth2_connector
 
 FAKE_AUTHORIZATION_URL = 'http://localhost:4242/foobar'
@@ -131,4 +131,4 @@ def test_should_throw_if_authflow_id_not_found(oauth2_connector, secrets_keeper)
 
 def test_should_return_if_is_oauth2_connector(oauth2_connector):
     assert is_oauth2_connector(GoogleSheets2Connector) is True
-    assert is_oauth2_connector(PostgresConnector) is False
+    assert is_oauth2_connector(HttpAPIConnector) is False

--- a/tests/oauth2_connector/test_oauth2connector.py
+++ b/tests/oauth2_connector/test_oauth2connector.py
@@ -9,6 +9,7 @@ from toucan_connectors.oauth2_connector.oauth2connector import (
     AuthFlowNotFound,
     NoOAuth2RefreshToken,
     OAuth2Connector,
+    OAuth2ConnectorConfig,
 )
 from toucan_connectors.postgres.postgresql_connector import PostgresConnector
 from toucan_connectors.toucan_connector import is_oauth2_connector
@@ -24,9 +25,7 @@ def oauth2_connector(secrets_keeper):
         name='test',
         authorization_url=FAKE_AUTHORIZATION_URL,
         scope=SCOPE,
-        client_id='',
-        client_secret='',
-        redirect_uri='',
+        config=OAuth2ConnectorConfig(client_id='', client_secret='', redirect_uri=''),
         token_url=FAKE_TOKEN_URL,
         secrets_keeper=secrets_keeper,
     )

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -6,7 +6,15 @@ import tenacity as tny
 from pydantic import create_model
 
 from toucan_connectors.common import ConnectorStatus
-from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
+from toucan_connectors.google_sheets_2.google_sheets_2_connector import GoogleSheets2Connector
+from toucan_connectors.mongo.mongo_connector import MongoConnector
+from toucan_connectors.oauth2_connector.oauth2connector import OAuth2ConnectorConfig
+from toucan_connectors.toucan_connector import (
+    ToucanConnector,
+    ToucanDataSource,
+    get_connector_config_form,
+    strlist_to_enum,
+)
 
 
 class DataSource(ToucanDataSource):
@@ -231,3 +239,11 @@ def test_strlist_to_enum_default_value():
         },
         'properties': {'pokemon': {'$ref': '#/definitions/pokemon'}},
     }
+
+
+def test_should_return_connector_config_form():
+    assert (
+        get_connector_config_form(GoogleSheets2Connector).config_schema
+        == OAuth2ConnectorConfig.schema()
+    )
+    assert get_connector_config_form(MongoConnector) is None

--- a/toucan_connectors/aircall/aircall_connector.py
+++ b/toucan_connectors/aircall/aircall_connector.py
@@ -8,7 +8,10 @@ from aiohttp import ClientSession
 from pydantic import Field
 
 from toucan_connectors.common import ConnectorStatus, get_loop
-from toucan_connectors.oauth2_connector.oauth2connector import OAuth2Connector
+from toucan_connectors.oauth2_connector.oauth2connector import (
+    OAuth2Connector,
+    OAuth2ConnectorConfig,
+)
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 from .constants import MAX_RUNS, PER_PAGE
@@ -123,7 +126,12 @@ class AircallConnector(ToucanConnector):
             authorization_url=AUTHORIZATION_URL,
             scope=SCOPE,
             token_url=TOKEN_URL,
-            **{k: v for k, v in kwargs.items() if k in OAuth2Connector.init_params},
+            secrets_keeper=kwargs['secrets_keeper'],
+            config=OAuth2ConnectorConfig(
+                client_id=kwargs['client_id'],
+                client_secret=kwargs['client_secret'],
+                redirect_uri=kwargs['redirect_uri'],
+            ),
         )
 
     def build_authorization_url(self):

--- a/toucan_connectors/google_sheets_2/doc.md
+++ b/toucan_connectors/google_sheets_2/doc.md
@@ -1,0 +1,5 @@
+The connector configuration for Google OAuth.
+You will need to provide a client_id and a client_secret
+to get these, you will need to create a new app in
+the Google Dashboard: https://console.developers.google.com/apis/dashboard.
+Create a 'Web Application

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -10,7 +10,10 @@ from aiohttp import ClientSession
 from pydantic import Field, create_model
 
 from toucan_connectors.common import ConnectorStatus, HttpError, fetch, get_loop
-from toucan_connectors.oauth2_connector.oauth2connector import OAuth2Connector, OAuth2ConnectorConfig
+from toucan_connectors.oauth2_connector.oauth2connector import (
+    OAuth2Connector,
+    OAuth2ConnectorConfig,
+)
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 AUTHORIZATION_URL: str = (

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -3,7 +3,7 @@
 # This will replace the old Google Sheets connector that works with the Bearer API
 import asyncio
 from contextlib import suppress
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import pandas as pd
 from aiohttp import ClientSession

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -75,7 +75,7 @@ class GoogleSheets2Connector(ToucanConnector):
     _baseroute = 'https://sheets.googleapis.com/v4/spreadsheets/'
 
     @staticmethod
-    def get_form():
+    def get_connector_config_form():
         return GoogleSheets2Connector.ConnectorConfig.schema()
 
     class ConnectorConfig(OauthConnectorConfig):
@@ -86,6 +86,7 @@ class GoogleSheets2Connector(ToucanConnector):
         the Google Dashboard: https://console.developers.google.com/apis/dashboard.
         Create a 'Web Application
         """
+
         pass
 
     def __init__(self, **kwargs):

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -76,7 +76,17 @@ class GoogleSheets2Connector(ToucanConnector):
 
     @staticmethod
     def get_form():
-        return OauthConnectorConfig.schema()
+        return GoogleSheets2Connector.ConnectorConfig.schema()
+
+    class ConnectorConfig(OauthConnectorConfig):
+        """
+        The connector configuration for Google OAuth.
+        You will need to provide a client_id and a client_secret
+        to get these, you will need to create a new app in
+        the Google Dashboard: https://console.developers.google.com/apis/dashboard.
+        Create a 'Web Application
+        """
+        pass
 
     def __init__(self, **kwargs):
         super().__init__(

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -10,7 +10,7 @@ from aiohttp import ClientSession
 from pydantic import Field, create_model
 
 from toucan_connectors.common import ConnectorStatus, HttpError, fetch, get_loop
-from toucan_connectors.oauth2_connector.oauth2connector import OAuth2Connector, OauthConnectorConfig
+from toucan_connectors.oauth2_connector.oauth2connector import OAuth2Connector, OAuth2ConnectorConfig
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 AUTHORIZATION_URL: str = (
@@ -78,7 +78,7 @@ class GoogleSheets2Connector(ToucanConnector):
     def get_connector_config_form():
         return GoogleSheets2Connector.ConnectorConfig.schema()
 
-    class ConnectorConfig(OauthConnectorConfig):
+    class ConnectorConfig(OAuth2ConnectorConfig):
         """
         The connector configuration for Google OAuth.
         You will need to provide a client_id and a client_secret

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -10,7 +10,7 @@ from aiohttp import ClientSession
 from pydantic import Field, create_model
 
 from toucan_connectors.common import ConnectorStatus, HttpError, fetch, get_loop
-from toucan_connectors.oauth2_connector.oauth2connector import OAuth2Connector
+from toucan_connectors.oauth2_connector.oauth2connector import OAuth2Connector, OauthConnectorConfig
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 AUTHORIZATION_URL: str = (
@@ -62,9 +62,6 @@ class GoogleSheets2DataSource(ToucanDataSource):
         return create_model('FormSchema', **constraints, __base__=cls).schema()
 
 
-Secrets = Dict[str, Any]
-
-
 class GoogleSheets2Connector(ToucanConnector):
     """The Google Sheets connector."""
 
@@ -76,6 +73,10 @@ class GoogleSheets2Connector(ToucanConnector):
 
     # TODO: turn into a class property
     _baseroute = 'https://sheets.googleapis.com/v4/spreadsheets/'
+
+    @staticmethod
+    def get_form():
+        return OauthConnectorConfig.schema()
 
     def __init__(self, **kwargs):
         super().__init__(

--- a/toucan_connectors/oauth2_connector/oauth2connector.py
+++ b/toucan_connectors/oauth2_connector/oauth2connector.py
@@ -6,6 +6,7 @@ from urllib import parse as url_parse
 
 from authlib.common.security import generate_token
 from authlib.integrations.requests_client import OAuth2Session
+from pydantic import BaseModel
 
 
 class SecretsKeeper(ABC):
@@ -14,12 +15,16 @@ class SecretsKeeper(ABC):
         """
         Save secrets in a secrets repository
         """
-
     @abstractmethod
     def load(self, key: str) -> Any:
         """
         Load secrets from the secrets repository
         """
+
+
+class OauthConnectorConfig(BaseModel):
+    client_id: str
+    client_secret: str
 
 
 class OAuth2Connector:

--- a/toucan_connectors/oauth2_connector/oauth2connector.py
+++ b/toucan_connectors/oauth2_connector/oauth2connector.py
@@ -23,7 +23,7 @@ class SecretsKeeper(ABC):
         """
 
 
-class OauthConnectorConfig(BaseModel):
+class OAuth2ConnectorConfig(BaseModel):
     client_id: str
     client_secret: str
 

--- a/toucan_connectors/oauth2_connector/oauth2connector.py
+++ b/toucan_connectors/oauth2_connector/oauth2connector.py
@@ -15,6 +15,7 @@ class SecretsKeeper(ABC):
         """
         Save secrets in a secrets repository
         """
+
     @abstractmethod
     def load(self, key: str) -> Any:
         """

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -43,6 +43,10 @@ def is_oauth2_connector(cls):
     return hasattr(cls, '_auth_flow') and getattr(cls, '_auth_flow') == 'oauth2'
 
 
+def get_form(cls):
+    if hasattr(cls, 'get_form'):
+        return getattr(cls, 'get_form')()
+
 class ToucanDataSource(BaseModel):
     domain: str
     name: str

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -43,9 +43,9 @@ def is_oauth2_connector(cls):
     return hasattr(cls, '_auth_flow') and getattr(cls, '_auth_flow') == 'oauth2'
 
 
-def get_form(cls):
-    if hasattr(cls, 'get_form'):
-        return getattr(cls, 'get_form')()
+def get_connector_config_form(cls):
+    if hasattr(cls, 'get_connector_config_form'):
+        return getattr(cls, 'get_connector_config_form')()
 
 
 class ToucanDataSource(BaseModel):

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -47,6 +47,7 @@ def get_form(cls):
     if hasattr(cls, 'get_form'):
         return getattr(cls, 'get_form')()
 
+
 class ToucanDataSource(BaseModel):
     domain: str
     name: str


### PR DESCRIPTION
Some connnectors need to be configured when they are instanciated (eg. Postgres needs an hostname, etc.)
Some connectors need to be configured prior to instanciation, because such config is instance wide. eg GoogleSheets2 needs a client_secret, and a client_id. Without those, it is not possible to instanciate a connector.

This PR adds a method get_connector_config_form, optional, at the class level for ToucanConnectors subclasses. it also add a function get_connector_config_form(cls) that dispatches call to  the appropriate class.get_form.

I also separated the config part of the OAuth2Connector in a Pydantic model.