### PR TITLE
feat: Automatic refresh token in HttpApiConnector

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,3 +1,6 @@
+from datetime import datetime, timedelta
+
+import jwt
 import responses
 
 from toucan_connectors.auth import Auth, CustomTokenServer
@@ -33,3 +36,39 @@ def test_custom_token_server():
 
     session.auth(TMP())
     assert responses.calls[1].request.headers['Authorization'].startswith('Basic')
+
+
+@responses.activate
+def test_oauth2_oidc():
+    # Case 1: id_token is valid and not expired
+    id_token = jwt.encode(
+        {'exp': (datetime.now() + timedelta(seconds=10000)).timestamp(), 'user': 'babar'}, key='key'
+    )
+    auth = Auth(
+        type='oauth2_oidc',
+        args=[],
+        kwargs={
+            'id_token': id_token,
+            'client_id': 'example_client_id',
+            'refresh_token': jwt.encode(
+                {'exp': (datetime.now() + timedelta(seconds=100000)).timestamp()}, key='refreshkey'
+            ),
+            'client_secret': 'example_client_secret',
+            'token_endpoint': 'https://example.com/token',
+            'refresh': True,
+        },
+    )
+    session = auth.get_session()
+    assert session.headers['Authorization'] == f'Bearer {id_token}'
+
+    # Case 2: id_token is expired but refresh token is not
+    id_token = jwt.encode(
+        {'exp': (datetime.now() - timedelta(seconds=100)).timestamp(), 'aud': 'babar'}, key='key'
+    )
+    auth.kwargs['id_token'] = id_token
+    responses.add(
+        method=responses.POST,
+        url='https://example.com/token',
+        json={'id_token': 'coucou'},
+    )
+    session = auth.get_session()

--- a/toucan_connectors/auth.py
+++ b/toucan_connectors/auth.py
@@ -1,7 +1,10 @@
+from datetime import datetime
 from enum import Enum
 from typing import List
 
+import jwt
 import pyjq
+import requests
 from oauthlib.oauth2 import BackendApplicationClient
 from pydantic import BaseModel, Field
 from requests import Session
@@ -16,6 +19,30 @@ def oauth2_backend(token_url, client_id, client_secret):
         token_url=token_url, client_id=client_id, client_secret=client_secret
     )
     return OAuth2Session(client_id=client_id, token=token)
+
+
+def oauth2_oidc(*args, **kwargs) -> Session:
+    """
+    Get a valid access token with the provided refresh_token
+    """
+    id_token = kwargs['id_token']
+    #  check that the id_token is not expired
+    decoded = jwt.decode(kwargs['id_token'], verify=False, options={'verify_signature': False})
+    if datetime.fromtimestamp(decoded['exp']) < datetime.now():
+        response = requests.post(
+            kwargs['token_endpoint'],
+            data={
+                'grant_type': 'refresh_token',
+                'client_id': kwargs['client_id'],
+                'client_secret': kwargs['client_secret'],
+                'refresh_token': kwargs['refresh_token'],
+            },
+        )
+        id_token = response.json()['id_token']  # we don't store it as of now
+
+    session = requests.Session()
+    session.headers.update({'Authorization': f'Bearer {id_token}'})
+    return session
 
 
 class CustomTokenServer(AuthBase):
@@ -56,13 +83,14 @@ class AuthType(str, Enum):
     digest = 'digest'
     oauth1 = 'oauth1'
     oauth2_backend = 'oauth2_backend'
+    oauth2_oidc = 'oauth2_oidc'
     custom_token_server = 'custom_token_server'
 
 
 class Auth(BaseModel):
     type: AuthType = Field(
         ...,
-        description='As we rely on the python request lirary, we suggest that you '
+        description='As we rely on the python request library, we suggest that you '
         'refer to the dedicated '
         '<a href="https://2.python-requests.org/en/master/user/authentication/">documentation</a> '
         'for more details.',
@@ -86,9 +114,9 @@ class Auth(BaseModel):
             'digest': HTTPDigestAuth,
             'oauth1': OAuth1,
             'oauth2_backend': oauth2_backend,
+            'oauth2_oidc': oauth2_oidc,
             'custom_token_server': CustomTokenServer,
         }.get(self.type.value)
-
         kwargs = {} if not self.kwargs else self.kwargs
         auth_instance = auth_class(*self.args, **kwargs)
 

--- a/toucan_connectors/auth.py
+++ b/toucan_connectors/auth.py
@@ -24,6 +24,13 @@ def oauth2_backend(token_url, client_id, client_secret):
 def oauth2_oidc(*args, **kwargs) -> Session:
     """
     Get a valid access token with the provided refresh_token
+
+    Required kwargs:
+                id_token: <initial token that may need to be refreshed>,
+                refresh_token: <initial refresh_token>,
+                client_id: <oauth client id>,
+                client_secret: <oauth client secret>,
+                token_endpoint: <oauth api token endpoint>,
     """
     id_token = kwargs['id_token']
     #  check that the id_token is not expired

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -121,7 +121,9 @@ class HttpAPIConnector(ToucanConnector):
         if self.cert:
             # `cert` is a list of PosixPath. `request` needs a list of strings for certificates
             query['cert'] = [str(c) for c in self.cert]
+
         res = session.request(**query)
+
         if self.responsetype == 'xml':
             try:
                 data = fromstring(res.content)


### PR DESCRIPTION
## Change Summary

* Created a new auth oauth2_oidc method in auth.py
* This method is usable in HttpApi connector and will take care of automatically retrieving an id_token with a refresh_token from a given token endpoint. 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
