### PR TITLE
fix(MicroStrategy Connector): Set default password if not set

### DIFF
--- a/toucan_connectors/micro_strategy/micro_strategy_connector.py
+++ b/toucan_connectors/micro_strategy/micro_strategy_connector.py
@@ -97,7 +97,8 @@ class MicroStrategyConnector(ToucanConnector):
         """Retrieves cube or report data, flattens return dataframe"""
         if data_source.dataset == Dataset.search:
             return self._retrieve_metadata(data_source)
-
+        if not self.password:
+            self.password = SecretStr('')
         client = Client(
             self.base_url, self.project_id, self.username, self.password.get_secret_value()
         )


### PR DESCRIPTION
## Related issue number

https://trello.com/c/YE2ro8O6/4491-as-a-conceptor-when-creating-a-new-ms-connector-with-the-demo-without-pswd-i-want-the-pswd-to-be-in-the-etl

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
