### PR TITLE
fix:aircall query params

### DIFF
--- a/tests/aircall/test_async_funcs.py
+++ b/tests/aircall/test_async_funcs.py
@@ -3,7 +3,7 @@ import pytest
 from aiohttp import web
 
 from tests.aircall.helpers import assert_called_with
-from toucan_connectors.aircall.aircall_connector import fetch, fetch_page
+from toucan_connectors.aircall.aircall_connector import AircallDataset, fetch, fetch_page
 
 fetch_fn_name = 'toucan_connectors.aircall.aircall_connector.fetch'
 
@@ -156,3 +156,15 @@ async def test_fetch_page_with_params(mocker):
     fake_fetch = mocker.patch(fetch_fn_name, return_value=fake_data)
     await fetch_page(dataset, [], {}, 1, 0, query_params={'from': 1609459200, 'to': 1612137599})
     assert fake_fetch.call_args_list[0][0][2] == {'from': 1609459200, 'to': 1612137599}
+
+
+async def test_query_params_not_named_arg(mocker):
+    """
+    Check that fetch_page fails if query params are not given
+    as named arg
+    """
+    ds = AircallDataset('calls')
+    params = {'bla': 'bla'}
+
+    with pytest.raises(TypeError):
+        await fetch_page(ds, [], 'session', 0, 0, 0, 0, params)

--- a/toucan_connectors/aircall/aircall_connector.py
+++ b/toucan_connectors/aircall/aircall_connector.py
@@ -49,6 +49,7 @@ async def fetch_page(
     current_pass: int,
     new_page=1,
     delay_counter=0,
+    *,
     query_params=None,
 ) -> List[dict]:
     """

--- a/toucan_connectors/aircall/aircall_connector.py
+++ b/toucan_connectors/aircall/aircall_connector.py
@@ -84,7 +84,7 @@ async def fetch_page(
                 current_pass,
                 new_page,
                 delay_counter,
-                query_params,
+                query_params=query_params,
             )
         else:
             logging.getLogger(__file__).error('Aborting Aircall requests')
@@ -104,13 +104,25 @@ async def fetch_page(
         if next_page_link is not None and current_pass < limit:
             next_page = meta_data['current_page'] + 1
             data_list = await fetch_page(
-                dataset, data_list, session, limit, current_pass, next_page, query_params
+                dataset,
+                data_list,
+                session,
+                limit,
+                current_pass,
+                next_page,
+                query_params=query_params,
             )
     else:
         if next_page_link is not None:
             next_page = meta_data['current_page'] + 1
             data_list = await fetch_page(
-                dataset, data_list, session, limit, current_pass, next_page, query_params
+                dataset,
+                data_list,
+                session,
+                limit,
+                current_pass,
+                next_page,
+                query_params=query_params,
             )
 
     return data_list


### PR DESCRIPTION
Fixed wrong query_params forwarding to `_retrieve_data`