### PR TITLE
snowflake: Add a default warehouse field

### DIFF
--- a/doc/connectors/snowflake.md
+++ b/doc/connectors/snowflake.md
@@ -8,6 +8,7 @@ Import data from Snowflake data warehouse.
 * `name`: str, required
 * `user`: str, required
 * `password`: str, required
+* `default_warehouse`: str, name of the default warehouse to be used in a data source if no warehouse was specified in the concerned data source
 * `account`: str, required
 * `ocsp_response_cache_filename`: str, path to the location used to store [ocsp cache] (https://docs.snowflake.net/manuals/user-guide/python-connector-example.html#caching-ocsp-responses)
 

--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -3,7 +3,11 @@ import pytest
 from toucan_connectors.snowflake import SnowflakeConnector, SnowflakeDataSource
 
 sc = SnowflakeConnector(
-    name='test_name', user='test_user', password='test_password', account='test_account'
+    name='test_name',
+    user='test_user',
+    password='test_password',
+    account='test_account',
+    default_warehouse='default_wh',
 )
 
 sd = SnowflakeDataSource(
@@ -38,6 +42,43 @@ def test_snowflake(mocker):
     reasq.assert_called_once_with('test_query with bar and pikachu', con=snock())
 
 
+def test_snowflake_data_source_get_form(mocker):
+    ds = SnowflakeDataSource(
+        name='test',
+        domain='blah',
+        database='bleh',
+        query='foo',
+        warehouse='',
+    )
+
+    sf_form = ds.get_form(sc, {})
+
+    assert 'default_wh' == sf_form['properties']['warehouse']['default']
+
+
+def test_snowflake_data_source_default_warehouse(mocker):
+    snow_mock = mocker.patch('snowflake.connector.connect')
+    # Avoid to call read_sql for nothing but no tests required here
+    mocker.patch('pandas.read_sql')
+
+    ds = SnowflakeDataSource(name='test', domain='test', database='db', query='foo', warehouse='')
+
+    sc.get_df(ds)
+
+    snow_mock.return_value.cursor.return_value.execute.assert_called_once_with(
+        'USE WAREHOUSE default_wh'
+    )
+
+    snow_mock.assert_called_once_with(
+        user='test_user',
+        password='test_password',
+        account='test_account',
+        database='db',
+        warehouse='default_wh',
+        ocsp_response_cache_filename=None,
+    )
+
+
 def test_missing_cache_file():
     with pytest.raises(ValueError):
         SnowflakeConnector(
@@ -45,5 +86,10 @@ def test_missing_cache_file():
         )
 
     SnowflakeConnector(
-        user='', password='', account='', name='', ocsp_response_cache_filename=__file__
+        user='',
+        password='',
+        account='',
+        name='',
+        default_warehouse='bleh',
+        ocsp_response_cache_filename=__file__,
     )


### PR DESCRIPTION
## Change Summary

This PR adds a default warehouse field in the Snowflake connector.
The default warehouse will used in any datasource that does not have its warehouse field defined.

<!-- Please give a short summary of the changes. -->

## Related issue number

None.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
