### PR TITLE
chore:bump connectors version to 43.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.43.14',
+    version='0.43.15',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Change Summary

Onboards the changes in Google Sheets labels 

## Checklist

* [x] Tests pass on CI and coverage remains at 100%
