### PR TITLE
 fix: behavior for default authentication for snowflake connector

### DIFF
--- a/doc/connectors/snowflake.md
+++ b/doc/connectors/snowflake.md
@@ -6,6 +6,7 @@ Import data from Snowflake data warehouse.
 
 * `type`: `"Snowflake"`
 * `name`: str, required
+* `authentication_method`, str, the authentication mechanism that will be used against Snowflake's APIs (default: plain text)
 * `user`: str, required
 * `password`: str, required
 * `default_warehouse`: str, name of the default warehouse to be used in a data source if no warehouse was specified in the concerned data source

--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -58,6 +58,18 @@ def test_snowflake(mocker):
     reasq.assert_called_once_with('test_query with bar and pikachu', con=snock())
 
 
+def test_snowflake_get_connection_params_no_auth_method(mocker):
+    res = SnowflakeConnector(
+        name='test',
+        user='test',
+        password='test_password',
+        account='test_account',
+        default_warehouse='test_wh',
+    ).get_connection_params()
+
+    assert res['authenticator'] == AuthenticationMethod.PLAIN
+
+
 def test_snowflake_data_source_get_form(mocker):
     ds = SnowflakeDataSource(
         name='test',

--- a/toucan_connectors/snowflake/snowflake_connector.py
+++ b/toucan_connectors/snowflake/snowflake_connector.py
@@ -66,7 +66,7 @@ class SnowflakeConnector(ToucanConnector):
     data_source_model: SnowflakeDataSource
 
     authentication_method: AuthenticationMethod = Field(
-        ...,
+        None,
         title='Authentication Method',
         description='The authentication mechanism that will be used to connect to your snowflake data source',
     )
@@ -99,7 +99,12 @@ class SnowflakeConnector(ToucanConnector):
             'authenticator': self.authentication_method,
         }
 
-        if self.authentication_method == AuthenticationMethod.PLAIN and self.password:
+        if not self.authentication_method:
+            # Default to User/Password authentication method if the parameter
+            # was not set when the connector was created
+            res['authenticator'] = AuthenticationMethod.PLAIN
+
+        if res['authenticator'] == AuthenticationMethod.PLAIN and self.password:
             res['password'] = self.password.get_secret_value()
 
         if self.authentication_method == AuthenticationMethod.OAUTH:


### PR DESCRIPTION
## Change Summary

This PR fixes a faulty behavior when a user tries to create a Snowflake Datasource.

When no authentication method was provided at the creation of a snowflake connector, the datasource creation would fail because the `authentication_method` field was mandatory.
This would also make `get_connection_params` fail since `authentication_method`'s value was set to `None`; thus making the method return an empty password to the snowflake python client.

This PR adds a way to default to plain text user/password authentication if no method was specified during the connector creation.

## Related issue number

None

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
