### PR TITLE
feat(githubconnector, aircallconnector): added ratelimit info extraction & handling

### DIFF
--- a/tests/aircall/test_async_funcs.py
+++ b/tests/aircall/test_async_funcs.py
@@ -1,4 +1,6 @@
 """Module containing tests with fake server"""
+from datetime import datetime
+
 import pytest
 from aiohttp import web
 
@@ -205,8 +207,14 @@ async def test_fetch_page_rate_limited(mocker):
     ds = AircallDataset('calls')
     fake_data = {'data': {'stuff': 'stuff'}}
     mocker.patch(
-        fetch_fn_name, side_effect=[AircallRateLimitExhaustedException('16100000'), fake_data]
+        fetch_fn_name, side_effect=[AircallRateLimitExhaustedException('1610000003'), fake_data]
     )
+    mockeddatetime = mocker.patch('toucan_connectors.aircall.aircall_connector.datetime')
+    mocked_utcnow = mockeddatetime.utcnow
+    mocked_utcnow.return_value = datetime(2021, 1, 7, 6, 13, 20)
+    mocked_timestamp = mockeddatetime.timestamp
+    mocked_timestamp.return_value = 1610000001
     mockedsleep = mocker.patch('toucan_connectors.aircall.aircall_connector.time.sleep')
     await fetch_page(ds, [], 'session', 0, 0, 0, 0)
     mockedsleep.assert_called_once()
+    assert mockedsleep.call_args_list[0][0][0] == 1

--- a/tests/github/conftest.py
+++ b/tests/github/conftest.py
@@ -445,3 +445,48 @@ def extracted_prs_3():
             }
         }
     }
