### PR TITLE
fix(snowflake): fix refresh mechanism and fix user management

### DIFF
--- a/doc/connectors/snowflake.md
+++ b/doc/connectors/snowflake.md
@@ -7,7 +7,7 @@ Import data from Snowflake data warehouse.
 * `type`: `"Snowflake"`
 * `name`: str, required
 * `authentication_method`, str, the authentication mechanism that will be used against Snowflake's APIs (default: plain text)
-* `user`: str, optional: this username can be none if the connector is using a OIDC-based authentication
+* `user`: str, required
 * `password`: str, required
 * `oauth_token`: str, an OAuth token
 * `oauth_args`: Dict, a dict that contains furthermore information for OIDC-based authentication

--- a/doc/connectors/snowflake.md
+++ b/doc/connectors/snowflake.md
@@ -7,7 +7,7 @@ Import data from Snowflake data warehouse.
 * `type`: `"Snowflake"`
 * `name`: str, required
 * `authentication_method`, str, the authentication mechanism that will be used against Snowflake's APIs (default: plain text)
-* `user`: str, required
+* `user`: str, optional: this username can be none if the connector is using a OIDC-based authentication
 * `password`: str, required
 * `oauth_token`: str, an OAuth token
 * `oauth_args`: Dict, a dict that contains furthermore information for OIDC-based authentication

--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -208,12 +208,11 @@ def test_snowflake_oauth_auth(mocker):
     snow_mock = mocker.patch('snowflake.connector.connect')
 
     sf = copy.deepcopy(sc_oauth)
