### PR TITLE
bumps connectors version to 0.43.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.43.5',
+    version='0.43.6',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Bumps toucan connector version to 0.43.6 to add a fix on Aircall connector.
The fix allow to write the correct auth_flow_id in mongo while saving the params of the oAuth2 flow
