### PR TITLE
fix(Aircall): changed connector's name

### DIFF
--- a/toucan_connectors/__init__.py
+++ b/toucan_connectors/__init__.py
@@ -12,7 +12,7 @@ CONNECTORS_REGISTRY = {
         'label': 'Adobe Analytics',
         'logo': 'adobe_analytics/adobe-analytics.png',
     },
-    'AircallConnector': {
+    'Aircall': {
         'connector': 'aircall.aircall_connector.AircallConnector',
         'logo': 'aircall/Aircall.svg',
     },


### PR DESCRIPTION
#182  Change Summary

I renamed the connector in CONNECTORS_REGISTRY of __init__.py (was previously AircallConnector). Changed to Aircall.

## Checklist

* [ ] Tests pass on CI and coverage remains at 100%
