### PR TITLE
refactor(sql connectors): add util pandas_read_sql

### DIFF
--- a/tests/azure_mssql/test_azure_mssql.py
+++ b/tests/azure_mssql/test_azure_mssql.py
@@ -42,4 +42,4 @@ def test_gcmysql_get_df(mocker):
         password='ilovetoucan',
         driver='{ODBC Driver 17 for SQL Server}',
     )
-    reasq.assert_called_once_with('my_query', con=snock())
+    reasq.assert_called_once_with('my_query', con=snock(), params=None)

--- a/tests/google_cloud_mysql/test_google_cloud_mysql.py
+++ b/tests/google_cloud_mysql/test_google_cloud_mysql.py
@@ -44,4 +44,4 @@ def test_gcmysql_get_df(mocker):
         conv=conv,
         cursorclass=pymysql.cursors.DictCursor,
     )
-    reasq.assert_called_once_with('my_query', con=snock())
+    reasq.assert_called_once_with('my_query', con=snock(), params=None)

--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -261,6 +261,22 @@ def test_get_df_db(mysql_connector):
     assert df.shape == (24, 5)
 
 
+def test_get_df_forbidden_table_interpolation(mysql_connector):
+    data_source_spec = {
+        'domain': 'MySQL test',
+        'type': 'external_database',
+        'name': 'Some MySQL provider',
+        'database': 'mysql_db',
+        'query': 'SELECT * FROM %(tablename)s WHERE Population > 5000000',
+        'parameters': {'tablename': 'City'},
+    }
+
+    data_source = MySQLDataSource(**data_source_spec)
+    with pytest.raises(pd.io.sql.DatabaseError) as e:
+        mysql_connector.get_df(data_source)
+    assert 'interpolating table name is forbidden' in str(e.value)
+
+
 def test_clean_response():
     """ It should replace None by np.nan and decode bytes data """
     response = [{'name': 'fway', 'age': 13}, {'name': b'zbruh', 'age': None}]

--- a/tests/oracle_sql/test_oracle_sql.py
+++ b/tests/oracle_sql/test_oracle_sql.py
@@ -50,7 +50,7 @@ def test_oracle_get_df(mocker):
 
     snock.assert_called_once_with(user='system', password='oracle', dsn='localhost:22/xe')
 
-    reasq.assert_called_once_with('SELECT * FROM City', con=snock())
+    reasq.assert_called_once_with('SELECT * FROM City', con=snock(), params=None)
 
 
 def test_get_df_db(oracle_connector):

--- a/tests/postgres/test_postgres.py
+++ b/tests/postgres/test_postgres.py
@@ -146,6 +146,21 @@ def test_get_df_db_jinja_syntax(postgres_connector):
     assert df.shape == (24, 5)
 
 
