### PR TITLE
fix: add github connector _oauth_trigger attribute

### DIFF
--- a/toucan_connectors/github/github_connector.py
+++ b/toucan_connectors/github/github_connector.py
@@ -99,6 +99,7 @@ class GithubConnector(ToucanConnector):
     _auth_flow = 'oauth2'
     auth_flow_id: Optional[str]
     data_source_model: GithubDataSource
+    _oauth_trigger = 'instance'
 
     @staticmethod
     def get_connector_secrets_form() -> ConnectorSecretsForm:

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -178,8 +178,9 @@ def get_oauth2_configuration(cls):
     return oauth2_enabled, oauth2_credentials_location
 
 
+# Deprecated
 def is_oauth2_connector(cls) -> bool:
-    return get_oauth2_configuration(cls)[0]
+    return get_oauth2_configuration(cls)[0]  # pragma: no cover
 
 
 def needs_sso_credentials(cls) -> bool:


### PR DESCRIPTION
Add the forgotten "_oauth_trigger" attribute in Github Connector. 
& Remove deprecated `is_oauth2_connector` function from coverage.