### PR TITLE
feat(SSO): Make snowflake connector be able to hold external tokens and credentials

### DIFF
--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -9,11 +9,13 @@ import snowflake.connector
 from requests.models import HTTPError
 
 from toucan_connectors.common import ConnectorStatus
+from toucan_connectors.postgres.postgresql_connector import PostgresConnector
 from toucan_connectors.snowflake import (
     AuthenticationMethod,
     SnowflakeConnector,
     SnowflakeDataSource,
 )
+from toucan_connectors.toucan_connector import needs_sso_credentials
 
 sc = SnowflakeConnector(
     name='test_name',
@@ -560,3 +562,8 @@ def test_get_status_account_nok(
         error='Account nok',
         details=[('Connection to Snowflake', False), ('Warehouse exists', None)],
     )
+
+
+def test_needs_sso_credentials():
+    assert needs_sso_credentials(SnowflakeConnector)
+    assert not needs_sso_credentials(PostgresConnector)

--- a/toucan_connectors/snowflake/snowflake_connector.py
+++ b/toucan_connectors/snowflake/snowflake_connector.py
@@ -2,7 +2,7 @@ from contextlib import suppress
 from datetime import datetime
 from enum import Enum
 from os import path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import jwt
 import pandas as pd
@@ -83,6 +83,11 @@ class SnowflakeConnector(ToucanConnector):
     """
     Import data from Snowflake data warehouse.
     """
+
+    _sso_credentials_access: bool = True
+
+    sso_credentials_keeper: Any = None
+    user_tokens_keeper: Any = None
 
     data_source_model: SnowflakeDataSource
 

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -171,6 +171,10 @@ def is_oauth2_connector(cls):
     return hasattr(cls, '_auth_flow') and getattr(cls, '_auth_flow') == 'oauth2'
 
 
+def needs_sso_credentials(cls) -> bool:
+    return hasattr(cls, '_sso_credentials_access') and getattr(cls, '_sso_credentials_access')
+
+
 class ConnectorSecretsForm(BaseModel):
     documentation_md: str = Field(description='This field contains documentation as a md string')
     secrets_schema: dict = Field(description='The schema for the configuration form')


### PR DESCRIPTION
## Change Summary

This PR adds three fields to the Snowflake connector :
	* _sso_credentials_access
	* sso_credentials_keeper
	* user_tokens_keeper

These fields will be used in laputa to inject at runtime tokens and credentials keeper to allow the connector to use these credentials in a secure way instead of relying on plain text data.

This fields will also allow the connector to update these credentials if needed.

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [ ] ~~Documentation reflects the changes where applicable~~
