### PR TITLE
docs: added help message to oauth connectors config

### DIFF
--- a/toucan_connectors/aircall/aircall_connector.py
+++ b/toucan_connectors/aircall/aircall_connector.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
+import os
 from enum import Enum
+from pathlib import Path
 from typing import List, Optional, Tuple
 
 import pandas as pd
@@ -12,7 +14,11 @@ from toucan_connectors.oauth2_connector.oauth2connector import (
     OAuth2Connector,
     OAuth2ConnectorConfig,
 )
-from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
+from toucan_connectors.toucan_connector import (
+    ConnectorSecretsForm,
+    ToucanConnector,
+    ToucanDataSource,
+)
 
 from .constants import MAX_RUNS, PER_PAGE
 from .helpers import DICTIONARY_OF_FORMATTERS, build_df, build_empty_df
@@ -116,6 +122,13 @@ class AircallConnector(ToucanConnector):
     _auth_flow = 'oauth2'
     auth_flow_id: Optional[str]
     data_source_model: AircallDataSource
+
+    @staticmethod
+    def get_connector_secrets_form() -> ConnectorSecretsForm:
+        return ConnectorSecretsForm(
+            documentation_md=(Path(os.path.dirname(__file__)) / 'doc.md').read_text(),
+            secrets_schema=OAuth2ConnectorConfig.schema(),
+        )
 
     def __init__(self, **kwargs):
         super().__init__(

--- a/toucan_connectors/aircall/doc.md
+++ b/toucan_connectors/aircall/doc.md
@@ -1,0 +1,11 @@
+<div class="connector_config_modal__documentation"> 
+<p>
+Please contact your Aircall support to get a client_id/secret_id.<br> Aircall will ask you a redirect URI. 
+You can provide the following URL:
+<br>https://api-{{ back.instance_name }}.toucantoco.com/oauth/redirect?type=Aircall 
+</p>
+<p>
+For more information, please visit: <a href="https://developer.aircall.io/api-references/#oauth-credentials">Aircall Documentation</a>
+</p>
+</div>
+

--- a/toucan_connectors/google_sheets_2/doc.md
+++ b/toucan_connectors/google_sheets_2/doc.md
@@ -1,5 +1,9 @@
-The connector configuration for Google OAuth.
-You will need to provide a client_id and a client_secret
-to get these, you will need to create a new app in
-the Google Dashboard: https://console.developers.google.com/apis/dashboard.
-Create a 'Web Application
+<div class="connector_config_modal__documentation"> 
+<p> You should create a new Web Application with OAuth credentials in your Google APIs console.
+<br><br> For a detailed tutorial on how to do that, please refer to our dedicated 
+<a href="https://docs.toucantoco.com/concepteur/tutorials/power-apps-with-data/4-google-sheets-oauth.html">documentation</a>.
+<br><br>
+ In authorized redirect URIs, you should specify:<br>
+ https://api-{{ back.instance_name }}.toucantoco.com/oauth/redirect?type=GoogleSheets2
+</p> </div>
+


### PR DESCRIPTION
## Change Summary
A small doc is needed to configure oAuth connectors (Gsheets & Aircall at the moment) in the secrets config window. 
The two docs were written in their respective connectors directory. 

## Checklist

* [x] Tests pass on CI and coverage remains at 100%
