### PR TITLE
feat: add get_cache_key method for queries caching

### DIFF
--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -473,3 +473,22 @@ def test_schema_extra():
             'validation': {},
         }
     }
+
+
+def test_get_cache_key(connector, data_source):
+    data_source.headers = {'name': '%(first_name)s'}
+    data_source.parameters = {'first_name': 'raphael'}
+    key = connector.get_cache_key(data_source)
+
+    assert key == '3562ab28-ab63-324d-8cb4-5e3964fe1310'
+
+    data_source.headers = {'name': '{{ first_name }}'}  # change the templating style
+    key2 = connector.get_cache_key(data_source)
+    assert key2 == key  # same result because the templates are rendered
+
+    data_source.parameters['nickname'] = 'raph'  # add a useless parameter
+    key3 = connector.get_cache_key(data_source)
+    assert key3 == key  # same result because the new parameter does not impact the result
+
+    key4 = connector.get_cache_key(data_source, offset=10)
+    assert key4 != key  # adding an offset changed the result

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -139,6 +139,19 @@ def test_get_cache_key():
     assert key3 == key
 
 
+def test_get_cache_key_connector_alone():
+    connector_a1 = DataConnector(name='a')
+    connector_a2 = DataConnector(name='a')
+    connector_b = DataConnector(name='b')
+
+    key_a1 = connector_a1.get_cache_key()
+    key_a2 = connector_a2.get_cache_key()
+    key_b = connector_b.get_cache_key()
+
+    assert key_a1 == key_a2
+    assert key_a1 != key_b
+
+
 class UnreliableDataConnector(ToucanConnector):
     type = 'MyUnreliableDB'
     data_source_model: DataSource

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -121,6 +121,24 @@ def test_get_status():
     assert DataConnector(name='my_name').get_status() == ConnectorStatus()
 
 
+def test_get_cache_key():
+    connector = DataConnector(name='my_name')
+    ds = connector.data_source_model(domain='yo', name='my_name', query='much caching')
+
+    key = connector.get_cache_key(ds)
+    # We should get a deterministic identifier:
+    # /!\ the identifier will change if the model of the connector or the datasource changes
+    assert key == '9d3ac11f-49d4-39ef-bc0e-8fc3ad85131d'
+
+    ds.query = 'wow'
+    key2 = connector.get_cache_key(ds)
+    assert key2 != key
+
+    ds.query = 'much caching'
+    key3 = connector.get_cache_key(ds)
+    assert key3 == key
+
+
 class UnreliableDataConnector(ToucanConnector):
     type = 'MyUnreliableDB'
     data_source_model: DataSource

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -1,7 +1,9 @@
+import json
 import logging
 import operator
 import os
 import socket
+import uuid
 from abc import ABCMeta, abstractmethod
 from enum import Enum
 from functools import reduce, wraps
@@ -11,7 +13,11 @@ import pandas as pd
 import tenacity as tny
 from pydantic import BaseModel, Field
 
-from toucan_connectors.common import ConnectorStatus, apply_query_parameters
+from toucan_connectors.common import (
+    ConnectorStatus,
+    apply_query_parameters,
+    nosql_apply_parameters_to_query,
+)
 from toucan_connectors.pandas_translator import PandasConditionTranslator
 
 try:
@@ -375,3 +381,30 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         }
         """
         return ConnectorStatus()
+
+    def get_cache_key(
+        self,
+        data_source: ToucanDataSource,
+        permissions: Optional[dict] = None,
+        offset: int = 0,
+        limit: Optional[int] = None,
+    ) -> str:
+        """
+        Generate a unique identifier (str) for a query.
+        This identifier will then be used as a cache key.
+        """
+        data_source_rendered = nosql_apply_parameters_to_query(
+            data_source.dict(), data_source.parameters, handle_errors=True
+        )
+        del data_source_rendered['parameters']
+
+        unique_identifier = {
+            'connector': self.dict(),
+            'datasource': data_source_rendered,
+            'permissions': permissions,
+            'offset': offset,
+            'limit': limit,
+        }
+        json_uid = json.dumps(unique_identifier, sort_keys=True)
+        string_uid = str(uuid.uuid3(uuid.NAMESPACE_OID, json_uid))
+        return string_uid


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

Add a `get_cache_key` method, which will return a key used for caching (see PAT 231).
The key should be the same if the query is the same.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
