### PR TITLE
refactor(oauth2 connectors): the _oauth2_connector property of oauth2 connectors is no longer set using __dict__

### DIFF
--- a/tests/aircall/test_aircall.py
+++ b/tests/aircall/test_aircall.py
@@ -414,6 +414,19 @@ def test_build_authorization_url(mocker, con):
     mock_oauth2_connector.build_authorization_url.assert_called()
 
 
+def test_retrieve_tokens(mocker, con):
+    """
+    Check that the retrieve_tokens method properly returns
+    tokens
+    """
+    mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
+    mock_oauth2_connector.client_id = 'test_client_id'
+    mock_oauth2_connector.client_secret = 'test_client_secret'
+    con._oauth2_connector = mock_oauth2_connector
+    con.retrieve_tokens('bla')
+    mock_oauth2_connector.retrieve_tokens.assert_called()
+
+
 @pytest.mark.asyncio
 async def test__get_data_no_secrets(mocker, con, remove_secrets):
     """It should raise an exception if there are no secrets returned during the fetch"""

--- a/tests/aircall/test_aircall.py
+++ b/tests/aircall/test_aircall.py
@@ -409,7 +409,7 @@ def test_build_authorization_url(mocker, con):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'test_client_id'
     mock_oauth2_connector.client_secret = 'test_client_secret'
-    con.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    con._oauth2_connector = mock_oauth2_connector
     con.build_authorization_url()
     mock_oauth2_connector.build_authorization_url.assert_called()
 

--- a/tests/facebook_ads/test_facebook_ads.py
+++ b/tests/facebook_ads/test_facebook_ads.py
@@ -122,7 +122,7 @@ def test_facebook_ads_build_authorization_uri(connector, mocker):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'client_id'
     mock_oauth2_connector.client_secret = 'secret'
-    connector.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    connector._oauth2_connector = mock_oauth2_connector
     connector.build_authorization_url()
 
     mock_oauth2_connector.build_authorization_url.assert_called()
@@ -132,7 +132,7 @@ def test_facebook_ads_retrieve_tokens(connector, mocker):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'client_id'
     mock_oauth2_connector.client_secret = 'secret'
-    connector.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    connector._oauth2_connector = mock_oauth2_connector
     connector.retrieve_tokens('foo')
 
     mock_oauth2_connector.retrieve_tokens.assert_called()

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -121,7 +121,7 @@ def test_build_authorization_url(mocker, gc):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'test_client_id'
     mock_oauth2_connector.client_secret = 'test_client_secret'
-    gc.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    gc._oauth2_connector = mock_oauth2_connector
     gc.build_authorization_url()
     mock_oauth2_connector.build_authorization_url.assert_called()
 
@@ -144,7 +144,7 @@ def test_retrieve_tokens(mocker, gc):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'test_client_id'
     mock_oauth2_connector.client_secret = 'test_client_secret'
-    gc.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    gc._oauth2_connector = mock_oauth2_connector
     gc.retrieve_tokens('bla')
     mock_oauth2_connector.retrieve_tokens.assert_called()
 

--- a/tests/google_adwords/test_google_adwords.py
+++ b/tests/google_adwords/test_google_adwords.py
@@ -121,7 +121,7 @@ def test_retrieve_tokens(mocker, connector):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'test_client_id'
     mock_oauth2_connector.client_secret = 'test_client_secret'
-    connector.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    connector._oauth2_connector = mock_oauth2_connector
     connector.retrieve_tokens('bla')
     mock_oauth2_connector.retrieve_tokens.assert_called()
 

