### PR TITLE
fix: pin python snowflake connector version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras_require = {
     'ROK': ['requests', 'pyjwt', 'simplejson'],
     'sap_hana': ['pyhdb>=0.3.4'],
     'soap': ['zeep', 'lxml==4.2.5'],
-    'snowflake': ['snowflake-connector-python', 'pyarrow<0.18'],
+    'snowflake': ['snowflake-connector-python==2.4.1'],
     'toucan_toco': ['toucan_client'],
 }
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
This commit pins the Snowflake python connector to 2.4.1 and removes the previous pin on pyarrow.