+
+
+@pytest.fixture(scope='session')
+def extracted_prs_4():
+    return {
+        'data': {
+            'organization': {
+                'repository': {
+                    'name': 'repo4',
+                    'pullRequests': {
+                        'nodes': [
+                            {
+                                'createdAt': '2020-11-18T15:58:44Z',
+                                'mergedAt': None,
+                                'deletions': 45,
+                                'additions': 162,
+                                'title': 'feat(blalbla):blalba ',
+                                'state': 'OPEN',
+                                'labels': {
+                                    'edges': [
+                                        {'node': {'name': 'feature'}},
+                                        {'node': {'name': 'Label'}},
+                                        {'node': {'name': 'Other Label'}},
+                                    ]
+                                },
+                                'commits': {
+                                    'edges': [
+                                        {
+                                            'node': {
+                                                'commit': {
+                                                    'author': {'user': {'login': 'jeanlouis'}}
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                            },
+                        ],
+                        'pageInfo': {'hasNextPage': False, 'endCursor': '123'},
+                        'rateLimit': {'remaining': 0, 'resetAt': '2021-02-23T13:26:47Z'},
+                    },
+                }
+            }
+        }
+    }

--- a/tests/github/conftest.py
+++ b/tests/github/conftest.py
@@ -449,44 +449,44 @@ def extracted_prs_3():
 
 @pytest.fixture(scope='session')
 def extracted_prs_4():
-    return {
-        'data': {
-            'organization': {
-                'repository': {
-                    'name': 'repo4',
-                    'pullRequests': {
-                        'nodes': [
-                            {
-                                'createdAt': '2020-11-18T15:58:44Z',
-                                'mergedAt': None,
-                                'deletions': 45,
-                                'additions': 162,
-                                'title': 'feat(blalbla):blalba ',
-                                'state': 'OPEN',
-                                'labels': {
-                                    'edges': [
-                                        {'node': {'name': 'feature'}},
-                                        {'node': {'name': 'Label'}},
-                                        {'node': {'name': 'Other Label'}},
-                                    ]
-                                },
-                                'commits': {
-                                    'edges': [
-                                        {
-                                            'node': {
-                                                'commit': {
-                                                    'author': {'user': {'login': 'jeanlouis'}}
+        return {
+            'data': {
+                'organization': {
+                    'repository': {
+                        'name': 'repo4',
+                        'pullRequests': {
+                            'nodes': [
+                                {
+                                    'createdAt': '2020-11-18T15:58:44Z',
+                                    'mergedAt': None,
+                                    'deletions': 45,
+                                    'additions': 162,
+                                    'title': 'feat(blalbla):blalba ',
+                                    'state': 'OPEN',
+                                    'labels': {
+                                        'edges': [
+                                            {'node': {'name': 'feature'}},
+                                            {'node': {'name': 'Label'}},
+                                            {'node': {'name': 'Other Label'}},
+                                        ]
+                                    },
+                                    'commits': {
+                                        'edges': [
+                                            {
+                                                'node': {
+                                                    'commit': {
+                                                        'author': {'user': {'login': 'jeanlouis'}}
+                                                    }
                                                 }
                                             }
-                                        }
-                                    ]
+                                        ]
+                                    },
                                 },
-                            },
-                        ],
-                        'pageInfo': {'hasNextPage': False, 'endCursor': '123'},
-                        'rateLimit': {'remaining': 0, 'resetAt': '2021-02-23T13:26:47Z'},
-                    },
-                }
+                            ],
+                            'pageInfo': {'hasNextPage': True, 'endCursor': '123'},
+                        },
+                    }
+                },
+                'rateLimit': {'remaining': 70, 'resetAt': '2021-02-23T13:26:47Z'},
             }
         }
-    }

--- a/tests/github/conftest.py
+++ b/tests/github/conftest.py
@@ -449,44 +449,44 @@ def extracted_prs_3():
 
 @pytest.fixture(scope='session')
 def extracted_prs_4():
-        return {
-            'data': {
-                'organization': {
-                    'repository': {
-                        'name': 'repo4',
-                        'pullRequests': {
-                            'nodes': [
-                                {
-                                    'createdAt': '2020-11-18T15:58:44Z',
-                                    'mergedAt': None,
-                                    'deletions': 45,
-                                    'additions': 162,
-                                    'title': 'feat(blalbla):blalba ',
-                                    'state': 'OPEN',
-                                    'labels': {
-                                        'edges': [
-                                            {'node': {'name': 'feature'}},
-                                            {'node': {'name': 'Label'}},
-                                            {'node': {'name': 'Other Label'}},
-                                        ]
-                                    },
-                                    'commits': {
-                                        'edges': [
-                                            {
-                                                'node': {
-                                                    'commit': {
-                                                        'author': {'user': {'login': 'jeanlouis'}}
-                                                    }
+    return {
+        'data': {
+            'organization': {
+                'repository': {
+                    'name': 'repo4',
+                    'pullRequests': {
+                        'nodes': [
+                            {
+                                'createdAt': '2020-11-18T15:58:44Z',
+                                'mergedAt': None,
+                                'deletions': 45,
+                                'additions': 162,
+                                'title': 'feat(blalbla):blalba ',
+                                'state': 'OPEN',
+                                'labels': {
+                                    'edges': [
+                                        {'node': {'name': 'feature'}},
+                                        {'node': {'name': 'Label'}},
+                                        {'node': {'name': 'Other Label'}},
+                                    ]
+                                },
+                                'commits': {
+                                    'edges': [
+                                        {
+                                            'node': {
+                                                'commit': {
+                                                    'author': {'user': {'login': 'jeanlouis'}}
                                                 }
                                             }
-                                        ]
-                                    },
+                                        }
+                                    ]
                                 },
-                            ],
-                            'pageInfo': {'hasNextPage': True, 'endCursor': '123'},
-                        },
-                    }
-                },
-                'rateLimit': {'remaining': 70, 'resetAt': '2021-02-23T13:26:47Z'},
-            }
+                            },
+                        ],
+                        'pageInfo': {'hasNextPage': True, 'endCursor': '123'},
+                    },
+                }
+            },
+            'rateLimit': {'remaining': 70, 'resetAt': '2021-02-23T13:26:47Z'},
         }
+    }

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -503,12 +503,12 @@ def test_get_organizations(gc):
     assert res == ['power_rangers', 'teletubbies']
 
 
-def test_get_rate_limit_exhausted(gc, mocker, extracted_prs_4, event_loop, client):
+def test_get_rate_limit_exhausted(gc, mocker, extracted_prs_4, extracted_prs_3, event_loop, client):
     """Check that the connector is paused when rate limit is exhausted"""
     mockedsleep = mocker.patch(
         'toucan_connectors.github.github_connector.asyncio.sleep', return_value=None
     )
-    mocker.patch('python_graphql_client.GraphqlClient.execute_async', return_value=extracted_prs_4)
+    mocker.patch('python_graphql_client.GraphqlClient.execute_async', side_effect=[extracted_prs_4, extracted_prs_3])
     event_loop.run_until_complete(
         gc.get_pages(
             name='repo1',
@@ -519,4 +519,4 @@ def test_get_rate_limit_exhausted(gc, mocker, extracted_prs_4, event_loop, clien
         )
     )
 
-    assert mockedsleep.call_count == 2
+    assert mockedsleep.call_count == 3

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -501,3 +501,22 @@ def test_get_organizations(gc):
     res = gc.get_organizations()
     assert len(responses.calls) == 1
     assert res == ['power_rangers', 'teletubbies']
+
+
+def test_get_rate_limit_exhausted(gc, mocker, extracted_prs_4, event_loop, client):
+    """Check that the connector is paused when rate limit is exhausted"""
+    mockedsleep = mocker.patch(
+        'toucan_connectors.github.github_connector.asyncio.sleep', return_value=None
+    )
+    mocker.patch('python_graphql_client.GraphqlClient.execute_async', return_value=extracted_prs_4)
+    event_loop.run_until_complete(
+        gc.get_pages(
+            name='repo1',
+            organization='foorganization',
+            dataset='pull requests',
+            client=client,
+            page_limit=1,
+        )
+    )
+
+    assert mockedsleep.call_count == 2

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 import responses
 from python_graphql_client import GraphqlClient
@@ -505,10 +507,18 @@ def test_get_organizations(gc):
 
 def test_get_rate_limit_exhausted(gc, mocker, extracted_prs_4, extracted_prs_3, event_loop, client):
     """Check that the connector is paused when rate limit is exhausted"""
-    mockedsleep = mocker.patch(
-        'toucan_connectors.github.github_connector.asyncio.sleep', return_value=None
+    mockedsleep = mocker.patch('toucan_connectors.github.github_connector.asyncio.sleep')
+    mockeddatetime = mocker.patch('toucan_connectors.github.helpers.datetime')
+    mocked_strptime = mockeddatetime.strptime
+    mocked_strptime.return_value = datetime(2021, 2, 23, 13, 26, 47)
+    mocked_utcnow = mockeddatetime.utcnow
+    mocked_utcnow.return_value = datetime(2021, 2, 23, 13, 26, 0)
+    mocked_seconds = mockeddatetime.seconds
+    mocked_seconds.return_value = 47
+    mocker.patch(
+        'python_graphql_client.GraphqlClient.execute_async',
+        side_effect=[extracted_prs_4, extracted_prs_3],
     )
-    mocker.patch('python_graphql_client.GraphqlClient.execute_async', side_effect=[extracted_prs_4, extracted_prs_3])
     event_loop.run_until_complete(
         gc.get_pages(
             name='repo1',
@@ -518,5 +528,5 @@ def test_get_rate_limit_exhausted(gc, mocker, extracted_prs_4, extracted_prs_3, 
             page_limit=1,
         )
     )
-
     assert mockedsleep.call_count == 3
+    assert mockedsleep.call_args_list[1][0][0] == 48

--- a/tests/github/test_helpers_github.py
+++ b/tests/github/test_helpers_github.py
@@ -3,6 +3,7 @@ import pytest
 from toucan_connectors.github.helpers import (
     GithubError,
     KeyNotFoundException,
+    RateLimitExhaustedException,
     build_query_members,
     build_query_pr,
     build_query_repositories,
@@ -21,6 +22,7 @@ from toucan_connectors.github.helpers import (
     get_organization,
     get_page_info,
     get_pull_requests,
+    get_rate_limit_info,
     get_repositories,
     get_repository,
     get_team,
@@ -262,3 +264,12 @@ def test_get_message():
     """
     with pytest.raises(GithubError):
         assert get_message({'documentation_url': 'bla', 'message': 'bla'}) == 'bla'
+
+
+def test_get_rate_limit_info():
+    """
+    Check that get_rate_limit_info is able to extract
+    rate limit info from the API response
+    """
+    with pytest.raises(RateLimitExhaustedException):
+        get_rate_limit_info({'rateLimit': {'remaining': 0, 'resetAt': '2021-02-23T13:26:47Z'}})

--- a/toucan_connectors/aircall/aircall_connector.py
+++ b/toucan_connectors/aircall/aircall_connector.py
@@ -70,19 +70,19 @@ async def fetch_page(
         else:
             data: dict = await fetch(endpoint, session)
 
-        logging.getLogger(__file__).info(
+        logging.getLogger(__name__).info(
             f'Request sent to Aircall for page {new_page} for dataset {dataset}'
         )
 
         aircall_error = data.get('error')
         if aircall_error:
-            logging.getLogger(__file__).error(f'Aircall error has occurred: {aircall_error}')
+            logging.getLogger(__name__).error(f'Aircall error has occurred: {aircall_error}')
             delay_timer = 1
             max_num_of_retries = 3
             await asyncio.sleep(delay_timer)
             if delay_counter < max_num_of_retries:
                 delay_counter += 1
-                logging.getLogger(__file__).info('Retrying Aircall API')
+                logging.getLogger(__name__).info('Retrying Aircall API')
                 data_list = await fetch_page(
                     dataset,
                     data_list,
@@ -94,7 +94,7 @@ async def fetch_page(
                     query_params=query_params,
                 )
             else:
-                logging.getLogger(__file__).error('Aborting Aircall requests')
+                logging.getLogger(__name__).error('Aborting Aircall requests')
                 raise AircallException(f'Aborting Aircall requests due to {aircall_error}')
 
         delay_counter = 0
@@ -135,9 +135,9 @@ async def fetch_page(
     except AircallRateLimitExhaustedException as a:
         reset_timestamp = int(a.args[0])
         delay = reset_timestamp - (int(datetime.timestamp(datetime.utcnow())) + 1)
-        logging.getLogger(__file__).info(f'Rate limit reached, pausing {delay} seconds')
+        logging.getLogger(__name__).info(f'Rate limit reached, pausing {delay} seconds')
         time.sleep(delay)
-        logging.getLogger(__file__).info('Extraction restarted')
+        logging.getLogger(__name__).info('Extraction restarted')
         data_list = await fetch_page(
             dataset,
             data_list,

--- a/toucan_connectors/aircall/helpers.py
+++ b/toucan_connectors/aircall/helpers.py
@@ -89,7 +89,7 @@ def format_calls_data(call_obj: dict) -> dict:
         }
 
 
-def format_teams_data(team_obj: dict) -> dict:
+def format_teams_data(team_obj: dict):
     """Provides a filter for teams"""
     if team_obj:
         return list(

--- a/toucan_connectors/github/github_connector.py
+++ b/toucan_connectors/github/github_connector.py
@@ -27,6 +27,7 @@ from toucan_connectors.toucan_connector import (
 from .helpers import (
     GithubError,
     KeyNotFoundException,
+    RateLimitExhaustedException,
     dataset_formatter,
     extraction_funcs_names,
     extraction_funcs_pages_1,
@@ -40,6 +41,7 @@ from .helpers import (
     get_nodes,
     get_organization,
     get_page_info,
+    get_rate_limit_info,
     has_next_page,
     queries_funcs_names,
     queries_funcs_pages,
@@ -230,6 +232,7 @@ class GithubConnector(ToucanConnector):
                 extraction_funcs_pages_2[dataset](get_organization(get_data(data)))
             )
             page_info = get_page_info(extracted_data)
+            get_rate_limit_info(extracted_data)
             formatted_data = format_functions[dataset](extracted_data, name)
 
             # Check if the extraction script can see a previously extracted object (e.g PR)
@@ -289,6 +292,11 @@ class GithubConnector(ToucanConnector):
 
         except KeyNotFoundException as k:
             logging.getLogger(__name__).error(f'{k}')
+
+        except RateLimitExhaustedException as r:
+            sleep_time = r.args[0]  # Value to wait is sent within the Exception
+            logging.getLogger(__name__).info(f'Pausing until reset, waiting {sleep_time}')
+            await asyncio.sleep(sleep_time)
 
         return data_list
 

--- a/toucan_connectors/github/helpers.py
+++ b/toucan_connectors/github/helpers.py
@@ -462,7 +462,7 @@ def get_rate_limit_info(response: dict):
     """
     rate_limit_info = response.get('rateLimit')
     if rate_limit_info:
-        if rate_limit_info['remaining'] == 0:
+        if rate_limit_info['remaining'] < 100:  # Raise the Exception Before reaching the limit
             logging.getLogger(__name__).info('Rate limit exhausted')
             resetAt_date = datetime.strptime(rate_limit_info['resetAt'], '%Y-%m-%dT%H:%M:%SZ')
             timetowait = (resetAt_date - datetime.utcnow()).seconds + 1  # adding 1 sec to round up


### PR DESCRIPTION
## Change Summary

This PR aims to add ratelimit handling feature to Github & Aircall Connectors. 
The goal is to be able to know when the extraction reached the API Rate Limit and pause until the limit is reset. 

For Github see: https://docs.github.com/en/graphql/overview/resource-limitations
For Aircall See: https://developer.aircall.io/api-references/#rate-limiting

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
