### PR TITLE
feat(facebook ads): Add insights endpoint

### DIFF
--- a/doc/connectors/facebook_ads.md
+++ b/doc/connectors/facebook_ads.md
@@ -33,6 +33,7 @@ DATA_PROVIDERS: [
   * [Campaigns](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group)
   * [Ads under a campaign](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group/ads)
   * [Ads for a specific account](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group/ads)
+  * [Insights](https://developers.facebook.com/docs/marketing-api/insights/)
 
 
 ```javascript

--- a/tests/facebook_ads/test_facebook_ads.py
+++ b/tests/facebook_ads/test_facebook_ads.py
@@ -79,6 +79,19 @@ def test_facebook_ads_ads_under_campaign(connector, data_source, http_get_mock):
     assert given_kwargs['params']['fields'] == 'name'
 
 
+def test_facebook_ads_insights(connector, data_source, http_get_mock):
+    data_source.data_kind = FacebookAdsDataKind.insights
+
+    connector.get_df(data_source)
+
+    given_url, _ = http_get_mock.call_args
+    assert http_get_mock.called_once()
+    assert (
+        given_url[0]
+        == f'https://graph.facebook.com/v10.0/act_{data_source.parameters.get("account_id")}/insights'
+    )
+
+
 def test_facebook_ads_handle_pagination(connector, data_source, http_get_mock, mocker):
     requests_json_mock = mocker.Mock()
     requests_json_mock.side_effect = [

--- a/toucan_connectors/facebook_ads/enums.py
+++ b/toucan_connectors/facebook_ads/enums.py
@@ -5,3 +5,4 @@ class FacebookAdsDataKind(str, Enum):
     campaigns = 'Campaigns'
     ads_under_campaign = 'AdsUnderCampaign'
     all_ads = 'AllAds'
+    insights = 'Insights'

--- a/toucan_connectors/facebook_ads/facebook_ads_connector.py
+++ b/toucan_connectors/facebook_ads/facebook_ads_connector.py
@@ -26,6 +26,7 @@ API_ENDPOINTS_MAPPING = {
     FacebookAdsDataKind.campaigns: 'act_{act_id}/campaigns',
     FacebookAdsDataKind.ads_under_campaign: '{campaign_id}/ads',
     FacebookAdsDataKind.all_ads: 'act_{act_id}/ads',
+    FacebookAdsDataKind.insights: 'act_{act_id}/insights',
 }
 
 AUTHORIZATION_URL = 'https://www.facebook.com/v10.0/dialog/oauth'
@@ -56,6 +57,7 @@ class FacebookAdsDataSource(ToucanDataSource):
             FacebookAdsDataKind.ads_under_campaign: {
                 'campaign_id': self.parameters.get('campaign_id')
             },
+            FacebookAdsDataKind.insights: {'act_id': self.parameters.get('account_id')},
         }
         return urljoin(
             API_BASE_ROUTE,


### PR DESCRIPTION
## Change Summary

This PR adds the support of the Insights endpoint for the Facebook Ads connector

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
