### PR TITLE
fix(mysql): support table and query

### DIFF
--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -35,7 +35,7 @@ class MySQLDataSource(ToucanDataSource):
         None,
         description='You can write a custom query against your '
         'database here. It will take precedence over '
-        'the "table" parameter above',
+        'the "table" parameter',
         widget='sql',
     )
     follow_relations: bool = Field(
@@ -53,8 +53,6 @@ class MySQLDataSource(ToucanDataSource):
         table = data.get('table')
         if query is None and table is None:
             raise ValueError("'query' or 'table' must be set")
-        elif query is not None and table is not None:
-            raise ValueError("Only one of 'query' or 'table' must be set")
 
     @classmethod
     def get_form(cls, connector: 'MySQLConnector', current_config):

--- a/toucan_connectors/postgres/postgresql_connector.py
+++ b/toucan_connectors/postgres/postgresql_connector.py
@@ -13,7 +13,7 @@ class PostgresDataSource(ToucanDataSource):
         None,
         description='You can write a custom query against your '
         'database here. It will take precedence over '
-        'the "table" parameter above',
+        'the "table" parameter',
         widget='sql',
     )
     table: constr(min_length=1) = Field(


### PR DESCRIPTION
Get rid of the error when both table and query are set. Query should have priority.
This is the same behavior as postgres and mssql connectors.