### PR TITLE
feat(snowflake): add role specification for snowflake connector

### DIFF
--- a/doc/connectors/snowflake.md
+++ b/doc/connectors/snowflake.md
@@ -19,6 +19,7 @@ Import data from Snowflake data warehouse.
     * `content_type` (optional): the default content type used to refresh a token is `application/json`, setting this value will override the default one
 * `default_warehouse`: str, name of the default warehouse to be used in a data source if no warehouse was specified in the concerned data source
 * `account`: str, required
+* `role`: str, optional: the [User Role](https://docs.snowflake.com/en/user-guide/admin-user-management.html#user-roles) that your user may need to access certain data
 * `ocsp_response_cache_filename`: str, path to the location used to store [ocsp cache] (https://docs.snowflake.net/manuals/user-guide/python-connector-example.html#caching-ocsp-responses)
 
 ```coffee

--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -73,7 +73,41 @@ def test_snowflake(mocker):
         authenticator='snowflake',
         ocsp_response_cache_filename=None,
         application='ToucanToco',
+        role=None,
     )
+
+
+def test_snowflake_custom_role(mocker):
+    snock = mocker.patch('snowflake.connector.connect')
+
+    connector = copy.deepcopy(sc)
+    connector.role = 'TEST'
+
+    connector.get_df(sd)
+
+    snock.assert_called_once_with(
+        user='test_user',
+        password='test_password',
+        account='test_account',
+        database='test_database',
+        warehouse='test_warehouse',
+        authenticator='snowflake',
+        ocsp_response_cache_filename=None,
+        application='ToucanToco',
+        role='TEST',
+    )
+
+
+def test_snowflake_custom_role_empty(mocker):
+    snock = mocker.patch('snowflake.connector.connect')
+
+    connector = copy.deepcopy(sc)
+    connector.role = ''
+
+    connector.get_df(sd)
+
+    _, kwargs = snock.call_args_list[0]
+    assert 'role' not in kwargs
 
 
 def test_snowflake_get_connection_params_no_auth_method(mocker):
@@ -166,6 +200,7 @@ def test_snowflake_data_source_default_warehouse(mocker):
         ocsp_response_cache_filename=None,
         authenticator='snowflake',
         application='ToucanToco',
+        role=None,
     )
 
 
@@ -183,6 +218,7 @@ def test_snowflake_oauth_auth(mocker):
         token=sc_oauth.oauth_token,
         ocsp_response_cache_filename=None,
         application='ToucanToco',
+        role=None,
     )
 
 
@@ -200,6 +236,7 @@ def test_snowflake_plain_auth(mocker):
         warehouse='test_warehouse',
         ocsp_response_cache_filename=None,
         application='ToucanToco',
+        role=None,
     )
 
 

--- a/toucan_connectors/snowflake/snowflake_connector.py
+++ b/toucan_connectors/snowflake/snowflake_connector.py
@@ -94,6 +94,11 @@ class SnowflakeConnector(ToucanConnector):
         'in the form of: "your_account_name.region_id.cloud_platform". See more details '
         '<a href="https://docs.snowflake.net/manuals/user-guide/python-connector-api.html#label-account-format-info" target="_blank">here</a>.',
     )
+    role: str = Field(
+        None,
+        description='The user role that you want to connect with. '
+        'See more details <a href="https://docs.snowflake.com/en/user-guide/admin-user-management.html#user-roles" target="_blank">here</a>.',
+    )
 
     default_warehouse: str = Field(
         ..., description='The default warehouse that shall be used for any data source'
@@ -124,6 +129,9 @@ class SnowflakeConnector(ToucanConnector):
         if self.authentication_method == AuthenticationMethod.OAUTH:
             if self.oauth_token is not None:
                 res['token'] = Template(self.oauth_token).render()
+
+        if self.role != '':
+            res['role'] = self.role
 
         return res
 


### PR DESCRIPTION
## Change Summary

This PR adds the support of user defined [snowflake User Roles](https://docs.snowflake.com/en/user-guide/admin-user-management.html#user-roles).

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
