### PR TITLE
feat: add `cache_ttl` field on ToucanConnector and ToucanDataSource

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='1.1.1',
+    version='1.2.0',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -480,7 +480,7 @@ def test_get_cache_key(connector, data_source):
     data_source.parameters = {'first_name': 'raphael'}
     key = connector.get_cache_key(data_source)
 
-    assert key == '3562ab28-ab63-324d-8cb4-5e3964fe1310'
+    assert key == '93eb707a-65d8-37c4-9d3b-a2344ca9b5f3'
 
     data_source.headers = {'name': '{{ first_name }}'}  # change the templating style
     key2 = connector.get_cache_key(data_source)

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -480,7 +480,7 @@ def test_get_cache_key(connector, data_source):
     data_source.parameters = {'first_name': 'raphael'}
     key = connector.get_cache_key(data_source)
 
-    assert key == '93eb707a-65d8-37c4-9d3b-a2344ca9b5f3'
+    assert key == 'a889058e-46e7-30ae-b6e8-e544c963957d'
 
     data_source.headers = {'name': '{{ first_name }}'}  # change the templating style
     key2 = connector.get_cache_key(data_source)

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -480,7 +480,7 @@ def test_get_cache_key(connector, data_source):
     data_source.parameters = {'first_name': 'raphael'}
     key = connector.get_cache_key(data_source)
 
-    assert key == 'a889058e-46e7-30ae-b6e8-e544c963957d'
+    assert key == 'f31e8815-d1b4-356c-8600-f5b25ed75db2'
 
     data_source.headers = {'name': '{{ first_name }}'}  # change the templating style
     key2 = connector.get_cache_key(data_source)

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -645,3 +645,11 @@ def test_format_stages_explain_result():
             },
         ],
     }
+
+
+def test_get_cache_key(mongo_connector):
+    """
+    It should not raise 'TypeError: Object of type 'MongoClient' is not JSON serializable'
+    """
+    assert mongo_connector.client is not None
+    assert isinstance(mongo_connector.get_cache_key(), str)

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -653,3 +653,7 @@ def test_get_cache_key(mongo_connector):
     """
     assert mongo_connector.client is not None
     assert isinstance(mongo_connector.get_cache_key(), str)
+
+    conn1 = MongoConnector(name='aaa', host='here', port=42, username='me', password='s3cr3t')
+    conn2 = MongoConnector(name='aaa', host='here', port=42, username='me', password='?')
+    assert conn1.get_cache_key() != conn2.get_cache_key()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -128,7 +128,7 @@ def test_get_cache_key():
     key = connector.get_cache_key(ds)
     # We should get a deterministic identifier:
     # /!\ the identifier will change if the model of the connector or the datasource changes
-    assert key == '9d3ac11f-49d4-39ef-bc0e-8fc3ad85131d'
+    assert key == 'c1e63213-bb27-3596-a24e-f7542e73e05d'
 
     ds.query = 'wow'
     key2 = connector.get_cache_key(ds)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -128,7 +128,7 @@ def test_get_cache_key():
     key = connector.get_cache_key(ds)
     # We should get a deterministic identifier:
     # /!\ the identifier will change if the model of the connector or the datasource changes
-    assert key == '78c0a10d-100d-3b1e-bb67-d0cb6f855c6a'
+    assert key == 'b9d78e08-43b0-3acd-b453-e2c03424e73c'
 
     ds.query = 'wow'
     key2 = connector.get_cache_key(ds)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -128,7 +128,7 @@ def test_get_cache_key():
     key = connector.get_cache_key(ds)
     # We should get a deterministic identifier:
     # /!\ the identifier will change if the model of the connector or the datasource changes
-    assert key == 'c1e63213-bb27-3596-a24e-f7542e73e05d'
+    assert key == '78c0a10d-100d-3b1e-bb67-d0cb6f855c6a'
 
     ds.query = 'wow'
     key2 = connector.get_cache_key(ds)

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -107,6 +107,7 @@ def test_get_form():
             'live_data': {'title': 'Live Data', 'type': 'boolean', 'default': False},
             'validation': {'title': 'Validation', 'type': 'object'},
             'parameters': {'title': 'Parameters', 'type': 'object'},
+            'ttl': {'title': 'Ttl', 'type': 'integer'},
         },
         'required': ['domain', 'name'],
         'additionalProperties': False,

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -107,7 +107,7 @@ def test_get_form():
             'live_data': {'title': 'Live Data', 'type': 'boolean', 'default': False},
             'validation': {'title': 'Validation', 'type': 'object'},
             'parameters': {'title': 'Parameters', 'type': 'object'},
-            'ttl': {'title': 'Ttl', 'type': 'integer'},
+            'cache_ttl': {'title': 'Cache Ttl', 'type': 'integer'},
         },
         'required': ['domain', 'name'],
         'additionalProperties': False,

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -286,8 +286,8 @@ class MongoConnector(ToucanConnector):
         )
         return _format_explain_result(result)
 
-    def to_serializable_dict(self) -> dict:
-        return self.dict(
+    def to_json(self) -> dict:
+        return self.json(
             exclude={'client'}
         )  # client is a MongoClient instance, not json serializable
 

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -286,6 +286,11 @@ class MongoConnector(ToucanConnector):
         )
         return _format_explain_result(result)
 
+    def to_serializable_dict(self) -> dict:
+        return self.dict(
+            exclude={'client'}
+        )  # client is a MongoClient instance, not json serializable
+
 
 def _format_explain_result(explain_result):
     """format output of an `explain` mongo command

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -286,7 +286,7 @@ class MongoConnector(ToucanConnector):
         )
         return _format_explain_result(result)
 
