### PR TITLE
updated version of aiohttp in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 
 install_requires = [
     'authlib',
-    'aiohttp',
+    'aiohttp<3.7.0',
     'cached_property',
     'jinja2',
     'pydantic',


### PR DESCRIPTION
Tests on wootric are failling because of change in aiohttp version. 
I uploaded setup.py, it now requires an aiohttp version < 3.7.0 (the version introducing breaking changes)


## Checklist

* [x] Tests pass on CI and coverage remains at 100%
