### PR TITLE
fix: Salesforce connector is now in init file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.45.0',
+    version='0.45.1',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/toucan_connectors/__init__.py
+++ b/toucan_connectors/__init__.py
@@ -156,6 +156,11 @@ CONNECTORS_REGISTRY = {
         'connector': 'rok.rok_connector.RokConnector',
         'logo': 'rok/rok.png',
     },
+    'Salesforce': {
+        'connector': 'salesforce.salesforce_connector.SalesforceConnector',
+        'label': 'Salesforce',
+        'logo': 'salesforce/salesforce.png',
+    },
     'SapHana': {
         'connector': 'sap_hana.sap_hana_connector.SapHanaConnector',
         'label': 'SAP HANA',


### PR DESCRIPTION
Just forgot to add the Salesforce connector in __init__.py

## Checklist

* [x] Tests pass on CI and coverage remains at 100%
