### PR TITLE
fix(mongo-connector): make regex match case insensitive

### DIFF
--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -333,6 +333,15 @@ def test_get_df_with_regex_with_integers(mongo_connector, mongo_datasource):
         {'domain': 'domain1', 'country': 'France', 'language': 'French', 'value': 20}
     ]
 
+def test_get_df_with_regex_case_sensitiveness(mongo_connector, mongo_datasource):
+    datasource = mongo_datasource(
+        collection='test_col',
+        query=[{'$match': {'domain': 'domain1'}}],
+    )
+    df = mongo_connector.get_df_with_regex(datasource, field='country', regex=re.compile('^FrAn.*'))
+    assert df.drop(columns='_id').to_dict(orient='records') == [
+        {'domain': 'domain1', 'country': 'France', 'language': 'French', 'value': 20}
+    ]
 
 def test_get_df_with_regex_with_limit(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -333,6 +333,7 @@ def test_get_df_with_regex_with_integers(mongo_connector, mongo_datasource):
         {'domain': 'domain1', 'country': 'France', 'language': 'French', 'value': 20}
     ]
 
+
 def test_get_df_with_regex_case_sensitiveness(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(
         collection='test_col',
@@ -342,6 +343,7 @@ def test_get_df_with_regex_case_sensitiveness(mongo_connector, mongo_datasource)
     assert df.drop(columns='_id').to_dict(orient='records') == [
         {'domain': 'domain1', 'country': 'France', 'language': 'French', 'value': 20}
     ]
+
 
 def test_get_df_with_regex_with_limit(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -258,6 +258,7 @@ class MongoConnector(ToucanConnector):
                 '$regexMatch': {
                     'input': {'$toString': f'${field}'},
                     'regex': regex.pattern,
+                    'options': 'i' # i -> Case insensitivity
                 }
             }
         }

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -258,7 +258,7 @@ class MongoConnector(ToucanConnector):
                 '$regexMatch': {
                     'input': {'$toString': f'${field}'},
                     'regex': regex.pattern,
-                    'options': 'i' # i -> Case insensitivity
+                    'options': 'i',  # i -> Case insensitivity
                 }
             }
         }


### PR DESCRIPTION
## Change Summary
The regex match was case sensitive (making the lazy requester not work properly). 