### PR TITLE
chore(version): bump-v0.51.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.51.4',
+    version='0.51.5',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Change Summary

Bump the connectors to the v0.51.5, this version adds:

- Facebook Ads: the access to the `insights` endpoint