+def test_get_df_forbidden_table_interpolation(postgres_connector):
+    data_source_spec = {
+        'domain': 'Postgres test',
+        'type': 'external_database',
+        'name': 'Some Postgres provider',
+        'database': 'postgres_db',
+        'query': 'SELECT * FROM %(tablename)s WHERE Population > 5000000',
+        'parameters': {'tablename': 'City'},
+    }
+    data_source = PostgresDataSource(**data_source_spec)
+    with pytest.raises(pd.io.sql.DatabaseError) as e:
+        postgres_connector.get_df(data_source)
+    assert 'interpolating table name is forbidden' in str(e.value)
+
+
 def test_get_df_array_interpolation(postgres_connector):
     data_source_spec = {
         'domain': 'Postgres test',

--- a/tests/sap_hana/test_sap_hana.py
+++ b/tests/sap_hana/test_sap_hana.py
@@ -26,4 +26,4 @@ def test_saphana_get_df(mocker):
     saphana_connector.get_df(ds)
 
     snock.assert_called_once_with('localhost', 22, 'ubuntu', 'truc')
-    reasq.assert_called_once_with('my_query', con=snock())
+    reasq.assert_called_once_with('my_query', con=snock(), params=None)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timedelta
 
+import pandas as pd
 import pytest
 from aiohttp import web
+from pytest_mock import MockFixture
 
 from toucan_connectors.common import (
     ConnectorStatus,
@@ -14,6 +16,7 @@ from toucan_connectors.common import (
     fetch,
     is_interpolating_table_name,
     nosql_apply_parameters_to_query,
+    pandas_read_sql,
 )
 
 
@@ -337,3 +340,35 @@ def test_extract_table_name():
 def test_is_interpolating_table_name():
     assert is_interpolating_table_name('select * from mytable;') is False
     assert is_interpolating_table_name('SELECT * FROM %(plop)s WHERE age > 21;')
+
+
+def test_pandas_read_sql_forbidden_interpolation(mocker: MockFixture):
+    """
+    It should enhance the error provided by pandas' read_sql when someone tries to template a table name
+    """
+    mocker.patch(
+        'toucan_connectors.common.pd.read_sql', side_effect=pd.io.sql.DatabaseError('Some error')
+    )
+    with pytest.raises(pd.io.sql.DatabaseError) as e:
+        pandas_read_sql(
+            query='SELECT * FROM %(tablename)s WHERE Population > 5000000',
+            con='sample_connexion',
+            params={'tablename': 'City'},
+        )
+    assert 'interpolating table name is forbidden' in str(e.value)
+
+
+def test_pandas_read_sql_error(mocker: MockFixture):
+    """
+    It should raise the error raised by pandas' read_sql
+    """
+    mocker.patch(
+        'toucan_connectors.common.pd.read_sql', side_effect=pd.io.sql.DatabaseError('Some error')
+    )
+    with pytest.raises(pd.io.sql.DatabaseError) as e:
+        pandas_read_sql(
+            query='SELECT * FROM CITY WHERE Population > %(max_pop)s',
+            con='sample_connexion',
+            params={'max_pop': 1_000_000},
+        )
+    assert 'Some error' in str(e.value)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -10,7 +10,9 @@ from toucan_connectors.common import (
     apply_query_parameters,
     convert_to_printf_templating_style,
     convert_to_qmark_paramstyle,
+    extract_table_name,
     fetch,
+    is_interpolating_table_name,
     nosql_apply_parameters_to_query,
 )
 
@@ -325,3 +327,13 @@ def test_convert_to_printf_templating_style():
 
 def test_adapt_param_type():
     assert adapt_param_type({'test': [1, 2], 'id': 1}) == {'test': (1, 2), 'id': 1}
+
+
+def test_extract_table_name():
+    assert extract_table_name('select * from mytable;') == 'mytable'
+    assert extract_table_name('SELECT * FROM %(plop)s WHERE age > 21;') == '%(plop)s'
+
+
+def test_is_interpolating_table_name():
+    assert is_interpolating_table_name('select * from mytable;') is False
+    assert is_interpolating_table_name('SELECT * FROM %(plop)s WHERE age > 21;')

--- a/toucan_connectors/azure_mssql/azure_mssql_connector.py
+++ b/toucan_connectors/azure_mssql/azure_mssql_connector.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pyodbc
 from pydantic import Field, SecretStr, constr
 
-from toucan_connectors.common import convert_to_printf_templating_style, pandas_read_sql
+from toucan_connectors.common import pandas_read_sql
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 CLOUD_HOST = 'database.windows.net'
@@ -57,8 +57,7 @@ class AzureMSSQLConnector(ToucanConnector):
     def _retrieve_data(self, datasource: AzureMSSQLDataSource) -> pd.DataFrame:
         connection = pyodbc.connect(**self.get_connection_params(database=datasource.database))
 
-        query = convert_to_printf_templating_style(datasource.query)
-        df = pandas_read_sql(query, con=connection)
+        df = pandas_read_sql(datasource.query, con=connection)
 
         connection.close()
         return df

--- a/toucan_connectors/azure_mssql/azure_mssql_connector.py
+++ b/toucan_connectors/azure_mssql/azure_mssql_connector.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pyodbc
 from pydantic import Field, SecretStr, constr
 
-from toucan_connectors.common import convert_to_printf_templating_style
+from toucan_connectors.common import convert_to_printf_templating_style, pandas_read_sql
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 CLOUD_HOST = 'database.windows.net'
@@ -58,7 +58,7 @@ class AzureMSSQLConnector(ToucanConnector):
         connection = pyodbc.connect(**self.get_connection_params(database=datasource.database))
 
         query = convert_to_printf_templating_style(datasource.query)
-        df = pd.read_sql(query, con=connection)
+        df = pandas_read_sql(query, con=connection)
 
         connection.close()
         return df

--- a/toucan_connectors/clickhouse/clickhouse_connector.py
+++ b/toucan_connectors/clickhouse/clickhouse_connector.py
@@ -2,10 +2,13 @@ from contextlib import suppress
 from typing import Any, Dict, Type
 
 import clickhouse_driver
-import pandas as pd
 from pydantic import Field, SecretStr, constr, create_model
 
-from toucan_connectors.common import adapt_param_type, convert_to_printf_templating_style
+from toucan_connectors.common import (
+    adapt_param_type,
+    convert_to_printf_templating_style,
+    pandas_read_sql,
+)
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -109,7 +112,7 @@ class ClickhouseConnector(ToucanConnector):
             else f'select * from {data_source.table} limit 50;'
         )
         query = convert_to_printf_templating_style(query)
-        df = pd.read_sql(query, con=connection, params=adapt_param_type(query_params))
+        df = pandas_read_sql(query, con=connection, params=adapt_param_type(query_params))
 
         connection.close()
 

--- a/toucan_connectors/clickhouse/clickhouse_connector.py
+++ b/toucan_connectors/clickhouse/clickhouse_connector.py
@@ -4,11 +4,7 @@ from typing import Any, Dict, Type
 import clickhouse_driver
 from pydantic import Field, SecretStr, constr, create_model
 
-from toucan_connectors.common import (
-    adapt_param_type,
-    convert_to_printf_templating_style,
-    pandas_read_sql,
-)
+from toucan_connectors.common import pandas_read_sql
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -111,8 +107,7 @@ class ClickhouseConnector(ToucanConnector):
             if data_source.query
             else f'select * from {data_source.table} limit 50;'
         )