-    sf.user = None
 
     sf.get_df(sd)
 
     snow_mock.assert_called_once_with(
-        user='snowflake_user',
+        user='test_user',
         account='test_account',
         authenticator=AuthenticationMethod.OAUTH,
         database='test_database',

--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -27,7 +27,7 @@ sc_oauth = SnowflakeConnector(
     user='test_user',
     password='test_password',
     account='test_account',
-    oauth_token=jwt.encode({'exp': 42}, key='clef'),
+    oauth_token=jwt.encode({'exp': 42, 'sub': 'snowflake_user'}, key='clef'),
     default_warehouse='default_wh',
 )
 
@@ -207,10 +207,13 @@ def test_snowflake_data_source_default_warehouse(mocker):
 def test_snowflake_oauth_auth(mocker):
     snow_mock = mocker.patch('snowflake.connector.connect')
 
-    sc_oauth.get_df(sd)
+    sf = copy.deepcopy(sc_oauth)
+    sf.user = None
+
+    sf.get_df(sd)
 
     snow_mock.assert_called_once_with(
-        user='test_user',
+        user='snowflake_user',
         account='test_account',
         authenticator=AuthenticationMethod.OAUTH,
         database='test_database',
@@ -315,7 +318,9 @@ def test_specified_oauth_args(mocker):
     sf = copy.deepcopy(sc_oauth)
     sf.oauth_args = copy.deepcopy(OAUTH_ARGS)
 
-    sf.oauth_token = jwt.encode({'exp': datetime.now() - timedelta(hours=24)}, key='supersecret')
+    sf.oauth_token = jwt.encode(
+        {'exp': datetime.now() - timedelta(hours=24), 'sub': 'user'}, key='supersecret'
+    )
 
     data_source = SnowflakeDataSource(
         name='test',
@@ -327,10 +332,56 @@ def test_specified_oauth_args(mocker):
 
     req_mock = mocker.patch('requests.post')
     req_mock.return_value.status_code = 200
+    req_mock.return_value.json = lambda: {
+        'access_token': jwt.encode({'exp': datetime.now(), 'sub': 'user'}, key='supersecret')
+    }
 
     sf._retrieve_data(data_source)
 
+    url, kwargs = req_mock.call_args_list[0]
     assert req_mock.call_count == 1
+    assert OAUTH_ARGS['token_endpoint'] == url[0]
+    assert OAUTH_ARGS['client_id'] == kwargs['data']['client_id']
+    assert OAUTH_ARGS['client_secret'] == kwargs['data']['client_secret']
+    assert OAUTH_ARGS['content_type'] == kwargs['headers']['Content-Type']
+
+
+def test_oauth_args_empty_user(mocker):
+    snow_mock = mocker.patch('snowflake.connector.connect')
+    req_mock = mocker.patch('requests.post')
+    req_mock.return_value.json = lambda: {
+        'access_token': jwt.encode({'exp': datetime.now(), 'sub': 'user'}, key='supersecret')
+    }
+
+    sf = copy.deepcopy(sc_oauth)
+    sf.oauth_args = copy.deepcopy(OAUTH_ARGS)
+    sf.user = None
+
+    sf.oauth_token = jwt.encode(
+        {'exp': datetime.now() - timedelta(hours=24), 'sub': 'provided_user'}, key='supersecret'
+    )
+
+    data_source = SnowflakeDataSource(
+        name='test',
+        domain='test',
+        database='test',
+        warehouse='test',
+        query='bar',
+    )
+
+    sf._retrieve_data(data_source)
+
+    assert snow_mock.called_once_with(
+        user='provided_user',
+        account='test_account',
+        password='test_password',
+        authenticator=AuthenticationMethod.OAUTH,
+        database='test',
+        warehouse='test',
+        ocsp_response_cache_filename=None,
+        application='ToucanToco',
+        role=None,
+    )
 
 
 def test_oauth_args_missing_endpoint(mocker):
@@ -355,13 +406,15 @@ def test_oauth_refresh_token(mocker):
     sf.oauth_args = copy.deepcopy(OAUTH_ARGS)
 
     req_mock.return_value.json = lambda: {
-        'access_token': 'baba_au_rhum',
+        'access_token': jwt.encode(
+            {'access_token': 'baba_au_rhum', 'sub': 'mon_super_user'}, key='supersecret'
+        )
     }
 
     sf._retrieve_data(sd)
 
     assert req_mock.call_count == 1
-    assert sf.oauth_args['access_token'] == 'baba_au_rhum'
+    assert sf.oauth_token == req_mock.return_value.json()['access_token']
 
 
 def test_oauth_args_endpoint_not_200(mocker):
@@ -378,13 +431,16 @@ def test_oauth_args_endpoint_not_200(mocker):
     def fake_raise_for_status():
         raise HTTPError('Unauthorized')
 
-    req_mock.return_value.raise_for_status = lambda: fake_raise_for_status
+    req_mock.return_value.ok = False
+    req_mock.return_value.raise_for_status = lambda: fake_raise_for_status()
 
     try:
         sf._retrieve_data(sd)
     except Exception as e:
         assert str(e) == 'Unauthorized'
-    assert req_mock.call_count == 1
+        assert req_mock.call_count == 1
+    else:
+        assert False
 
 
 def test_oauth_args_wrong_type_of_auth(mocker):

--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -345,44 +345,6 @@ def test_specified_oauth_args(mocker):
     assert OAUTH_ARGS['content_type'] == kwargs['headers']['Content-Type']
 
 
-def test_oauth_args_empty_user(mocker):
-    snow_mock = mocker.patch('snowflake.connector.connect')
-    req_mock = mocker.patch('requests.post')
-    req_mock.return_value.json = lambda: {
-        'access_token': jwt.encode({'exp': datetime.now(), 'sub': 'user'}, key='supersecret')
-    }
-
-    sf = copy.deepcopy(sc_oauth)
-    sf.oauth_args = copy.deepcopy(OAUTH_ARGS)
-    sf.user = None
-
-    sf.oauth_token = jwt.encode(
-        {'exp': datetime.now() - timedelta(hours=24), 'sub': 'provided_user'}, key='supersecret'
-    )
-
-    data_source = SnowflakeDataSource(
-        name='test',
-        domain='test',
-        database='test',
-        warehouse='test',
-        query='bar',
-    )
-
-    sf._retrieve_data(data_source)
-
-    assert snow_mock.called_once_with(
-        user='provided_user',
-        account='test_account',
-        password='test_password',
-        authenticator=AuthenticationMethod.OAUTH,
-        database='test',
-        warehouse='test',
-        ocsp_response_cache_filename=None,
-        application='ToucanToco',
-        role=None,
-    )
-
-
 def test_oauth_args_missing_endpoint(mocker):
     mocker.patch('snowflake.connector.connect')
     req_mock = mocker.patch('requests.post')

--- a/toucan_connectors/snowflake/snowflake_connector.py
+++ b/toucan_connectors/snowflake/snowflake_connector.py
@@ -112,11 +112,13 @@ class SnowflakeConnector(ToucanConnector):
 
     def get_connection_params(self):
         res = {
-            'user': self.user,
             'account': self.account,
             'authenticator': self.authentication_method,
             'application': 'ToucanToco',
         }
+
+        if self.user:
+            res['user'] = Template(self.user).render()
 
         if not self.authentication_method:
             # Default to User/Password authentication method if the parameter
@@ -132,8 +134,8 @@ class SnowflakeConnector(ToucanConnector):
                 decoded = jwt.decode(
                     res['token'], verify=False, options={'verify_signature': False}
                 )
-                # Override the default user if we have a sub
-                if 'sub' in decoded:
+                # Override the default user if we have a sub and no user configured
+                if 'sub' in decoded and not self.user:
                     res['user'] = decoded['sub']
 
         if self.role != '':


### PR DESCRIPTION
## Change Summary

This PR fixes two things : 

- The previous code used the original access_token even if a refresh occured
- The user used in case of a oauth authentication was not the one provided by the external IdP but the one that was saved in the connector at its creation; this PR makes the `sub` content supersede the `user` field if providen by the IdP. This PR also makes the `user` field optional since users can be provided through a IdP connection.

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
