### PR TITLE
chores(versions): bump connectors version 0.52.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.52.0',
+    version='0.52.1',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
chores(versions): bump connectors version 0.52.1

* Re-add (deprecated) is_oauth2_connector function
* Add GithubConnector missing attribute `_oauth_trigger` 