### PR TITLE
feat: implementation of get_slice for Aircall, Github, Googesheets

### DIFF
--- a/tests/aircall/test_aircall.py
+++ b/tests/aircall/test_aircall.py
@@ -89,6 +89,42 @@ def test__run_fetch(mocker, con):
 
 
 @pytest.mark.asyncio
+async def test_get_slice(con, mocker):
+    """Check that get_slice returns only one page of data"""
+    run_fetches_mock = mocker.patch.object(
+        AircallConnector, 'run_fetches', return_value=[filtered_teams, filtered_calls]
+    )
+    ds = build_ds('calls')
+
+    df, rows = con.get_slice(ds)
+    assert run_fetches_mock.call_count == 1
+    assert df.shape == (10, 10)
+    assert list(df.columns) == columns_for_calls
+    assert df['team'].isna().sum() == 0
+    assert df['team'].eq('Team 1').sum() == 6
+    assert df['team'].eq('Team 2').sum() == 4
+
+
+@pytest.mark.asyncio
+async def test_get_slice_limit(con, mocker):
+    """
+    Check that get_slice returns only one page of data
+    with 2 rows
+    """
+    run_fetches_mock = mocker.patch.object(
+        AircallConnector, 'run_fetches', return_value=[filtered_teams, filtered_calls]
+    )
+    ds = build_ds('calls')
+    df, rows = con.get_slice(ds, limit=2)
+    assert run_fetches_mock.call_count == 1
+    assert df.shape == (2, 10)
+    assert list(df.columns) == columns_for_calls
+    assert df['team'].isna().sum() == 0
+    assert df['team'].eq('Team 1').sum() == 2
+    assert df['team'].eq('Team 2').sum() == 0
+
+
+@pytest.mark.asyncio
 async def test__get_data_tags_case(con, mocker):
     """Tests with tags happy case"""
     dataset = 'tags'

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -469,3 +469,17 @@ def test_get_slice_limit(
     assert mocked_api_call.call_count == 1
     assert mocked_api_call_async.call_count == 3
     assert len(df) == 2
+
+
+@responses.activate
+def test_get_organizations(gc):
+    """Check that get_organizations is able to retrieve a list of organization"""
+    responses.add(
+        responses.GET,
+        'https://api.github.com/user/orgs',
+        json=[{'login': 'power_rangers'}, {'login': 'teletubbies'}],
+        status=200,
+    )
+    res = gc.get_organizations()
+    assert len(responses.calls) == 1
+    assert res == ['power_rangers', 'teletubbies']

--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -251,3 +251,21 @@ def test_delegate_oauth2_methods(mocker, con):
     mock_oauth2_connector.build_authorization_url.assert_called()
     con.retrieve_tokens('toto')
     mock_oauth2_connector.retrieve_tokens.assert_called_with('toto')
+
+
+def test_get_slice(mocker, con, ds):
+    """It should return a slice of spreadsheet"""
+    mocker.patch.object(GoogleSheets2Connector, '_run_fetch', return_value=FAKE_SHEET)
+
+    df, rows = con.get_slice(ds, limit=1)
+
+    assert df.shape == (1, 2)
+
+
+def test_get_slice_no_limit(mocker, con, ds):
+    """It should return a slice of spreadsheet"""
+    mocker.patch.object(GoogleSheets2Connector, '_run_fetch', return_value=FAKE_SHEET)
+
+    df, rows = con.get_slice(ds, limit=None)
+
+    assert df.shape == (2, 2)

--- a/toucan_connectors/aircall/aircall_connector.py
+++ b/toucan_connectors/aircall/aircall_connector.py
@@ -16,6 +16,7 @@ from toucan_connectors.oauth2_connector.oauth2connector import (
 )
 from toucan_connectors.toucan_connector import (
     ConnectorSecretsForm,
+    DataSlice,
     ToucanConnector,
     ToucanDataSource,
 )
@@ -282,6 +283,33 @@ class AircallConnector(ToucanConnector):
             return ConnectorStatus(status=False, error='Credentials are missing')
         if not access_token:
             return ConnectorStatus(status=False, error='Credentials are missing')
+
+    def get_slice(
+        self,
+        data_source: AircallDataSource,
+        permissions: Optional[dict] = None,
+        offset: int = 0,
+        limit: Optional[int] = None,
+    ) -> DataSlice:
+        """
+        Method to retrieve a part of the data as a pandas dataframe
+        and the total size filtered with permissions
+
+        - offset is the index of the starting row
+        - limit is the number of pages to retrieve
+        Exemple: if offset = 5 and limit = 10 then 10 results are expected from 6th row
+        """
+        preview_datasource = AircallDataSource(
+            limit=1,
+            dataset=data_source.dataset,
+            domain=f'preview_{data_source.domain}',
+            name=data_source.name,
+        )
+        df = self.get_df(preview_datasource, permissions)
+        if limit is not None:
+            return DataSlice(df[offset : offset + limit], len(df))
+        else:
+            return DataSlice(df[offset:], len(df))
 
 
 class AircallException(Exception):

--- a/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
+++ b/toucan_connectors/google_sheets_2/google_sheets_2_connector.py
@@ -18,6 +18,7 @@ from toucan_connectors.oauth2_connector.oauth2connector import (
 )
 from toucan_connectors.toucan_connector import (
     ConnectorSecretsForm,
+    DataSlice,
     ToucanConnector,
     ToucanDataSource,
     strlist_to_enum,
@@ -189,3 +190,24 @@ class GoogleSheets2Connector(ToucanConnector):
             return ConnectorStatus(status=True, message=f"Connected as {user_info.get('email')}")
         except HttpError:
             return ConnectorStatus(status=False, error="Couldn't retrieve user infos")
+
+    def get_slice(
+        self,
+        data_source: GoogleSheets2DataSource,
+        permissions: Optional[dict] = None,
+        offset: int = 0,
+        limit=50,
+    ) -> DataSlice:
+        """
+        Method to retrieve a part of the data as a pandas dataframe
+        and the total size filtered with permissions
+
+        - offset is the index of the starting row
+        - limit is the number of pages to retrieve
+        Exemple: if offset = 5 and limit = 10 then 10 results are expected from 6th row
+        """
+        df = self.get_df(data_source, permissions)
+        if limit is not None:
+            return DataSlice(df[offset : offset + limit], len(df))
+        else:
+            return DataSlice(df[offset:], len(df))


### PR DESCRIPTION
## Change Summary

During preview of a datasource, get_slice method is called to return only a slice of the data. 
For Aircall, Google sheets & Github datasources, it now limits query & return a slice of the data.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
