### PR TITLE
refactor: limit PR extraction to 1 year in get_pages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.45.11',
+    version='0.45.12',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/tests/github/conftest.py
+++ b/tests/github/conftest.py
@@ -413,7 +413,7 @@ def extracted_prs_3():
                     'pullRequests': {
                         'nodes': [
                             {
-                                'createdAt': '2020-11-18T15:58:44Z',
+                                'createdAt': '2020-01-18T15:58:44Z',
                                 'mergedAt': None,
                                 'deletions': 45,
                                 'additions': 162,

--- a/toucan_connectors/github/github_connector.py
+++ b/toucan_connectors/github/github_connector.py
@@ -54,7 +54,7 @@ TOKEN_URL: str = 'https://github.com/login/oauth/access_token'
 BASE_ROUTE: str = 'https://api.github.com/graphql'
 BASE_ROUTE_REST: str = 'https://api.github.com/'
 NO_CREDENTIALS_ERROR = 'No credentials'
-start = datetime.strftime(
+extraction_start_date = datetime.strftime(
     datetime.now() - relativedelta.relativedelta(years=1), '%Y-%m-%dT%H:%M:%SZ'
 )
 
@@ -253,13 +253,14 @@ class GithubConnector(ToucanConnector):
                     pass
 
             # For now we want to retrieve only max 1 year of Pull requests
-            # TODO change this to be able to receive a start date for extraction as a parameter
+            # TODO change this to be able to receive a extraction_start_date date for extraction as a parameter
             if dataset == GithubDataSet('pull requests'):
                 try:
-                    # Find the first index where PR Creation Date is < start
+                    # Find the first index where PR Creation Date is < extraction_start_date
                     # Throws IndexError if such index cannot be found
                     index = np.where(
-                        np.array([pr['PR Creation Date'] for pr in formatted_data]) < start
+                        np.array([pr['PR Creation Date'] for pr in formatted_data])
+                        < extraction_start_date
                     )[0][0]
                     formatted_data = formatted_data[:index]
                     data_list.extend(formatted_data)


### PR DESCRIPTION
## Change Summary

For Github's Business in a Box, we need to add a date limit on PR Extraction. For now this limit is hardcoded (== 1 year). 
In a future version, it will be given as a parameter. 

Modification was done in get_pages, if dataset is Pull Requests, then stop extraction if PR creation date is older than one year. 
With the query we are using, retrieved PR are sorted by creation date Descending.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
