### PR TITLE
fix(snowflake oauth): hide non user defined fields

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='0.53.5',
+    version='0.53.6',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/tests/snowflake_oauth2/conftest.py
+++ b/tests/snowflake_oauth2/conftest.py
@@ -11,11 +11,11 @@ def snowflake_oauth2_connector(secrets_keeper):
         account='acc',
         client_id='clientid',
         client_secret='clientsecret',
-        authorization_url='https://foo.bar/laputa/oauth/redirect',
         scope='all:your:data',
         token_url='https://acc.token',
         secrets_keeper=secrets_keeper,
         role='testrole',
+        default_warehouse='aqualy',
     )
 
 

--- a/toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py
+++ b/toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py
@@ -25,20 +25,14 @@ class SnowflakeoAuth2Connector(ToucanConnector):
     client_secret: SecretStr = Field(
         ..., title='Client Secret', description='The client secret of your Snowflake integration'
     )
-    redirect_uri: str = Field(
-        None, title='Redirect URI', description='The redirect URI called during the oauth2 flow'
-    )
-    authorization_url: str = Field(
-        ..., title='Authorization URL', description='The authorization URL', **{'ui.hidden': True}
-    )
+    authorization_url: str = Field(None, **{'ui.hidden': True})
     scope: str = Field(None, Title='Scope', description='The scope the integration')
-    token_url: str = Field(
-        None, title='Token URL', description='The URL to refresh the access token'
-    )
+    token_url: str = Field(None, **{'ui.hidden': True})
     auth_flow_id: str = Field(None, **{'ui.hidden': True})
     _auth_flow = 'oauth2'
     _oauth_trigger = 'connector'
     oauth2_version = Field('1', **{'ui.hidden': True})
+    redirect_uri: str = Field(None, **{'ui.hidden': True})
     role: str = Field(..., title='Role', description='Role to use for queries')
     account: str = Field(
         ...,
@@ -46,12 +40,17 @@ class SnowflakeoAuth2Connector(ToucanConnector):
         description='The full name of your Snowflake account. '
         'It might require the region and cloud platform where your account is located, '
         'in the form of: "your_account_name.region_id.cloud_platform". See more details '
-        '<a href="https://docs.snowflake.net/manuals/user-guide/python-connector-api.html#label-account-format-info" target="_blank">here</a>.',
+        '<a href="https://docs.snowflake.net/manuals/user-guide/python-connector-api.html#label-account-format-info" targte="_blank">here</a>.',
     )
     data_source_model: SnowflakeoAuth2DataSource
+    default_warehouse: str = Field(
+        ..., description='The default warehouse that shall be used for any data source'
+    )
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**{k: v for k, v in kwargs.items() if k != 'secrets_keeper'})
+        self.token_url = f'https://{self.account}.snowflakecomputing.com/oauth/token-request'
+        self.authorization_url = f'https://{self.account}.snowflakecomputing.com/oauth/authorize'
         self.__dict__['_oauth2_connector'] = OAuth2Connector(
             auth_flow_id=self.auth_flow_id,
             authorization_url=self.authorization_url,

--- a/toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py
+++ b/toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py
@@ -20,27 +20,40 @@ class SnowflakeoAuth2DataSource(SnowflakeDataSource):
 
 class SnowflakeoAuth2Connector(ToucanConnector):
     client_id: str = Field(
-        ..., title='Client ID', description='The client id of you Snowflake integration'
+        '',
+        title='Client ID',
+        description='The client id of you Snowflake integration',
+        **{'ui.required': True},
     )
     client_secret: SecretStr = Field(
-        '', title='Client Secret', description='The client secret of your Snowflake integration'
+        '',
+        title='Client Secret',
+        description='The client secret of your Snowflake integration',
+        **{'ui.required': True},
     )
     authorization_url: str = Field(None, **{'ui.hidden': True})
-    scope: str = Field(None, Title='Scope', description='The scope the integration')
+    scope: str = Field(
+        None, Title='Scope', description='The scope the integration', placeholder='refresh_token'
+    )
     token_url: str = Field(None, **{'ui.hidden': True})
     auth_flow_id: str = Field(None, **{'ui.hidden': True})
     _auth_flow = 'oauth2'
     _oauth_trigger = 'connector'
     oauth2_version = Field('1', **{'ui.hidden': True})
     redirect_uri: str = Field(None, **{'ui.hidden': True})
-    role: str = Field(..., title='Role', description='Role to use for queries')
+    role: str = Field(
+        ...,
+        title='Role',
+        description='Role to use for queries',
+        placeholder='PUBLIC',
+    )
     account: str = Field(
         ...,
         title='Account',
         description='The full name of your Snowflake account. '
         'It might require the region and cloud platform where your account is located, '
         'in the form of: "your_account_name.region_id.cloud_platform". See more details '
-        '<a href="https://docs.snowflake.net/manuals/user-guide/python-connector-api.html#label-account-format-info" targte="_blank">here</a>.',
+        '<a href="https://docs.snowflake.net/manuals/user-guide/python-connector-api.html#label-account-format-info" target="_blank">here</a>.',
     )
     data_source_model: SnowflakeoAuth2DataSource
     default_warehouse: str = Field(

--- a/toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py
+++ b/toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py
@@ -23,7 +23,7 @@ class SnowflakeoAuth2Connector(ToucanConnector):
         ..., title='Client ID', description='The client id of you Snowflake integration'
     )
     client_secret: SecretStr = Field(
-        ..., title='Client Secret', description='The client secret of your Snowflake integration'
+        '', title='Client Secret', description='The client secret of your Snowflake integration'
     )
     authorization_url: str = Field(None, **{'ui.hidden': True})
     scope: str = Field(None, Title='Scope', description='The scope the integration')


### PR DESCRIPTION
## Change Summary

* Adapt the Snowflake Oauth2 connector following changes in oauth2 flow management in backend 
* Hide non-user defined fields/

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%