### PR TITLE
Fix/oauth2connector retrieve tokens for aircall needs the client_id and client_secret

### DIFF
--- a/tests/aircall/test_aircall.py
+++ b/tests/aircall/test_aircall.py
@@ -18,7 +18,10 @@ from toucan_connectors.aircall.aircall_connector import (
     NoCredentialsError,
 )
 from toucan_connectors.common import HttpError
-from toucan_connectors.oauth2_connector.oauth2connector import OAuth2Connector
+from toucan_connectors.oauth2_connector.oauth2connector import (
+    OAuth2Connector,
+    OAuth2ConnectorConfig,
+)
 
 import_path = 'toucan_connectors.aircall.aircall_connector'
 
@@ -348,19 +351,6 @@ def test_build_authorization_url(mocker, con):
     con.__dict__['_oauth2_connector'] = mock_oauth2_connector
     con.build_authorization_url()
     mock_oauth2_connector.build_authorization_url.assert_called()
-
-
-def test_specific_retrieve_token(mocker, con):
-    """Check that the AircallConnector way of retrieving access token works"""
-    mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
-    mock_oauth2_connector.client_id = 'test_client_id'
-    mock_oauth2_connector.client_secret = 'test_client_secret'
-    con.__dict__['_oauth2_connector'] = mock_oauth2_connector
-    con.__dict__['_oauth2_connector'].authorization_url = 'https://authorization.url'
-    con.retrieve_tokens('toto')
-    mock_oauth2_connector.retrieve_tokens.assert_called_with(
-        'toto', client_id='test_client_id', client_secret='test_client_secret'
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/aircall/test_aircall.py
+++ b/tests/aircall/test_aircall.py
@@ -18,10 +18,7 @@ from toucan_connectors.aircall.aircall_connector import (
     NoCredentialsError,
 )
 from toucan_connectors.common import HttpError
-from toucan_connectors.oauth2_connector.oauth2connector import (
-    OAuth2Connector,
-    OAuth2ConnectorConfig,
-)
+from toucan_connectors.oauth2_connector.oauth2connector import OAuth2Connector
 
 import_path = 'toucan_connectors.aircall.aircall_connector'
 

--- a/toucan_connectors/aircall/aircall_connector.py
+++ b/toucan_connectors/aircall/aircall_connector.py
@@ -143,11 +143,7 @@ class AircallConnector(ToucanConnector):
         must be sent in the body of the request so we have to set them in
         the mother class. This way they'll be added to her get_access_token method
         """
-        client_id = self.__dict__['_oauth2_connector'].client_id
-        client_secret = self.__dict__['_oauth2_connector'].client_secret
-        return self.__dict__['_oauth2_connector'].retrieve_tokens(
-            authorization_response, client_id=client_id, client_secret=client_secret
-        )
+        return self.__dict__['_oauth2_connector'].retrieve_tokens(authorization_response)
 
     def get_access_token(self):
         return self.__dict__['_oauth2_connector'].get_access_token()

--- a/toucan_connectors/oauth2_connector/oauth2connector.py
+++ b/toucan_connectors/oauth2_connector/oauth2connector.py
@@ -84,7 +84,7 @@ class OAuth2Connector:
             authorization_response=authorization_response,
             client_id=self.config.client_id,
             client_secret=self.config.client_secret.get_secret_value(),
-            **kwargs
+            **kwargs,
         )
         self.secrets_keeper.save(self.auth_flow_id, token)
 

--- a/toucan_connectors/oauth2_connector/oauth2connector.py
+++ b/toucan_connectors/oauth2_connector/oauth2connector.py
@@ -64,7 +64,7 @@ class OAuth2Connector:
         self.secrets_keeper.save(self.auth_flow_id, {'state': state})
         return uri
 
-    def retrieve_tokens(self, authorization_response: str):
+    def retrieve_tokens(self, authorization_response: str, **kwargs):
         url = url_parse.urlparse(authorization_response)
         url_params = url_parse.parse_qs(url.query)
         client = OAuth2Session(
@@ -79,7 +79,13 @@ class OAuth2Connector:
             json.loads(saved_flow['state'])['token'] == json.loads(url_params['state'][0])['token']
         )
 
-        token = client.fetch_token(self.token_url, authorization_response=authorization_response)
+        token = client.fetch_token(
+            self.token_url,
+            authorization_response=authorization_response,
+            client_id=self.config.client_id,
+            client_secret=self.config.client_secret.get_secret_value(),
+            **kwargs
+        )
         self.secrets_keeper.save(self.auth_flow_id, token)
 
     def get_access_token(self) -> str:


### PR DESCRIPTION

Aircall needs the client_id and client_secret sent in the body of fetch_tokens. With this fix, this is now the default behavior.
It is also possible to give arbitrary kwargs to OAuth2Connector:retrieve_tokens, they will be passed-through to the body of the request