### PR TITLE
fix(nosql apply parameters to query): keep str type when appropriate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.51.6',
+    version='0.51.7',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -181,6 +181,17 @@ def test_apply_parameter_to_query_do_nothing():
             {'entity_id': 1, 'entity_array': [True]},
             {'mixed': [1, True]},
         ),
+        # 'data' should remain a string in these cases:
+        (
+            {'data': '["{{ my_var }}", "bar"]'},
+            {'my_var': 'foo'},
+            {'data': '["foo", "bar"]'},
+        ),
+        (
+            {'data': '{"x": "{{ my_var }}", "y": "42"}'},
+            {'my_var': 'foo'},
+            {'data': '{"x": "foo", "y": "42"}'},
+        ),
     ],
 )
 def test_nosql_apply_parameters_to_query(query, params, expected):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -192,6 +192,31 @@ def test_apply_parameter_to_query_do_nothing():
             {'my_var': 'foo'},
             {'data': '{"x": "foo", "y": "42"}'},
         ),
+        # tests with {% ... %}
+        (
+            {
+                'data': '{%if count %}{{ count }}{%else%}No{%endif%} chair{% if count != 1 %}s{% endif %}'
+            },
+            {'count': 0},
+            {'data': 'No chairs'},
+        ),
+        (
+            {
+                'data': '{%if count %}{{ count }}{%else%}No{%endif%} chair{% if count != 1 %}s{% endif %}'
+            },
+            {'count': 1},
+            {'data': '1 chair'},
+        ),
+        (
+            {'data': '{%if obj %}{{ obj }}{%else%}Nothing{%endif%}'},
+            {'obj': 0},
+            {'data': 'Nothing'},
+        ),
+        (
+            {'data': '{%if obj %}{{ obj }}{%else%}Nothing{%endif%}'},
+            {'obj': 1},
+            {'data': 1},
+        ),
     ],
 )
 def test_nosql_apply_parameters_to_query(query, params, expected):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

In some cases, we used to lose the `str` type when using the util nosql_apply_parameters_to_query, leading to errors.

<!-- Please give a short summary of the changes. -->


## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
