### PR TITLE
feat: enable array parameter interpolation in mssql & postgres

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.45.2',
+    version='0.45.3',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/tests/mssql/test_mssql.py
+++ b/tests/mssql/test_mssql.py
@@ -159,3 +159,16 @@ def test_query_variability(mocker):
         con=mock_pyodbc_connect(),
         params=[1, 10],
     )
+    mock_pandas_read_sql = mocker.patch('pandas.read_sql')
+    ds = MSSQLDataSource(
+        query='select * from test where id_nb in %(ids)s;',
+        domain='test',
+        name='test',
+        parameters={'ids': [1, 2]},
+    )
+    con.get_df(ds)
+    mock_pandas_read_sql.assert_called_once_with(
+        'select * from test where id_nb in (?,?);',
+        con=mock_pyodbc_connect(),
+        params=[1, 2],
+    )

--- a/tests/postgres/test_postgres.py
+++ b/tests/postgres/test_postgres.py
@@ -110,3 +110,18 @@ def test_get_df_db(postgres_connector):
     assert not df.empty
     assert set(df.columns) == expected_columns
     assert df.shape == (24, 5)
+
+
+def test_get_df_array_interpolation(postgres_connector):
+    data_source_spec = {
+        'domain': 'Postgres test',
+        'type': 'external_database',
+        'name': 'Some Postgres provider',
+        'database': 'postgres_db',
+        'query': 'SELECT * FROM City WHERE id in %(ids)s',
+        'parameters': {'ids': [1, 2]},
+    }
+    data_source = PostgresDataSource(**data_source_spec)
+    df = postgres_connector.get_df(data_source)
+    assert not df.empty
+    assert df.shape == (2, 5)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,6 +4,7 @@ from aiohttp import web
 from toucan_connectors.common import (
     ConnectorStatus,
     NonValidVariable,
+    adapt_param_type,
     apply_query_parameters,
     convert_to_qmark_paramstyle,
     fetch,
@@ -273,3 +274,7 @@ def test_convert_pyformat_to_qmark(query, params, expected_query, expected_order
     converted_query, ordered_values = convert_to_qmark_paramstyle(query, params)
     assert ordered_values == expected_ordered_values
     assert converted_query == expected_query
+
+
+def test_adapt_param_type():
+    assert adapt_param_type({'test': [1, 2], 'id': 1}) == {'test': (1, 2), 'id': 1}

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -274,3 +274,11 @@ def convert_to_qmark_paramstyle(query_string: str, params_values: dict) -> str:
             flattened_values.append(val)
 
     return re.sub(RE_NAMED_PARAM, '?', query_string), flattened_values
+
+
+def adapt_param_type(params):
+    """Adapts provided params when a conversion is needed. For example, when
+    passing a list parameter it should be converted to tuple in order for
+    postgres to correctly interpret them as an array.
+    """
+    return {k: (tuple(v) if isinstance(v, list) else v) for (k, v) in params.items()}

--- a/toucan_connectors/mssql/mssql_connector.py
+++ b/toucan_connectors/mssql/mssql_connector.py
@@ -64,9 +64,8 @@ class MSSQLConnector(ToucanConnector):
         connection = pyodbc.connect(**self.get_connection_params(datasource.database))
 
         query_params = datasource.parameters or {}
-        query_params = {k: f'{v}' for k, v in query_params.items()}  # add enclosing quotes
         converted_query, ordered_values = convert_to_qmark_paramstyle(
-            datasource.query, datasource.parameters
+            datasource.query, query_params
         )
         df = pd.read_sql(converted_query, con=connection, params=ordered_values)
 

--- a/toucan_connectors/postgres/postgresql_connector.py
+++ b/toucan_connectors/postgres/postgresql_connector.py
@@ -2,6 +2,7 @@ import pandas as pd
 import psycopg2 as pgsql
 from pydantic import Field, SecretStr, constr
 
+from toucan_connectors.common import adapt_param_type
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 
@@ -57,7 +58,7 @@ class PostgresConnector(ToucanConnector):
         connection = pgsql.connect(**self.get_connection_params(database=data_source.database))
 
         query_params = data_source.parameters or {}
-        df = pd.read_sql(data_source.query, con=connection, params=query_params)
+        df = pd.read_sql(data_source.query, con=connection, params=adapt_param_type(query_params))
 
         connection.close()
 


### PR DESCRIPTION
## Change Summary

In the same vein as https://github.com/ToucanToco/toucan-connectors/pull/297, array interpolation was not working for mssql & postgresql. 
I've updated these connectors to allow the interpolation

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
