### PR TITLE
added kwargs in build_authorization_url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.43.2',
+    version='0.43.3',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/toucan_connectors/aircall/aircall_connector.py
+++ b/toucan_connectors/aircall/aircall_connector.py
@@ -134,8 +134,8 @@ class AircallConnector(ToucanConnector):
             ),
         )
 
-    def build_authorization_url(self):
-        return self.__dict__['_oauth2_connector'].build_authorization_url()
+    def build_authorization_url(self, **kwargs):
+        return self.__dict__['_oauth2_connector'].build_authorization_url(**kwargs)
 
     def retrieve_tokens(self, authorization_response: str):
         """


### PR DESCRIPTION
#182  Change Summary

Aircall Connector build_authorization_url() can now accept and transfer kwargs to oAuth2Connector.build_authorization_url

## Checklist

* [x] Tests pass on CI and coverage remains at 100%
