### PR TITLE
fix(GithubConnector): using a get instead of a key on latest_retrieve…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.45.7',
+    version='0.45.8',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/toucan_connectors/github/github_connector.py
+++ b/toucan_connectors/github/github_connector.py
@@ -321,7 +321,7 @@ class GithubConnector(ToucanConnector):
                 dataset=dataset,
                 organization=organization,
                 page_limit=page_limit,
-                latest_retrieved_object=latest_retrieved_object[name]
+                latest_retrieved_object=latest_retrieved_object.get(name)
                 if latest_retrieved_object
                 else None,
             )


### PR DESCRIPTION
## Change Summary
in github_connector.py, 
changed 
`self.get_pages(
                name=name,
                client=client,
                dataset=dataset,
                organization=organization,
                page_limit=page_limit,
                latest_retrieved_object=latest_retrieved_object[name]
                if latest_retrieved_object
                else None,
            )`
to
`
self.get_pages(
                name=name,
                client=client,
                dataset=dataset,
                organization=organization,
                page_limit=page_limit,
                latest_retrieved_object=latest_retrieved_object.get(name)
                if latest_retrieved_object
                else None,
            )
`
To avoid a KeyError in case the name cannot be found in dict.