-    def to_json(self) -> dict:
+    def get_unique_identifier(self) -> dict:
         return self.json(
             exclude={'client'}
         )  # client is a MongoClient instance, not json serializable

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -11,7 +11,7 @@ from typing import Iterable, List, NamedTuple, Optional, Type
 
 import pandas as pd
 import tenacity as tny
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretBytes, SecretStr
 
 from toucan_connectors.common import (
     ConnectorStatus,
@@ -269,6 +269,10 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
     class Config:
         extra = 'forbid'
         validate_assignment = True
+        json_encoders = {
+            SecretStr: lambda v: v.get_secret_value(),
+            SecretBytes: lambda v: v.get_secret_value(),
+        }
 
     @classmethod
     def __init_subclass__(cls):

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -73,6 +73,7 @@ class ToucanDataSource(BaseModel):
     live_data: bool = False
     validation: dict = None
     parameters: dict = None
+    ttl: Optional[int] = None  # overrides connector's ttl
 
     class Config:
         extra = 'forbid'
@@ -257,6 +258,10 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
     _retry_on: Iterable[Type[BaseException]] = ()
     type: str = Field(None)
     secrets_storage_version = Field('1', **{'ui.hidden': True})
+
+    # Default ttl for all connector's queries (overridable at the data_source level)
+    # /!\ ttl is used by the caching system which is not implemented in toucan_connectors.
+    ttl: Optional[int] = Field(None, title='TTL (cache')
 
     # Used to defined the connection
     identifier: str = Field(None, **{'ui.hidden': True})

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -387,6 +387,15 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         """
         return ConnectorStatus()
 
+    def to_serializable_dict(self) -> dict:
+        """
+        Returns a serializable version of the connector's config.
+        Override this method in connectors which have not-serializable properties.
+
+        Used by `get_cache_key` method.
+        """
+        return self.dict()
+
     def get_cache_key(
         self,
         data_source: Optional[ToucanDataSource] = None,
@@ -401,7 +410,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         This identifier will then be used as a cache key.
         """
         unique_identifier = {
-            'connector': self.dict(),
+            'connector': self.to_serializable_dict(),
             'permissions': permissions,
             'offset': offset,
             'limit': limit,

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -387,14 +387,14 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         """
         return ConnectorStatus()
 
-    def to_serializable_dict(self) -> dict:
+    def to_json(self) -> dict:
         """
-        Returns a serializable version of the connector's config.
+        Returns a serialized version of the connector's config.
         Override this method in connectors which have not-serializable properties.
 
         Used by `get_cache_key` method.
         """
-        return self.dict()
+        return self.json()
 
     def get_cache_key(
         self,
@@ -410,7 +410,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         This identifier will then be used as a cache key.
         """
         unique_identifier = {
-            'connector': self.to_serializable_dict(),
+            'connector': self.to_json(),
             'permissions': permissions,
             'offset': offset,
             'limit': limit,

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -261,7 +261,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
 
     # Default ttl for all connector's queries (overridable at the data_source level)
     # /!\ cache ttl is used by the caching system which is not implemented in toucan_connectors.
-    cache_ttl: Optional[int] = Field(None, title='TTL (cache')
+    cache_ttl: Optional[int] = Field(None, title='TTL (cache)')
 
     # Used to defined the connection
     identifier: str = Field(None, **{'ui.hidden': True})
@@ -391,7 +391,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         """
         return ConnectorStatus()
 
-    def to_json(self) -> dict:
+    def get_unique_identifier(self) -> dict:
         """
         Returns a serialized version of the connector's config.
         Override this method in connectors which have not-serializable properties.
@@ -414,7 +414,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         This identifier will then be used as a cache key.
         """
         unique_identifier = {
-            'connector': self.to_json(),
+            'connector': self.get_unique_identifier(),
             'permissions': permissions,
             'offset': offset,
             'limit': limit,

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -73,7 +73,7 @@ class ToucanDataSource(BaseModel):
     live_data: bool = False
     validation: dict = None
     parameters: dict = None
-    ttl: Optional[int] = None  # overrides connector's ttl
+    cache_ttl: Optional[int] = None  # overrides connector's ttl
 
     class Config:
         extra = 'forbid'
@@ -260,8 +260,8 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
     secrets_storage_version = Field('1', **{'ui.hidden': True})
 
     # Default ttl for all connector's queries (overridable at the data_source level)
-    # /!\ ttl is used by the caching system which is not implemented in toucan_connectors.
-    ttl: Optional[int] = Field(None, title='TTL (cache')
+    # /!\ cache ttl is used by the caching system which is not implemented in toucan_connectors.
+    cache_ttl: Optional[int] = Field(None, title='TTL (cache')
 
     # Used to defined the connection
     identifier: str = Field(None, **{'ui.hidden': True})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Add a field `cache_ttl` (optional int, defaults to None) to models `ToucanConnector` and `ToucanDataSource`.

These fields will be used by the caching system implemented in laputa.

The ttl of the datasource will take precedence over the one of the connector.

---

This PR also contains a fix for `get_cache_key` (now it works for mongo).

<!-- Please give a short summary of the changes. -->