### PR TITLE
feat(http connector): Added xml support

### DIFF
--- a/doc/connectors/http_api.md
+++ b/doc/connectors/http_api.md
@@ -4,7 +4,10 @@ This is a generic connector to get data from any HTTP APIs (REST style APIs).
 
 This type of data source combines the features of Python’s [requests](http://docs.python-requests.org/)
 library to get data from any API with the filtering langage [jq](https://stedolan.github.io/jq/) for
-flexbile transformations of the responses.
+flexible transformations of the responses.
+The connector is able to retrieve data in json or xml format depending on the responsetype defined.
+If the format is set to 'xml', an xpath can be provided in the xpath field to parse the response and then
+the jq filter can be applied to get the data in tabular format.
 
 Please see our [complete tutorial](https://docs.toucantoco.com/concepteur/tutorials/18-jq.html) for
 an example of advanced use of this connector.
@@ -18,6 +21,7 @@ an example of advanced use of this connector.
     cf. [requests auth](http://docs.python-requests.org/en/master/) and
     [requests oauthlib](https://requests-oauthlib.readthedocs.io/en/latest/oauth2_workflow) doc.
 * `template`: dict. See below.
+* `responsetype`: str, default to 'json'
 
 ```coffee
 DATA_PROVIDERS: [
@@ -28,6 +32,7 @@ DATA_PROVIDERS: [
   template:
     <headers|json|params>:
         <header key>: '<header value>'
+  responsetype: '<responsetype>'
 ,
   ...
 ]
@@ -56,9 +61,10 @@ all data sources using this provider.
 * `headers`: dict
 * `params`: dict
 * `data`: str or dict
-* `filter`: str, [`jq` filter](https://stedolan.github.io/jq/manual/), default to `"."
+* `filter`: str, [`jq` filter](https://stedolan.github.io/jq/manual/), default to "."
 * `auth`: Auth
 * `parameters`: dict
+* `xpath`: str, [xpath](https://developer.mozilla.org/en-US/docs/Web/XPath), default to ""
 
 ```coffee
 DATA_SOURCES: [
@@ -72,6 +78,7 @@ DATA_SOURCES: [
   filter:    '<filter>'
   auth:    '<auth>'
   parameters:    '<parameters>'
+  xpath: '<xpath>'
 ,
   ...
 ]

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -16,3 +16,4 @@ python-slugify >= 1.2.5
 PyYAML >= 3.12
 responses >= 0.9.0
 psycopg2
+xmltodict

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require = {
     'google_sheets': bearer_deps,
     'google_spreadsheet': ['gspread>=3', 'oauth2client'],
     'hive': ['pyhive[hive]'],
-    'http_api': auth_deps,
+    'http_api': auth_deps + ['xmltodict'],
     'lightspeed': bearer_deps,
     'mongo': ['pymongo>=3.6.1'],
     'mssql': ['pyodbc'],

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -368,4 +368,6 @@ def test_parse_xml_response(xml_connector, xml_datasource):
             </response>""",
     )
     df = xml_connector.get_df(xml_datasource)
-    assert df.shape == (2, 7)
+    assert df['login'][0] == 'analytica@fakecompany.com'
+    assert df['timeZone'][0] == 'US/Pacific'
+    assert df['id'][1] == '123'

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -1,10 +1,35 @@
 import json
+from xml.etree.ElementTree import ParseError
 
 import pytest
 import responses
 
 from toucan_connectors.common import transform_with_jq
 from toucan_connectors.http_api.http_api_connector import Auth, HttpAPIConnector, HttpAPIDataSource
+
+
+@pytest.fixture
+def xml_connector():
+    data_provider = {
+        'name': 'APIreturningXML',
+        'type': 'HttpAPI',
+        'baseroute': 'http://example.com/api/v1',
+        'responsetype': 'xml',
+    }
+    return HttpAPIConnector(**data_provider)
+
+
+@pytest.fixture()
+def xml_datasource():
+    data_source = {
+        'domain': 'testxml',
+        'name': 'XMLAPI',
+        'url': 'foo/xml',
+        'method': 'GET',
+        'xpath': 'output',
+        'filter': '.output.users.user',
+    }
+    return HttpAPIDataSource(**data_source)
 
 
 @pytest.fixture(scope='function')
@@ -301,3 +326,46 @@ def test_no_top_level_domain():
     c.get_df(HttpAPIDataSource(**data_source))
 
     assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_parse_xml_error(xml_connector, xml_datasource):
+    """
+    Check that the http connector returns an error if the XML
+    is invalid
+    """
+    responses.add(
+        responses.GET,
+        'http://example.com/api/v1/foo/xml',
+        content_type='application/xml',
+        body="""<?xml version='1.0' encoding='UTF-8'?><response success='true'>
+        <output><usThis is a broken XML</output></response>""",
+    )
+
+    with pytest.raises(ParseError):
+        xml_connector.get_df(xml_datasource)
+
+
+@responses.activate
+def test_parse_xml_response(xml_connector, xml_datasource):
+    """
+    Check that the http connector is able to parse an XML response
+    """
+    responses.add(
+        responses.GET,
+        'http://example.com/api/v1/foo/xml',
+        content_type='application/xml',
+        body="""<?xml version='1.0' encoding='UTF-8'?>
+            <response success="true">
+            <output>
+                <users seqNo="55">
+                    <user id="19" guid="B9ADBCB81AA2F9BAE040307F02092C2E" login="analytica@fakecompany.com" email="analytica@fakecompany.com"
+                    name="Anna Analyzer" roleId="3" timeZone="US/Pacific"/>
+                    <user id="123" guid="AAFF5218D55ABB9234660001BEC117A9" login="randomuser@fakecompany.com" email="randomuser@fakecompany.com"
+                    name="J. Random User" roleId="2" timeZone="US/Pacific"/>
+                </users>
+            </output>
+            </response>""",
+    )
+    df = xml_connector.get_df(xml_datasource)
+    assert df.shape == (2, 7)

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -198,6 +198,13 @@ FilterSchema = Field(
     '<a href="https://stedolan.github.io/jq/manual/">documentation</a>',
 )
 
+XpathSchema = Field(
+    '',
+    description='You can define an XPath to parse the XML cdata retrieved.'
+    'For reference visit: '
+    '<a href="https://developer.mozilla.org/en-US/docs/Web/XPath">documentation</a>',
+)
+
 
 def get_loop():
     """Sets up event loop"""


### PR DESCRIPTION
This PR adds the support of XML in HttpAPI connector

## Change Summary

The HttpApi connector can be configured to parse XML responses using xmltodict package. 
* A ResponseType field was added to the connector's configuration, options are xml or json
* An XpathSchema was added to the Data Source, in order to receive the xpath string the user might want to use to parse the xml content of the response
* Once converted to a dict the xml response is parsed with the jq filter provided in the jq_filter field

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
