### PR TITLE
chore(versions): bump connectors v0.44.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.44.6',
+    version='0.44.7',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Bumps connectors version to 0.44.7 to onboard small fixes on Gitihub Connector