### PR TITLE
Fix(Aircall):Change Aircall Connector's name

### DIFF
--- a/toucan_connectors/__init__.py
+++ b/toucan_connectors/__init__.py
@@ -12,7 +12,7 @@ CONNECTORS_REGISTRY = {
         'label': 'Adobe Analytics',
         'logo': 'adobe_analytics/adobe-analytics.png',
     },
-    'AircallConnector': {
+    'Aircall': {
         'connector': 'aircall.aircall_connector.AircallConnector',
         'logo': 'aircall/Aircall.svg',
     },


### PR DESCRIPTION
## Change Summary

I changed Aircall Connector's name in CONNECTORS_REGISTRY of toucan_connectors __init__.py. 
Previously was: AircallConnector, now Aircall.

## Checklist

* [x] Tests pass on CI and coverage remains at 100%
