### PR TITLE
fix(snowflake): Apply query parameters through snowflake's client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ extras_require = {
     'postgres': ['psycopg2>=2.7.4'],
     'ROK': ['requests', 'pyjwt', 'simplejson'],
     'sap_hana': ['pyhdb>=0.3.4'],
-    'snowflake': ['snowflake-connector-python'],
+    'snowflake': ['snowflake-connector-python', 'pyarrow<0.18'],
     'toucan_toco': ['toucan_client'],
 }
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
## Change Summary

This PR discards the usage of `nosql_apply_parameters_to_query` in the snowflake connector in order to use snowflake's own way of applying parameters to a query.

This PR also pins the version of `pyarrow` since the snowflake python client is not compatible (for now) with any version of pyarrow >= 0.18.

## Related issue number

None

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
