### PR TITLE
chore(versions): bump connectors v0.44.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.44.5',
+    version='0.44.6',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Bumps connectors to 0.44.6 to onboard a fix on gsheets2 connector
