### PR TITLE
feat(sql connectors): convert basic jinja to printf templating style

### DIFF
--- a/tests/postgres/test_postgres.py
+++ b/tests/postgres/test_postgres.py
@@ -128,6 +128,24 @@ def test_get_df_db(postgres_connector):
     assert df.shape == (24, 5)
 
 
+def test_get_df_db_jinja_syntax(postgres_connector):
+    data_source_spec = {
+        'domain': 'Postgres test',
+        'type': 'external_database',
+        'name': 'Some Postgres provider',
+        'database': 'postgres_db',
+        'query': 'SELECT * FROM City WHERE Population > {{ max_pop }}',
+        'parameters': {'max_pop': 5000000},
+    }
+    expected_columns = {'id', 'name', 'countrycode', 'district', 'population'}
+    data_source = PostgresDataSource(**data_source_spec)
+    df = postgres_connector.get_df(data_source)
+
+    assert not df.empty
+    assert set(df.columns) == expected_columns
+    assert df.shape == (24, 5)
+
+
 def test_get_df_array_interpolation(postgres_connector):
     data_source_spec = {
         'domain': 'Postgres test',

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -8,6 +8,7 @@ from toucan_connectors.common import (
     NonValidVariable,
     adapt_param_type,
     apply_query_parameters,
+    convert_to_printf_templating_style,
     convert_to_qmark_paramstyle,
     fetch,
     nosql_apply_parameters_to_query,
@@ -311,6 +312,15 @@ def test_convert_pyformat_to_qmark(query, params, expected_query, expected_order
     converted_query, ordered_values = convert_to_qmark_paramstyle(query, params)
     assert ordered_values == expected_ordered_values
     assert converted_query == expected_query
+
+
+def test_convert_to_printf_templating_style():
+    """It should convert jinja templates to printf templates only for valid python identifiers"""
+    query = 'SELECT {{ a }} {{a1}}{{ _a1}} FROM {{ 1a }} {{ aa$%@%}}\n{{aa bb}} hey {{aa_bb }};'
+    expected_result = (
+        'SELECT %(a)s %(a1)s%(_a1)s FROM {{ 1a }} {{ aa$%@%}}\n{{aa bb}} hey %(aa_bb)s;'
+    )
+    assert convert_to_printf_templating_style(query) == expected_result
 
 
 def test_adapt_param_type():

--- a/toucan_connectors/azure_mssql/azure_mssql_connector.py
+++ b/toucan_connectors/azure_mssql/azure_mssql_connector.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pyodbc
 from pydantic import Field, SecretStr, constr
 
+from toucan_connectors.common import convert_to_printf_templating_style
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 CLOUD_HOST = 'database.windows.net'
@@ -56,7 +57,8 @@ class AzureMSSQLConnector(ToucanConnector):
     def _retrieve_data(self, datasource: AzureMSSQLDataSource) -> pd.DataFrame:
         connection = pyodbc.connect(**self.get_connection_params(database=datasource.database))
 
-        df = pd.read_sql(datasource.query, con=connection)
+        query = convert_to_printf_templating_style(datasource.query)
+        df = pd.read_sql(query, con=connection)
 
         connection.close()
         return df

--- a/toucan_connectors/clickhouse/clickhouse_connector.py
+++ b/toucan_connectors/clickhouse/clickhouse_connector.py
@@ -5,7 +5,7 @@ import clickhouse_driver
 import pandas as pd
 from pydantic import Field, SecretStr, constr, create_model
 
-from toucan_connectors.common import adapt_param_type
+from toucan_connectors.common import adapt_param_type, convert_to_printf_templating_style
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -103,13 +103,13 @@ class ClickhouseConnector(ToucanConnector):
             self.get_connection_url(database=data_source.database)
         )
         query_params = data_source.parameters or {}
-        df = pd.read_sql(
+        query = (
             data_source.query
             if data_source.query
-            else f'select * from {data_source.table} limit 50;',
-            con=connection,
-            params=adapt_param_type(query_params),
+            else f'select * from {data_source.table} limit 50;'
         )
+        query = convert_to_printf_templating_style(query)
+        df = pd.read_sql(query, con=connection, params=adapt_param_type(query_params))
 
         connection.close()
 

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -16,6 +16,7 @@ from toucan_data_sdk.utils.helpers import slugify
 
 RE_PARAM = r'%\(([^(%\()]*)\)s'
 RE_JINJA = r'{{([^({{)}]*)}}'
+RE_SINGLE_VAR_JINJA = r'{{\s*([^\W\d]\w*)\s*}}'  # a single identifier, e.g: {{ __foo__ }}
 
 RE_JINJA_ALONE = r'^' + RE_JINJA + '$'
 
@@ -289,6 +290,15 @@ def convert_to_qmark_paramstyle(query_string: str, params_values: dict) -> str:
             flattened_values.append(val)
 
     return re.sub(RE_NAMED_PARAM, '?', query_string), flattened_values
+
+
+def convert_to_printf_templating_style(query_string: str) -> str:
+    """
+    Replaces '{{ foo }}' by '%(foo)s' in the query.
+    Useful for sql-based connectors, which, for security reasons, cannot be rendered
+    with jinja.
+    """
+    return re.sub(RE_SINGLE_VAR_JINJA, r'%(\g<1>)s', query_string)
 
 
 def adapt_param_type(params):

--- a/toucan_connectors/google_cloud_mysql/google_cloud_mysql_connector.py
+++ b/toucan_connectors/google_cloud_mysql/google_cloud_mysql_connector.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pymysql
 from pydantic import Field, SecretStr, constr
 
+from toucan_connectors.common import convert_to_printf_templating_style
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 
@@ -60,7 +61,8 @@ class GoogleCloudMySQLConnector(ToucanConnector):
     def _retrieve_data(self, data_source: GoogleCloudMySQLDataSource) -> pd.DataFrame:
         connection = pymysql.connect(**self.get_connection_params(database=data_source.database))
 
-        df = pd.read_sql(data_source.query, con=connection)
+        query = convert_to_printf_templating_style(data_source.query)
+        df = pd.read_sql(query, con=connection)
 
         connection.close()
 

--- a/toucan_connectors/mssql/mssql_connector.py
+++ b/toucan_connectors/mssql/mssql_connector.py
@@ -5,7 +5,7 @@ import pyodbc
 from jinja2 import Template
 from pydantic import Field, SecretStr, constr, create_model
 
-from toucan_connectors.common import convert_to_qmark_paramstyle
+from toucan_connectors.common import convert_to_printf_templating_style, convert_to_qmark_paramstyle
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -115,7 +115,8 @@ class MSSQLConnector(ToucanConnector):
         connection = pyodbc.connect(**self.get_connection_params(datasource.database))
 
         query_params = datasource.parameters or {}
-        query = Template(datasource.query).render({'user': query_params.get('user', {})})
+        query = convert_to_printf_templating_style(datasource.query)
+        query = Template(query).render({'user': query_params.get('user', {})})
         converted_query, ordered_values = convert_to_qmark_paramstyle(query, query_params)
         df = pd.read_sql(converted_query, con=connection, params=ordered_values)
 

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -8,7 +8,7 @@ import pymysql
 from pydantic import Field, SecretStr, constr, create_model
 from pymysql.constants import CR, ER
 
-from toucan_connectors.common import ConnectorStatus
+from toucan_connectors.common import ConnectorStatus, convert_to_printf_templating_style
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -366,7 +366,7 @@ class MySQLConnector(ToucanConnector):
 
         # ----- Prepare -----
         if datasource.query:
-            query = datasource.query
+            query = convert_to_printf_templating_style(datasource.query)
             # Extract table name for logging purpose (see below)
             m = re.search(
                 r'from\s*(?P<table>[^\s]+)\s*(where|order by|group by|limit)?', query, re.I

--- a/toucan_connectors/odbc/odbc_connector.py
+++ b/toucan_connectors/odbc/odbc_connector.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pyodbc
 from pydantic import Field, constr
 
-from toucan_connectors.common import convert_to_qmark_paramstyle
+from toucan_connectors.common import convert_to_printf_templating_style, convert_to_qmark_paramstyle
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 
@@ -35,9 +35,8 @@ class OdbcConnector(ToucanConnector):
     def _retrieve_data(self, datasource: OdbcDataSource) -> pd.DataFrame:
 
         connection = pyodbc.connect(self.connection_string, **self.get_connection_params())
-        converted_query, ordered_values = convert_to_qmark_paramstyle(
-            datasource.query, datasource.parameters
-        )
+        query = convert_to_printf_templating_style(datasource.query)
+        converted_query, ordered_values = convert_to_qmark_paramstyle(query, datasource.parameters)
         df = pd.read_sql(converted_query, con=connection, params=ordered_values)
         connection.close()
         return df

--- a/toucan_connectors/oracle_sql/oracle_sql_connector.py
+++ b/toucan_connectors/oracle_sql/oracle_sql_connector.py
@@ -4,6 +4,7 @@ import cx_Oracle
 import pandas as pd
 from pydantic import Field, SecretStr, constr, create_model
 
+from toucan_connectors.common import convert_to_printf_templating_style
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -79,6 +80,7 @@ class OracleSQLConnector(ToucanConnector):
         connection = cx_Oracle.connect(**self.get_connection_params())
 
         query = data_source.query[:-1] if data_source.query.endswith(';') else data_source.query
+        query = convert_to_printf_templating_style(query)
         df = pd.read_sql(query, con=connection)
 
         connection.close()

--- a/toucan_connectors/postgres/postgresql_connector.py
+++ b/toucan_connectors/postgres/postgresql_connector.py
@@ -4,7 +4,7 @@ import pandas as pd
 import psycopg2 as pgsql
 from pydantic import Field, SecretStr, constr, create_model
 
-from toucan_connectors.common import adapt_param_type
+from toucan_connectors.common import adapt_param_type, convert_to_printf_templating_style
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -113,7 +113,8 @@ class PostgresConnector(ToucanConnector):
         connection = pgsql.connect(**self.get_connection_params(database=data_source.database))
 
         query_params = data_source.parameters or {}
-        df = pd.read_sql(data_source.query, con=connection, params=adapt_param_type(query_params))
+        query = convert_to_printf_templating_style(data_source.query)
+        df = pd.read_sql(query, con=connection, params=adapt_param_type(query_params))
 
         connection.close()
 

--- a/toucan_connectors/sap_hana/sap_hana_connector.py
+++ b/toucan_connectors/sap_hana/sap_hana_connector.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pyhdb
 from pydantic import Field, SecretStr, constr
 
+from toucan_connectors.common import convert_to_printf_templating_style
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 
@@ -33,7 +34,8 @@ class SapHanaConnector(ToucanConnector):
             self.host, self.port, self.user, self.password.get_secret_value()
         )
 
-        df = pd.read_sql(data_source.query, con=connection)
+        query = convert_to_printf_templating_style(data_source.query)
+        df = pd.read_sql(query, con=connection)
 
         connection.close()
 


### PR DESCRIPTION
SQL connectors (mysql, postgres, mssql, etc.) don't handle jinja templating (to avoid sql injections). They only handle printf-style templating (i.e `%(var)s`).

This PR aims to provide basic functionality of jinja templating for these connectors, by turning `{{ foo }}` into `%(foo)s`.

:warning: this is limited to jinja syntax (mustaches) arount a single valid python identifier. It does not work for `{{ foo.bar }}` for example.