### PR TITLE
fix(mongo): apply match regex at the end of the pipeline

### DIFF
--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -310,6 +310,19 @@ def test_get_df_with_regex(mongo_connector, mongo_datasource):
     pd.testing.assert_series_equal(df['country'], pd.Series(['France', 'Germany'], name='country'))
 
 
+def test_get_df_with_regex_with_projection_stage(mongo_connector, mongo_datasource):
+    datasource = mongo_datasource(
+        collection='test_col',
+        query=[{'$match': {'domain': 'domain1'}}, {'$addFields': {'new_country_col': '$country'}}],
+    )
+    df = mongo_connector.get_df_with_regex(
+        datasource, field='new_country_col', regex=re.compile('r.*a')
+    )
+    pd.testing.assert_series_equal(
+        df['new_country_col'], pd.Series(['France', 'Germany'], name='new_country_col')
+    )
+
+
 def test_get_df_with_regex_with_limit(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
     df = mongo_connector.get_df_with_regex(


### PR DESCRIPTION
## Change Summary
Adding the match regex to the existing `$match` of the query does not work if the `$match` comes before other stages that affect the field we are filtering on. 

*Example*
We rename the column of the queried field of our dataset. Applying the match with the new field name before renaming the column would result in an empty dataframe, since it will try to find the new field name in the old dataset (before renaming the column) . 
 
We now append the match regex at the end of the query pipeline, that way we are sure any dependent pipeline step will be executed "before" the match regex. 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