-        query = convert_to_printf_templating_style(query)
-        df = pandas_read_sql(query, con=connection, params=adapt_param_type(query_params))
+        df = pandas_read_sql(query, con=connection, params=query_params, adapt_params=True)
 
         connection.close()
 

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -310,6 +310,24 @@ def adapt_param_type(params):
     return {k: (tuple(v) if isinstance(v, list) else v) for (k, v) in params.items()}
 
 
-def pandas_read_sql(query, con, params=None, **kwargs) -> pd.DataFrame:
+def pandas_read_sql(
+    query: str,
+    con,
+    params=None,
+    adapt_params: bool = False,
+    convert_to_qmark: bool = False,
+    convert_to_printf: bool = True,
+    render_user: bool = False,
+    **kwargs,
+) -> pd.DataFrame:
+    if convert_to_printf:
+        query = convert_to_printf_templating_style(query)
+    if render_user:
+        query = Template(query).render({'user': params.get('user', {})})
+    if convert_to_qmark:
+        query, params = convert_to_qmark_paramstyle(query, params)
+    if adapt_params:
+        params = adapt_param_type(params)
+
     df = pd.read_sql(query, con=con, params=params, **kwargs)
     return df

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -5,6 +5,7 @@ import re
 from copy import deepcopy
 from typing import List, Optional, Tuple
 
+import pandas as pd
 import pyjq
 from aiohttp import ClientSession
 from jinja2 import Environment, StrictUndefined, Template, meta
