### PR TITLE
fix: increased retry limits and decreased sleeping time

### DIFF
--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -195,7 +195,13 @@ def test_error_get_pages(mocker, gc, error_response, client, event_loop):
     """
     mocker.patch(
         'python_graphql_client.GraphqlClient.execute_async',
-        side_effect=[error_response, error_response, error_response],
+        side_effect=[
+            error_response,
+            error_response,
+            error_response,
+            error_response,
+            error_response,
+        ],
     )
     mocker.patch('toucan_connectors.github.github_connector.asyncio.sleep', return_value=None)
 

--- a/toucan_connectors/github/github_connector.py
+++ b/toucan_connectors/github/github_connector.py
@@ -153,10 +153,10 @@ class GithubConnector(ToucanConnector):
         dataset: str,
         variables=None,
         data_list=None,
-        page_limit=30,
+        page_limit=50,
         retrieved_pages=0,
         retries=0,
-        retry_limit=2,
+        retry_limit=4,
     ) -> List[dict]:
         """
         Extracts pages of either members or pull requests
@@ -206,8 +206,8 @@ class GithubConnector(ToucanConnector):
                 )
 
         except GithubError:
-            logging.getLogger(__name__).info('Retrying in 30 seconds')
-            await asyncio.sleep(30)
+            logging.getLogger(__name__).info('Retrying in 1 second')
+            await asyncio.sleep(1)
             retries += 1
             if retries <= retry_limit:
                 await self.get_pages(


### PR DESCRIPTION
## Change Summary

Changed retry limits (4 retries) and waiting time (1 second) as well as the max pages number to retrieve.
