### PR TITLE
fix:MicroStrategy connector accepts empty password

### DIFF
--- a/toucan_connectors/micro_strategy/micro_strategy_connector.py
+++ b/toucan_connectors/micro_strategy/micro_strategy_connector.py
@@ -71,7 +71,7 @@ class MicroStrategyConnector(ToucanConnector):
         examples=['https://demo.microstrategy.com/MicroStrategyLibrary2/api/'],
     )
     username: str = Field(..., description='Your login username')
-    password: SecretStr = Field(None, description='Your login password')
+    password: SecretStr = Field('', description='Your login password')
     project_id: str = Field(
         ...,
         title='projectID',


### PR DESCRIPTION
## Change Summary

An error was raised during MicroStrategy instanciation because of pydantic receiving None default value in the password field. 
Default value was changed to ''. 

## Checklist

* [x] Tests pass on CI and coverage remains at 100%
