### PR TITLE
feat(google sheets2): the GoogleSheets2 can now parse dates

### DIFF
--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 from unittest.mock import Mock
 
@@ -279,3 +280,24 @@ def test_schema_fields_order(con, ds):
     assert schema_props_keys[0] == 'domain'
     assert schema_props_keys[1] == 'spreadsheet_id'
     assert schema_props_keys[2] == 'sheet'
+
+
+def test_parse_datetime(mocker, con):
+    ds = GoogleSheets2DataSource(
+        name='test_name',
+        domain='test_domain',
+        sheet='Constants',
+        spreadsheet_id='1SMnhnmBm-Tup3SfhS03McCf6S4pS2xqjI6CAXSSBpHU',
+        parse_dates=['a_date'],
+    )
+    fake_result = {
+        'metadata': '...',
+        'values': [
+            ['country', 'city', 'a_date'],
+            ['France', 'Paris', '2001-02-02'],
+            ['England', 'London', '2010-08-09'],
+        ],
+    }
+    mocker.patch(f'{import_path}.fetch', return_value=fake_result)
+    df, rows = con.get_slice(ds, limit=2)
+    assert df['a_date'].iloc[0] == datetime.datetime(year=2001, month=2, day=2)

--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -187,7 +187,7 @@ def test_spreadsheet_without_sheet(mocker, con, ds_without_sheet):
     )
     assert (
         fetch_mock.call_args_list[1][0][0]
-        == 'https://sheets.googleapis.com/v4/spreadsheets/1SMnhnmBm-Tup3SfhS03McCf6S4pS2xqjI6CAXSSBpHU/values/Foo?valueRenderOption=UNFORMATTED_VALUE'
+        == 'https://sheets.googleapis.com/v4/spreadsheets/1SMnhnmBm-Tup3SfhS03McCf6S4pS2xqjI6CAXSSBpHU/values/Foo?valueRenderOption=UNFORMATTED_VALUE&DateTimeRenderOption=FORMATTED_STRING'
     )
 
     assert df.shape == (2, 2)

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -58,7 +58,6 @@ def test_transform_with_jq():
     ]
 
 
-@pytest.mark.skip(reason='This uses an real api. https://jsonplaceholder.typicode.com is down')
 def test_get_df(connector, data_source):
     df = connector.get_df(data_source)
     assert df.shape == (500, 5)

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -58,6 +58,7 @@ def test_transform_with_jq():
     ]
 
 
+@pytest.mark.skip(reason='This uses an real api. https://jsonplaceholder.typicode.com is down')
 def test_get_df(connector, data_source):
     df = connector.get_df(data_source)
     assert df.shape == (500, 5)


### PR DESCRIPTION
## Change Summary

GoogleSheets2DataSource now contains a parse_dates field that contains the name of column which content will be treated as datetime

## Related issue number

:x:

## Checklist

* [X] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
