### PR TITLE
chore(version):Bump connector version to 0.44.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.44.0',
+    version='0.44.1',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Bump connectors version 0.44.1 for Organization dropdown in Github Connector
