### PR TITLE
feat(snowflake): add OAuth connection support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.45.4',
+    version='0.45.5',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/toucan_connectors/snowflake/__init__.py
+++ b/toucan_connectors/snowflake/__init__.py
@@ -1,1 +1,1 @@
-from .snowflake_connector import SnowflakeConnector, SnowflakeDataSource
+from .snowflake_connector import AuthenticationMethod, SnowflakeConnector, SnowflakeDataSource


### PR DESCRIPTION
## Change Summary

This PR adds a way to handle a connection through OAuth for Snowflake.
The Snowflake model was changed to handle multiple ways of authentication (plain text and oauth for now), the OAuth authentication is already handled by the Snowflake python client, this PR only adds a way for the user to supply a OAuth token at the creation of the connector


## Related issue number

None

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