--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -248,7 +248,7 @@ def test_delegate_oauth2_methods(mocker, con):
     It should proxy OAuth2Connectors methods
     """
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
-    con.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    con._oauth2_connector = mock_oauth2_connector
     con.build_authorization_url()
     mock_oauth2_connector.build_authorization_url.assert_called()
     con.retrieve_tokens('toto')

--- a/tests/hubspot/test_hubspot.py
+++ b/tests/hubspot/test_hubspot.py
@@ -31,7 +31,7 @@ def test_hubspot_build_authorization_uri(connector, mocker):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'client_id'
     mock_oauth2_connector.client_secret = 'secret'
-    connector.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    connector._oauth2_connector = mock_oauth2_connector
     connector.build_authorization_url()
 
     mock_oauth2_connector.build_authorization_url.assert_called()
@@ -41,7 +41,7 @@ def test_hubspot_retrieve_tokens(connector, mocker):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'client_id'
     mock_oauth2_connector.client_secret = 'secret'
-    connector.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    connector._oauth2_connector = mock_oauth2_connector
     connector.retrieve_tokens('foo')
 
     mock_oauth2_connector.retrieve_tokens.assert_called()

--- a/tests/linkedinads/test_linkedinads.py
+++ b/tests/linkedinads/test_linkedinads.py
@@ -148,7 +148,7 @@ def test_retrieve_tokens(mocker, connector):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'test_client_id'
     mock_oauth2_connector.client_secret = 'test_client_secret'
-    connector.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    connector._oauth2_connector = mock_oauth2_connector
     connector.retrieve_tokens('bla')
     mock_oauth2_connector.retrieve_tokens.assert_called()
 

--- a/tests/one_drive/test_one_drive.py
+++ b/tests/one_drive/test_one_drive.py
@@ -175,7 +175,7 @@ def test_build_authorization_uri(con, mocker):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'client_id'
     mock_oauth2_connector.client_secret = 'secret'
-    con.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    con._oauth2_connector = mock_oauth2_connector
     con.build_authorization_url()
 
     mock_oauth2_connector.build_authorization_url.assert_called()
@@ -185,7 +185,7 @@ def test_retrieve_tokens(con, mocker):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'client_id'
     mock_oauth2_connector.client_secret = 'secret'
-    con.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    con._oauth2_connector = mock_oauth2_connector
     con.retrieve_tokens('foo')
 
     mock_oauth2_connector.retrieve_tokens.assert_called()
@@ -195,7 +195,7 @@ def test_get_access_token(con, mocker):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'client_id'
     mock_oauth2_connector.client_secret = 'secret'
-    con.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    con._oauth2_connector = mock_oauth2_connector
     con._get_access_token()
 
     mock_oauth2_connector.get_access_token.assert_called()
@@ -205,7 +205,7 @@ def test_run_fetch(con, mocker):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'client_id'
     mock_oauth2_connector.client_secret = 'secret'
-    con.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    con._oauth2_connector = mock_oauth2_connector
 
     con._run_fetch('https://jsonplaceholder.typicode.com/posts')
 

--- a/tests/salesforce/test_salesforce.py
+++ b/tests/salesforce/test_salesforce.py
@@ -24,7 +24,7 @@ def test_build_authorization_url(mocker, sc):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'test_client_id'
     mock_oauth2_connector.client_secret = 'test_client_secret'
-    sc.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    sc._oauth2_connector = mock_oauth2_connector
     sc.build_authorization_url()
     mock_oauth2_connector.build_authorization_url.assert_called()
 
@@ -37,7 +37,7 @@ def test_retrieve_tokens(mocker, sc):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'test_client_id'
     mock_oauth2_connector.client_secret = 'test_client_secret'
-    sc.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    sc._oauth2_connector = mock_oauth2_connector
     sc.retrieve_tokens('bla')
     mock_oauth2_connector.retrieve_tokens.assert_called()
 

--- a/tests/snowflake_oauth2/test_snowflake_oauth2.py
+++ b/tests/snowflake_oauth2/test_snowflake_oauth2.py
@@ -474,7 +474,7 @@ def test_build_authorization_url(mocker, snowflake_oauth2_connector):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'test_client_id'
     mock_oauth2_connector.client_secret = 'test_client_secret'
-    snowflake_oauth2_connector.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    snowflake_oauth2_connector._oauth2_connector = mock_oauth2_connector
     snowflake_oauth2_connector.build_authorization_url()
     mock_oauth2_connector.build_authorization_url.assert_called()
 
@@ -487,7 +487,7 @@ def test_retrieve_tokens(mocker, snowflake_oauth2_connector):
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'test_client_id'
     mock_oauth2_connector.client_secret = 'test_client_secret'
-    snowflake_oauth2_connector.__dict__['_oauth2_connector'] = mock_oauth2_connector
+    snowflake_oauth2_connector._oauth2_connector = mock_oauth2_connector
     snowflake_oauth2_connector.retrieve_tokens('bla')
     mock_oauth2_connector.retrieve_tokens.assert_called()
 

--- a/toucan_connectors/aircall/aircall_connector.py
+++ b/toucan_connectors/aircall/aircall_connector.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Tuple
 
 import pandas as pd
 from aiohttp import ClientSession
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 from toucan_connectors.common import ConnectorStatus, get_loop
 from toucan_connectors.oauth2_connector.oauth2connector import (
@@ -180,6 +180,7 @@ class AircallConnector(ToucanConnector):
     data_source_model: AircallDataSource
     _oauth_trigger = 'instance'
     oauth2_version = Field('1', **{'ui.hidden': True})
+    _oauth2_connector: OAuth2Connector = PrivateAttr()
 
     @staticmethod
     def get_connector_secrets_form() -> ConnectorSecretsForm:
@@ -192,7 +193,7 @@ class AircallConnector(ToucanConnector):
         super().__init__(
             **{k: v for k, v in kwargs.items() if k not in OAuth2Connector.init_params}
         )
-        self.__dict__['_oauth2_connector'] = OAuth2Connector(
+        self._oauth2_connector = OAuth2Connector(
             auth_flow_id=self.auth_flow_id,
             authorization_url=AUTHORIZATION_URL,
             scope=SCOPE,
@@ -207,7 +208,7 @@ class AircallConnector(ToucanConnector):
         self.provided_token = kwargs.get('provided_token', None)
 
     def build_authorization_url(self, **kwargs):
-        return self.__dict__['_oauth2_connector'].build_authorization_url(**kwargs)
+        return self._oauth2_connector.build_authorization_url(**kwargs)
 
     def retrieve_tokens(self, authorization_response: str):
         """
