### PR TITLE
refactor:updated gsheet connectors names

### DIFF
--- a/toucan_connectors/__init__.py
+++ b/toucan_connectors/__init__.py
@@ -77,12 +77,12 @@ CONNECTORS_REGISTRY = {
     },
     'GoogleSheets': {
         'connector': 'google_sheets.google_sheets_connector.GoogleSheetsConnector',
-        'label': 'Google Sheets',
+        'label': 'Google Sheets (Legacy)',
         'logo': 'google_sheets/google-sheets.png',
     },
     'GoogleSheets2': {
         'connector': 'google_sheets_2.google_sheets_2_connector.GoogleSheets2Connector',
-        'label': 'Google Sheets Modified',
+        'label': 'Google Sheets',
         'logo': 'google_sheets/google-sheets.png',
     },
     'GoogleSpreadsheet': {


### PR DESCRIPTION
## Change Summary

Google Sheets Connectors listing in "add connectors" view was cleaned up. 
The new google sheets connector using oAuth was renamed to Google Sheets to reflect this change.

## Checklist

* [x] Tests pass on CI and coverage remains at 100%
