### PR TITLE
feat(Github Connector): added page_limit in data source's form

### DIFF
--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -207,7 +207,13 @@ def test_error_get_pages(mocker, gc, error_response, client, event_loop):
 
     with pytest.raises(GithubError):
         event_loop.run_until_complete(
-            gc.get_pages(name='foo', organization='foorganization', dataset='teams', client=client)
+            gc.get_pages(
+                name='foo',
+                organization='foorganization',
+                dataset='teams',
+                client=client,
+                page_limit=4,
+            )
         )
 
 
@@ -220,7 +226,9 @@ def test_corrupt_get_pages(mocker, gc, client, event_loop, extracted_team_page_1
         side_effect=[extracted_team_page_1, {'corrupt': 'data'}],
     )
     result = event_loop.run_until_complete(
-        gc.get_pages(name='foo', organization='foorganization', dataset='teams', client=client)
+        gc.get_pages(
+            name='foo', organization='foorganization', dataset='teams', client=client, page_limit=2
+        )
     )
     assert result == [{'bar': 'foo', 'foo': 'foo', 'ofo': 'foo'}]
 
@@ -256,7 +264,9 @@ def test_fetch_members_data(
         ],
     )
     members_dataset = event_loop.run_until_complete(
-        gc._fetch_data(dataset=ds.dataset, organization=ds.organization, client=client)
+        gc._fetch_data(
+            dataset=ds.dataset, organization=ds.organization, client=client, page_limit=10
+        )
     )
     assert mocked_api_call.call_count == 2
     assert mocked_api_call_async.call_count == 7
@@ -285,7 +295,9 @@ def test_fetch_pull_requests_data(
         side_effect=[extracted_prs_1, extracted_prs_2, extracted_prs_3],
     )
     pr_dataset = event_loop.run_until_complete(
-        gc._fetch_data(dataset=ds.dataset, organization=ds.organization, client=client)
+        gc._fetch_data(
+            dataset=ds.dataset, organization=ds.organization, page_limit=10, client=client
+        )
     )
     assert mocked_api_call.call_count == 1
     assert mocked_api_call_async.call_count == 3
@@ -312,7 +324,11 @@ def test_get_pages(
     )
     pr_rows = event_loop.run_until_complete(
         gc.get_pages(
-            name='repo1', organization='foorganization', dataset='pull requests', client=client
+            name='repo1',
+            organization='foorganization',
+            dataset='pull requests',
+            client=client,
+            page_limit=2,
         )
     )
     assert mocked_api_call.call_count == 2
@@ -324,7 +340,9 @@ def test_get_pages(
         side_effect=[extracted_team_page_1, extracted_team_page_2],
     )
     members_rows = event_loop.run_until_complete(
-        gc.get_pages(name='foo', organization='foorganization', dataset='teams', client=client)
+        gc.get_pages(
+            name='foo', organization='foorganization', dataset='teams', client=client, page_limit=2
+        )
     )
     assert mocked_api_call.call_count == 2
     assert len(members_rows) == 2


### PR DESCRIPTION
## Change Summary
Page Limit (number of additional pages to retrieve when querying the API) in Github's connector was hardcoded.
To provide more flexibility, it's now added to the Data source's configuration and configurable in the Data Source's form.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
