### PR TITLE
fix(snowflake): convert parameters to qmark style

### DIFF
--- a/toucan_connectors/snowflake/snowflake_connector.py
+++ b/toucan_connectors/snowflake/snowflake_connector.py
@@ -12,6 +12,7 @@ from jinja2 import Template
 from pydantic import Field, SecretStr, constr, create_model
 from snowflake.connector import DictCursor
 
+from toucan_connectors.common import convert_to_qmark_paramstyle
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -160,6 +161,8 @@ class SnowflakeConnector(ToucanConnector):
                 self.oauth_args['access_token'] = res.json().get('access_token')
 
     def connect(self, **kwargs) -> snowflake.connector.SnowflakeConnection:
+        # This needs to be set before we connect
+        snowflake.connector.paramstyle = 'qmark'
         if self.oauth_args and self.authentication_method == AuthenticationMethod.OAUTH:
             self._refresh_oauth_token()
         connection_params = self.get_connection_params()
@@ -185,7 +188,9 @@ class SnowflakeConnector(ToucanConnector):
 
         Returns: A pandas DataFrame
         """
-        query_res = cursor.execute(query, query_parameters)
+        # Prevent error with dict and array values in the parameter object
+        converted_query, ordered_values = convert_to_qmark_paramstyle(query, query_parameters)
+        query_res = cursor.execute(converted_query, ordered_values)
 
         # https://docs.snowflake.com/en/user-guide/python-connector-api.html#fetch_pandas_all
         # `fetch_pandas_all` will only work with `SELECT` queries, if the


### PR DESCRIPTION
## Change Summary
The parameters value passed from the backend can be incompatible
with pyformat mapping (dict or array values).
I use convert to qmark method that is already used on other connectors
Another way would be to flatten parameters, but it could still leave
some incompatible values (arrays of dict).



## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
