### PR TITLE
fix(snowflake): fix snowflake parametrization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.51.10',
+    version='0.51.11',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -346,6 +346,12 @@ def test_connector_status():
             'select * from inventory where quantity in (?,?);',
             [150, 154],
         ),
+        (
+            'select * from test where price > %(__front_var_0__)s;',
+            {'__front_var_0__': 1},
+            'select * from test where price > ?;',
+            [1],
+        ),
     ],
 )
 def test_convert_pyformat_to_qmark(query, params, expected_query, expected_ordered_values):

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -26,7 +26,7 @@ RE_JINJA_ALONE_IN_STRING = [RE_JINJA + r'([ )])', RE_JINJA + r'()$']
 
 RE_SET_KEEP_TYPE = r'{{__keep_type__\1}}\2'
 RE_GET_KEEP_TYPE = r'{{(__keep_type__[^({{)}]*)}}'
-RE_NAMED_PARAM = r'%\([a-zA-Z1-9_]*\)s'
+RE_NAMED_PARAM = r'%\([a-zA-Z0-9_]*\)s'
 
 
 class NonValidVariable(Exception):

--- a/toucan_connectors/snowflake/snowflake_connector.py
+++ b/toucan_connectors/snowflake/snowflake_connector.py
@@ -12,7 +12,11 @@ from jinja2 import Template
 from pydantic import Field, SecretStr, constr, create_model
 from snowflake.connector import DictCursor
 
-from toucan_connectors.common import ConnectorStatus, convert_to_qmark_paramstyle
+from toucan_connectors.common import (
+    ConnectorStatus,
+    convert_to_printf_templating_style,
+    convert_to_qmark_paramstyle,
+)
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
@@ -256,6 +260,7 @@ class SnowflakeConnector(ToucanConnector):
         Returns: A pandas DataFrame
         """
         # Prevent error with dict and array values in the parameter object
+        query = convert_to_printf_templating_style(query)
         converted_query, ordered_values = convert_to_qmark_paramstyle(query, query_parameters)
         query_res = cursor.execute(converted_query, ordered_values)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

- fix(snowflake): conversion to printf templating style was forgotten in snowflake connector
- fix: bad regex was used in convert_to_qmark_paramstyle
- chore: bump version to 0.51.11

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
