### PR TITLE
Update connectors with new pydantic version

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -237,7 +237,9 @@ def test_strlist_to_enum_default_value():
                 'type': 'string',
             }
         },
-        'properties': {'pokemon': {'$ref': '#/definitions/pokemon'}},
+        'properties': {
+            'pokemon': {'allOf': [{'$ref': '#/definitions/pokemon'}], 'default': 'pika'}
+        },
     }
 
 

--- a/toucan_connectors/micro_strategy/micro_strategy_connector.py
+++ b/toucan_connectors/micro_strategy/micro_strategy_connector.py
@@ -81,7 +81,9 @@ class MicroStrategyConnector(ToucanConnector):
     )
 
     def _retrieve_metadata(self, data_source: MicroStrategyDataSource) -> pd.DataFrame:
-        client = Client(self.base_url, self.project_id, self.username, self.password)
+        client = Client(
+            self.base_url, self.project_id, self.username, self.password.get_secret_value()
+        )
 
         results = client.list_objects(
             [st.value for st in Subtypes], data_source.id, data_source.offset, data_source.limit
@@ -96,7 +98,9 @@ class MicroStrategyConnector(ToucanConnector):
         if data_source.dataset == Dataset.search:
             return self._retrieve_metadata(data_source)
 
-        client = Client(self.base_url, self.project_id, self.username, self.password)
+        client = Client(
+            self.base_url, self.project_id, self.username, self.password.get_secret_value()
+        )
 
         query_func = getattr(client, data_source.dataset)
         if not data_source.viewfilter:


### PR DESCRIPTION
updated test and microstrategy connector to reflect changes from pydantic

## Change Summary

Connectors tests were failling because of new pydantic version. 
I updated: 
- test/test_connector.py
- micro_strategy/micro_strategy_connector.py 
to reflect theses changes

## Checklist

* [x] Tests pass on CI and coverage remains at 100%