@@ -307,3 +308,8 @@ def adapt_param_type(params):
     postgres to correctly interpret them as an array.
     """
     return {k: (tuple(v) if isinstance(v, list) else v) for (k, v) in params.items()}
+
+
+def pandas_read_sql(query, con, params=None, **kwargs) -> pd.DataFrame:
+    df = pd.read_sql(query, con=con, params=params, **kwargs)
+    return df

--- a/toucan_connectors/google_cloud_mysql/google_cloud_mysql_connector.py
+++ b/toucan_connectors/google_cloud_mysql/google_cloud_mysql_connector.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pymysql
 from pydantic import Field, SecretStr, constr
 
-from toucan_connectors.common import convert_to_printf_templating_style
+from toucan_connectors.common import convert_to_printf_templating_style, pandas_read_sql
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 
@@ -62,7 +62,7 @@ class GoogleCloudMySQLConnector(ToucanConnector):
         connection = pymysql.connect(**self.get_connection_params(database=data_source.database))
 
         query = convert_to_printf_templating_style(data_source.query)
-        df = pd.read_sql(query, con=connection)
+        df = pandas_read_sql(query, con=connection)
 
         connection.close()
 

--- a/toucan_connectors/google_cloud_mysql/google_cloud_mysql_connector.py
+++ b/toucan_connectors/google_cloud_mysql/google_cloud_mysql_connector.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pymysql
 from pydantic import Field, SecretStr, constr
 
-from toucan_connectors.common import convert_to_printf_templating_style, pandas_read_sql
+from toucan_connectors.common import pandas_read_sql
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 
@@ -61,8 +61,7 @@ class GoogleCloudMySQLConnector(ToucanConnector):
     def _retrieve_data(self, data_source: GoogleCloudMySQLDataSource) -> pd.DataFrame:
         connection = pymysql.connect(**self.get_connection_params(database=data_source.database))
 
-        query = convert_to_printf_templating_style(data_source.query)
-        df = pandas_read_sql(query, con=connection)
+        df = pandas_read_sql(data_source.query, con=connection)
 
         connection.close()
 

--- a/toucan_connectors/mssql/mssql_connector.py
+++ b/toucan_connectors/mssql/mssql_connector.py
@@ -1,11 +1,14 @@
 from contextlib import suppress
 
-import pandas as pd
 import pyodbc
 from jinja2 import Template
 from pydantic import Field, SecretStr, constr, create_model
 
-from toucan_connectors.common import convert_to_printf_templating_style, convert_to_qmark_paramstyle
+from toucan_connectors.common import (
+    convert_to_printf_templating_style,
+    convert_to_qmark_paramstyle,
+    pandas_read_sql,
+)
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -118,7 +121,7 @@ class MSSQLConnector(ToucanConnector):
         query = convert_to_printf_templating_style(datasource.query)
         query = Template(query).render({'user': query_params.get('user', {})})
         converted_query, ordered_values = convert_to_qmark_paramstyle(query, query_params)
-        df = pd.read_sql(converted_query, con=connection, params=ordered_values)
+        df = pandas_read_sql(converted_query, con=connection, params=ordered_values)
 
         connection.close()
         return df

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -3,12 +3,15 @@ from contextlib import suppress
 from typing import Optional
 
 import numpy as np
-import pandas as pd
 import pymysql
 from pydantic import Field, SecretStr, constr, create_model
 from pymysql.constants import CR, ER
 
-from toucan_connectors.common import ConnectorStatus, convert_to_printf_templating_style
+from toucan_connectors.common import (
+    ConnectorStatus,
+    convert_to_printf_templating_style,
+    pandas_read_sql,
+)
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -380,7 +383,7 @@ class MySQLConnector(ToucanConnector):
         query_params = datasource.parameters or {}
 
         if not datasource.follow_relations:
-            df = pd.read_sql(query, con=connection, params=query_params)
+            df = pandas_read_sql(query, con=connection, params=query_params)
             df = self.decode_df(df)
             connection.close()
             return df
@@ -388,7 +391,7 @@ class MySQLConnector(ToucanConnector):
         # list used because we cannot reassign a variable to update the dataframe.
         # After the merge: append the new DataFrame and remove the pop the first
         # element.
-        lres = [pd.read_sql(query, con=connection, params=query_params)]
+        lres = [pandas_read_sql(query, con=connection, params=query_params)]
         MySQLConnector.logger.info(f'{table} : dumped first DataFrame')
 
         # ----- Merge -----
@@ -414,7 +417,7 @@ class MySQLConnector(ToucanConnector):
                 f"inside {table_info['f_table']}"
             )
 
-            f_df = pd.read_sql(f'select * from {table_info["f_table"]}', con=connection)
+            f_df = pandas_read_sql(f'select * from {table_info["f_table"]}', con=connection)
             suffixes = ('_' + table, '_' + table_info['f_table'])
             lres.append(
                 self._merge_drop(

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -7,11 +7,7 @@ import pymysql
 from pydantic import Field, SecretStr, constr, create_model
 from pymysql.constants import CR, ER
 
-from toucan_connectors.common import (
-    ConnectorStatus,
-    convert_to_printf_templating_style,
-    pandas_read_sql,
-)
+from toucan_connectors.common import ConnectorStatus, pandas_read_sql
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -369,7 +365,7 @@ class MySQLConnector(ToucanConnector):
 
         # ----- Prepare -----
         if datasource.query:
-            query = convert_to_printf_templating_style(datasource.query)
+            query = datasource.query
             # Extract table name for logging purpose (see below)
             m = re.search(
                 r'from\s*(?P<table>[^\s]+)\s*(where|order by|group by|limit)?', query, re.I

--- a/toucan_connectors/odbc/odbc_connector.py
+++ b/toucan_connectors/odbc/odbc_connector.py
@@ -2,11 +2,7 @@ import pandas as pd
 import pyodbc
 from pydantic import Field, constr
 
-from toucan_connectors.common import (
-    convert_to_printf_templating_style,
-    convert_to_qmark_paramstyle,
-    pandas_read_sql,
-)
+from toucan_connectors.common import pandas_read_sql
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 
@@ -39,8 +35,8 @@ class OdbcConnector(ToucanConnector):
     def _retrieve_data(self, datasource: OdbcDataSource) -> pd.DataFrame:
 
         connection = pyodbc.connect(self.connection_string, **self.get_connection_params())
-        query = convert_to_printf_templating_style(datasource.query)
-        converted_query, ordered_values = convert_to_qmark_paramstyle(query, datasource.parameters)
-        df = pandas_read_sql(converted_query, con=connection, params=ordered_values)
+        df = pandas_read_sql(
+            datasource.query, con=connection, params=datasource.parameters, convert_to_qmark=True
+        )
         connection.close()
         return df

--- a/toucan_connectors/odbc/odbc_connector.py
+++ b/toucan_connectors/odbc/odbc_connector.py
@@ -2,7 +2,11 @@ import pandas as pd
 import pyodbc
 from pydantic import Field, constr
 
-from toucan_connectors.common import convert_to_printf_templating_style, convert_to_qmark_paramstyle
+from toucan_connectors.common import (
+    convert_to_printf_templating_style,
+    convert_to_qmark_paramstyle,
+    pandas_read_sql,
+)
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 
@@ -37,6 +41,6 @@ class OdbcConnector(ToucanConnector):
         connection = pyodbc.connect(self.connection_string, **self.get_connection_params())
         query = convert_to_printf_templating_style(datasource.query)
         converted_query, ordered_values = convert_to_qmark_paramstyle(query, datasource.parameters)
-        df = pd.read_sql(converted_query, con=connection, params=ordered_values)
+        df = pandas_read_sql(converted_query, con=connection, params=ordered_values)
         connection.close()
         return df

--- a/toucan_connectors/oracle_sql/oracle_sql_connector.py
+++ b/toucan_connectors/oracle_sql/oracle_sql_connector.py
@@ -4,7 +4,7 @@ import cx_Oracle
 import pandas as pd
 from pydantic import Field, SecretStr, constr, create_model
 
-from toucan_connectors.common import convert_to_printf_templating_style
+from toucan_connectors.common import convert_to_printf_templating_style, pandas_read_sql
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -81,7 +81,7 @@ class OracleSQLConnector(ToucanConnector):
 
         query = data_source.query[:-1] if data_source.query.endswith(';') else data_source.query
         query = convert_to_printf_templating_style(query)
-        df = pd.read_sql(query, con=connection)
+        df = pandas_read_sql(query, con=connection)
 
         connection.close()
 

--- a/toucan_connectors/oracle_sql/oracle_sql_connector.py
+++ b/toucan_connectors/oracle_sql/oracle_sql_connector.py
@@ -4,7 +4,7 @@ import cx_Oracle
 import pandas as pd
 from pydantic import Field, SecretStr, constr, create_model
 
-from toucan_connectors.common import convert_to_printf_templating_style, pandas_read_sql
+from toucan_connectors.common import pandas_read_sql
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -80,7 +80,6 @@ class OracleSQLConnector(ToucanConnector):
         connection = cx_Oracle.connect(**self.get_connection_params())
 
         query = data_source.query[:-1] if data_source.query.endswith(';') else data_source.query
-        query = convert_to_printf_templating_style(query)
         df = pandas_read_sql(query, con=connection)
 
         connection.close()

--- a/toucan_connectors/postgres/postgresql_connector.py
+++ b/toucan_connectors/postgres/postgresql_connector.py
@@ -1,10 +1,13 @@
 from contextlib import suppress
 
-import pandas as pd
 import psycopg2 as pgsql
 from pydantic import Field, SecretStr, constr, create_model
 
-from toucan_connectors.common import adapt_param_type, convert_to_printf_templating_style
+from toucan_connectors.common import (
+    adapt_param_type,
+    convert_to_printf_templating_style,
+    pandas_read_sql,
+)
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -114,7 +117,7 @@ class PostgresConnector(ToucanConnector):
 
         query_params = data_source.parameters or {}
         query = convert_to_printf_templating_style(data_source.query)
-        df = pd.read_sql(query, con=connection, params=adapt_param_type(query_params))
+        df = pandas_read_sql(query, con=connection, params=adapt_param_type(query_params))
 
         connection.close()
 

--- a/toucan_connectors/postgres/postgresql_connector.py
+++ b/toucan_connectors/postgres/postgresql_connector.py
@@ -3,11 +3,7 @@ from contextlib import suppress
 import psycopg2 as pgsql
 from pydantic import Field, SecretStr, constr, create_model
 
-from toucan_connectors.common import (
-    adapt_param_type,
-    convert_to_printf_templating_style,
-    pandas_read_sql,
-)
+from toucan_connectors.common import pandas_read_sql
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -116,8 +112,9 @@ class PostgresConnector(ToucanConnector):
         connection = pgsql.connect(**self.get_connection_params(database=data_source.database))
 
         query_params = data_source.parameters or {}
-        query = convert_to_printf_templating_style(data_source.query)
-        df = pandas_read_sql(query, con=connection, params=adapt_param_type(query_params))
+        df = pandas_read_sql(
+            data_source.query, con=connection, params=query_params, adapt_params=True
+        )
 
         connection.close()
 

--- a/toucan_connectors/sap_hana/sap_hana_connector.py
+++ b/toucan_connectors/sap_hana/sap_hana_connector.py
@@ -1,7 +1,7 @@
 import pyhdb
 from pydantic import Field, SecretStr, constr
 
-from toucan_connectors.common import convert_to_printf_templating_style, pandas_read_sql
+from toucan_connectors.common import pandas_read_sql
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 
@@ -33,8 +33,7 @@ class SapHanaConnector(ToucanConnector):
             self.host, self.port, self.user, self.password.get_secret_value()
         )
 
-        query = convert_to_printf_templating_style(data_source.query)
-        df = pandas_read_sql(query, con=connection)
+        df = pandas_read_sql(data_source.query, con=connection)
 
         connection.close()
 

--- a/toucan_connectors/sap_hana/sap_hana_connector.py
+++ b/toucan_connectors/sap_hana/sap_hana_connector.py
@@ -1,8 +1,7 @@
-import pandas as pd
 import pyhdb
 from pydantic import Field, SecretStr, constr
 
-from toucan_connectors.common import convert_to_printf_templating_style
+from toucan_connectors.common import convert_to_printf_templating_style, pandas_read_sql
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 
 
@@ -35,7 +34,7 @@ class SapHanaConnector(ToucanConnector):
         )
 
         query = convert_to_printf_templating_style(data_source.query)
-        df = pd.read_sql(query, con=connection)
+        df = pandas_read_sql(query, con=connection)
 
         connection.close()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Centralize sql query manipulations in a dedicated util, so it's easier to add or modify common behaviours.

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
