### PR TITLE
fix(GithubConnector): Filtering CLOSED PR and changing PR author definition

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.45.10',
+    version='0.45.11',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/tests/github/conftest.py
+++ b/tests/github/conftest.py
@@ -104,7 +104,7 @@ def extracted_pr_list():
                 'deletions': 69,
                 'additions': 98,
                 'title': 'chore(somethinh):bla',
-                'state': 'MERGED',
+                'state': 'CLOSED',
                 'labels': {'edges': [{'node': {'name': 'tech'}}]},
                 'commits': {
                     'edges': [{'node': {'commit': {'author': {'user': {'login': 'jeanlouis'}}}}}]

--- a/tests/github/test_helpers_github.py
+++ b/tests/github/test_helpers_github.py
@@ -92,8 +92,8 @@ def test_format_pr_rows(extracted_pr_list):
     Check that format_pr_rows is able to format a list of prs
     """
     formatted = format_pr_rows(extracted_pr_list, 'buzz')
-    assert len(formatted) == 3
-    assert formatted[2]['Repo Name'] == 'buzz'
+    assert len(formatted) == 2  # CLOSED PR should be filtered out
+    assert formatted[1]['Repo Name'] == 'buzz'
 
 
 def test_format_team_row():


### PR DESCRIPTION
## Change Summary

Enhanced Data modelling in GithubConnector:
- CLOSED PR are now filtered out to avoid bias in Merging Time statistics
- PR Author is now the latest PR committer instead of the first 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%