### PR TITLE
bumps connectors version to 0.43.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.43.4',
+    version='0.43.5',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Bumps connector version to 0.43.5. 
Onboards the fix on Aircall connector see [related pr](https://github.com/ToucanToco/toucan-connectors/pull/236)
