### PR TITLE
fix: convert_to_qmark_paramstyle now handles list parameter

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -260,6 +260,12 @@ def test_connector_status():
             'select * from test where id > ? and price > ?;',
             [1, None],
         ),
+        (
+            'select * from inventory where quantity in %(quantities)s;',
+            {'quantities': [150, 154]},
+            'select * from inventory where quantity in (?,?);',
+            [150, 154],
+        ),
     ],
 )
 def test_convert_pyformat_to_qmark(query, params, expected_query, expected_ordered_values):

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -255,4 +255,22 @@ def convert_to_qmark_paramstyle(query_string: str, params_values: dict) -> str:
     extracted_params = re.findall(RE_NAMED_PARAM, query_string)
     qparams = [m[2:-2] for m in extracted_params]
     ordered_values = [params_values.get(p) for p in qparams]
-    return re.sub(RE_NAMED_PARAM, '?', query_string), ordered_values
+
+    # Check if we need to replace a list
+    for i, o in enumerate(ordered_values):
+        if type(o) is list:
+            # in the query string, replace the ? at index i by the number of item
+            # in the provided parameter of type list
+            query_string = query_string.replace(
+                extracted_params[i], f'({",".join(len(ordered_values[i])*["?"])})'
+            )
+
+    flattened_values = []
+    for val in ordered_values:
+        if type(val) is list:
+            for v in val:
+                flattened_values.append(v)
+        else:
+            flattened_values.append(val)
+
+    return re.sub(RE_NAMED_PARAM, '?', query_string), flattened_values

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -258,7 +258,7 @@ def convert_to_qmark_paramstyle(query_string: str, params_values: dict) -> str:
 
     # Check if we need to replace a list
     for i, o in enumerate(ordered_values):
-        if type(o) is list:
+        if isinstance(o, list):
             # in the query string, replace the ? at index i by the number of item
             # in the provided parameter of type list
             query_string = query_string.replace(
@@ -267,7 +267,7 @@ def convert_to_qmark_paramstyle(query_string: str, params_values: dict) -> str:
 
     flattened_values = []
     for val in ordered_values:
-        if type(val) is list:
+        if isinstance(val, list):
             for v in val:
                 flattened_values.append(v)
         else:

--- a/toucan_connectors/odbc/odbc_connector.py
+++ b/toucan_connectors/odbc/odbc_connector.py
@@ -35,8 +35,6 @@ class OdbcConnector(ToucanConnector):
     def _retrieve_data(self, datasource: OdbcDataSource) -> pd.DataFrame:
 
         connection = pyodbc.connect(self.connection_string, **self.get_connection_params())
-        query_params = datasource.parameters or {}
-        query_params = {k: f'{v}' for k, v in query_params.items()}  # add enclosing quotes
         converted_query, ordered_values = convert_to_qmark_paramstyle(
             datasource.query, datasource.parameters
         )


### PR DESCRIPTION
## Change Summary

Fixed convert_to_qmark_paramstyle function to handle parameters provided as list (e.g; 'quantities':[150, 154])

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%