@@ -215,12 +216,12 @@ class AircallConnector(ToucanConnector):
         must be sent in the body of the request so we have to set them in
         the mother class. This way they'll be added to her get_access_token method
         """
-        return self.__dict__['_oauth2_connector'].retrieve_tokens(authorization_response)
+        return self._oauth2_connector.retrieve_tokens(authorization_response)
 
     def get_access_token(self):
         if self.provided_token:
             return self.provided_token
-        return self.__dict__['_oauth2_connector'].get_access_token()
+        return self._oauth2_connector.get_access_token()
 
     async def _fetch(self, url, headers=None, query_params=None):
         """Build the final request along with headers."""

--- a/toucan_connectors/facebook_ads/facebook_ads_connector.py
+++ b/toucan_connectors/facebook_ads/facebook_ads_connector.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 
 import pandas as pd
 import requests
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 from toucan_connectors.oauth2_connector.oauth2connector import (
     OAuth2Connector,
@@ -82,12 +82,13 @@ class FacebookAdsConnector(ToucanConnector):
     _oauth_trigger = 'instance'
     data_source_model: FacebookAdsDataSource
     oauth2_version = Field('1', **{'ui.hidden': True})
+    _oauth2_connector: OAuth2Connector = PrivateAttr()
 
     def __init__(self, **kwargs) -> None:
         super().__init__(
             **{k: v for k, v in kwargs.items() if k not in OAuth2Connector.init_params}
         )
-        self.__dict__['_oauth2_connector'] = OAuth2Connector(
+        self._oauth2_connector = OAuth2Connector(
             auth_flow_id=self.auth_flow_id,
             authorization_url=AUTHORIZATION_URL,
             scope=SCOPES,
@@ -113,13 +114,13 @@ class FacebookAdsConnector(ToucanConnector):
         must be sent in the body of the request so we have to set them in
         the mother class. This way they'll be added to her get_access_token method
         """
-        return self.__dict__['_oauth2_connector'].retrieve_tokens(authorization_response)
+        return self._oauth2_connector.retrieve_tokens(authorization_response)
 
     def build_authorization_url(self, **kwargs):
-        return self.__dict__['_oauth2_connector'].build_authorization_url(**kwargs)
+        return self._oauth2_connector.build_authorization_url(**kwargs)
 
     def _get_access_token(self):
-        return self.__dict__['_oauth2_connector'].get_access_token()
+        return self._oauth2_connector.get_access_token()
 
     @staticmethod
     def _handle_pagination(url: str, params: Dict) -> List[Dict]:

--- a/toucan_connectors/hubspot/hubspot_connector.py
+++ b/toucan_connectors/hubspot/hubspot_connector.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 import requests
-from pydantic import Field
+from pydantic import Field, PrivateAttr
 
 from toucan_connectors.oauth2_connector.oauth2connector import (
     OAuth2Connector,
@@ -74,12 +74,13 @@ class HubspotConnector(ToucanConnector):
     _oauth_trigger = 'instance'
     oauth2_version = Field('1', **{'ui.hidden': True})
     data_source_model: HubspotDataSource
+    _oauth2_connector: OAuth2Connector = PrivateAttr()
 
     def __init__(self, **kwargs) -> None:
         super().__init__(
             **{k: v for k, v in kwargs.items() if k not in OAuth2Connector.init_params}
         )
-        self.__dict__['_oauth2_connector'] = OAuth2Connector(
+        self._oauth2_connector = OAuth2Connector(
             auth_flow_id=self.auth_flow_id,
             authorization_url=AUTHORIZATION_URL,
             scope=SCOPE,
@@ -105,13 +106,13 @@ class HubspotConnector(ToucanConnector):
         must be sent in the body of the request so we have to set them in
         the mother class. This way they'll be added to her get_access_token method
         """
-        return self.__dict__['_oauth2_connector'].retrieve_tokens(authorization_response)
+        return self._oauth2_connector.retrieve_tokens(authorization_response)
 
     def build_authorization_url(self, **kwargs):
-        return self.__dict__['_oauth2_connector'].build_authorization_url(**kwargs)
+        return self._oauth2_connector.build_authorization_url(**kwargs)
 
     def _get_access_token(self):
-        return self.__dict__['_oauth2_connector'].get_access_token()
+        return self._oauth2_connector.get_access_token()
 
     def _handle_pagination(
         self,

--- a/toucan_connectors/one_drive/one_drive_connector.py
+++ b/toucan_connectors/one_drive/one_drive_connector.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import pandas as pd
 import requests
-from pydantic import Field, SecretStr
+from pydantic import Field, PrivateAttr, SecretStr
 
 from toucan_connectors.oauth2_connector.oauth2connector import (
     OAuth2Connector,
@@ -42,6 +42,7 @@ class OneDriveConnector(ToucanConnector):
     authorization_url: str = Field(None, **{'ui.hidden': True})
     token_url: str = Field(None, **{'ui.hidden': True})
     redirect_uri: str = Field(None, **{'ui.hidden': True})
+    _oauth2_connector: OAuth2Connector = PrivateAttr()
 
     client_id: str = Field(
         '',
@@ -80,7 +81,7 @@ class OneDriveConnector(ToucanConnector):
         self.token_url = f'https://login.microsoftonline.com/{self.tenant}/oauth2/v2.0/token'
 
         # we use __dict__ so that pydantic does not complain about the _oauth2_connector field
-        self.__dict__['_oauth2_connector'] = OAuth2Connector(
+        self._oauth2_connector = OAuth2Connector(
             auth_flow_id=self.auth_flow_id,
             authorization_url=self.authorization_url,
             scope=self.scope,
@@ -95,15 +96,15 @@ class OneDriveConnector(ToucanConnector):
 
     def build_authorization_url(self, **kwargs):
         logging.getLogger(__name__).debug('build_authorization_url')
-        return self.__dict__['_oauth2_connector'].build_authorization_url(**kwargs)
+        return self._oauth2_connector.build_authorization_url(**kwargs)
 
     def retrieve_tokens(self, authorization_response: str):
         logging.getLogger(__name__).debug('retrieve_tokens')
-        return self.__dict__['_oauth2_connector'].retrieve_tokens(authorization_response)
+        return self._oauth2_connector.retrieve_tokens(authorization_response)
 
     def _get_access_token(self):
         logging.getLogger(__name__).debug('_get_access_token')
-        return self.__dict__['_oauth2_connector'].get_access_token()
+        return self._oauth2_connector.get_access_token()
 
     def _get_site_id(self, data_source):
         logging.getLogger(__name__).debug('_get_site_id')


### PR DESCRIPTION
## Change Summary
refactor(oauth2 connectors): the _oauth2_connector property of oauth2 connectors is no longer set using __dict__. It is now properly declared as private variables for pydantic. This excludes them from the json generated by `.json()`

