### PR TITLE
feat(Github Connector): enable incremental capability

### DIFF
--- a/tests/github/conftest.py
+++ b/tests/github/conftest.py
@@ -373,7 +373,7 @@ def extracted_prs_2():
                                 'mergedAt': None,
                                 'deletions': 45,
                                 'additions': 162,
-                                'title': 'feat(blalbla):blalba ',
+                                'title': 'feat(blalbla):bla',
                                 'state': 'OPEN',
                                 'labels': {
                                     'edges': [
@@ -393,7 +393,7 @@ def extracted_prs_2():
                                         }
                                     ]
                                 },
-                            },
+                            }
                         ],
                         'pageInfo': {'hasNextPage': False, 'endCursor': '123'},
                     },

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -337,7 +337,7 @@ def test_get_pages(
 
     mocked_api_call = mocker.patch(
         'python_graphql_client.GraphqlClient.execute_async',
-        side_effect=[extracted_prs_1],
+        side_effect=[extracted_prs_1, extracted_prs_2],
     )
     pr_rows = event_loop.run_until_complete(
         gc.get_pages(
@@ -346,12 +346,12 @@ def test_get_pages(
             dataset='pull requests',
             client=client,
             page_limit=1000,
-            latest_retrieved_object='build: something',
+            latest_retrieved_object='feat(blalbla):bla',
         )
     )
-    assert mocked_api_call.call_count == 1
-    assert len(pr_rows) == 1
-    assert pr_rows[-1]['PR Name'] == 'feat(blalbla):blalba '
+    assert mocked_api_call.call_count == 2
+    assert len(pr_rows) == 3
+    assert pr_rows[-1]['PR Name'] == 'chore(something): somethin'
 
     mocked_api_call = mocker.patch(
         'python_graphql_client.GraphqlClient.execute_async',

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -337,6 +337,24 @@ def test_get_pages(
 
     mocked_api_call = mocker.patch(
         'python_graphql_client.GraphqlClient.execute_async',
+        side_effect=[extracted_prs_1],
+    )
+    pr_rows = event_loop.run_until_complete(
+        gc.get_pages(
+            name='repo1',
+            organization='foorganization',
+            dataset='pull requests',
+            client=client,
+            page_limit=1000,
+            latest_retrieved_object='build: something',
+        )
+    )
+    assert mocked_api_call.call_count == 1
+    assert len(pr_rows) == 1
+    assert pr_rows[-1]['PR Name'] == 'feat(blalbla):blalba '
+
+    mocked_api_call = mocker.patch(
+        'python_graphql_client.GraphqlClient.execute_async',
         side_effect=[extracted_team_page_1, extracted_team_page_2],
     )
     members_rows = event_loop.run_until_complete(


### PR DESCRIPTION
## Change Summary

For the Github's Business in a Box, we need to be able to stop traversing pagination when the connector detects a pull request we retrieved previously. 
This logic won't be used in current Business in a Box but in the next Architecture with the scheduled extraction script.

The idea will be: in the scheduled Github extraction script, we will retrieve the latest extracted PR from the client's bucket and give it to an instanciated Github Connector, this way it will only extract the required pages & PR.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
