### PR TITLE
fix(Gsheets_2): get_slice now query only rows_limit rows during preview

### DIFF
--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -255,11 +255,13 @@ def test_delegate_oauth2_methods(mocker, con):
 
 def test_get_slice(mocker, con, ds):
     """It should return a slice of spreadsheet"""
-    mocker.patch.object(GoogleSheets2Connector, '_run_fetch', return_value=FAKE_SHEET)
+    run_fetch_mock = mocker.patch.object(
+        GoogleSheets2Connector, '_run_fetch', return_value=FAKE_SHEET
+    )
 
-    df, rows = con.get_slice(ds, limit=1)
-
-    assert df.shape == (1, 2)
+    df, rows = con.get_slice(ds, limit=2)
+    assert '!1:2' in run_fetch_mock.call_args_list[0][0][0]
+    assert df.shape == (2, 2)
 
 
 def test_get_slice_no_limit(mocker, con, ds):


### PR DESCRIPTION
## Change Summary

During preview, of gsheets_2 data source the query was made on the whole dataset and then only a subset was dispalyed.
I changed this behaviour by querying only 50 rows max in get_slice method.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
