### PR TITLE
fix: add odbc installation in the readme(for linux systems)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ configured with dictionaries (cf. `DataSource` class) and returning
 ## Setup
 In order to work you need `make` and `Python 3.8` (consider
 running `pip install -U pip setuptools` if needed)
-You can then install:
+:warning: On `linux`, you're going to need bindings for `unixodbc` to install `pyodbc` from the requirements, and to install that (using apt), just follow:
+```bash
+sudo apt-get update
+sudo apt-get install unixodbc-dev
+```
+Now, you can then install:
+
 - the main dependencies by typing `pip install -e .`
 - the test requirements by typing `pip install -r requirements-testing.txt`
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

While setting up my environment using `pip install -e [all]` i got an error with the package `pyodbc` while compiling it !
![Screenshot from 2021-07-28 09-45-28](https://user-images.githubusercontent.com/22576758/127284383-957c91ca-bb9f-4fd1-a1b0-fcfaef525a89.png)

Am on Ubuntu 20, and i discovered i needed a binding to be installed first before i can install that package !
To solve that i just ran this :
```bash
sudo apt-get update
sudo apt-get install unixodbc-dev
```
And that's what i just added in the [README.md](https://github.com/ToucanToco/toucan-connectors/blob/fix/pyodbc-readme-install/README.md) file !

## Related issue number
N/A

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
