### PR TITLE
fix(snowflake): Close connections after usage and mini fix

### DIFF
--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -60,6 +60,7 @@ def test_snowflake(mocker):
         warehouse='test_warehouse',
         authenticator='snowflake',
         ocsp_response_cache_filename=None,
+        application='ToucanToco',
     )
 
 
@@ -152,6 +153,7 @@ def test_snowflake_data_source_default_warehouse(mocker):
         warehouse='default_wh',
         ocsp_response_cache_filename=None,
         authenticator='snowflake',
+        application='ToucanToco',
     )
 
 
@@ -168,6 +170,7 @@ def test_snowflake_oauth_auth(mocker):
         warehouse='test_warehouse',
         token='tUh7G0lJs6TjjGzVkv5DAOD4cSFPK5o2',
         ocsp_response_cache_filename=None,
+        application='ToucanToco',
     )
 
 
@@ -184,6 +187,7 @@ def test_snowflake_plain_auth(mocker):
         database='test_database',
         warehouse='test_warehouse',
         ocsp_response_cache_filename=None,
+        application='ToucanToco',
     )
 
 


### PR DESCRIPTION
## Change Summary

Previous commits introduced multiple functions that use snowflake connections to retrieve data such as the list of databases, the list of warehouses, etc.
However these functions never closed properly the connection that they used, thus leaving unnecessary and unused connections in memory.

This PR fixes that.

This PR also introduces a small change that will identify every request made through the snowflake connector as a request done by Toucan Toco for metrics on snowflake's side.

## Related issue number

None

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
