### PR TITLE
Feat/mongo cache key

### DIFF
--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -291,6 +291,13 @@ class MongoConnector(ToucanConnector):
             exclude={'client'}
         )  # client is a MongoClient instance, not json serializable
 
+    def _render_datasource(self, data_source: MongoDataSource):
+        # let's make a copy first
+        data_source_rendered = MongoDataSource.parse_obj(data_source)
+        data_source_rendered.query = normalize_query(data_source.query, data_source.parameters)
+        del data_source_rendered.parameters
+        return data_source
+
 
 def _format_explain_result(explain_result):
     """format output of an `explain` mongo command

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -291,12 +291,12 @@ class MongoConnector(ToucanConnector):
             exclude={'client'}
         )  # client is a MongoClient instance, not json serializable
 
-    def _render_datasource(self, data_source: MongoDataSource):
+    def _render_datasource(self, data_source: MongoDataSource) -> dict:
         # let's make a copy first
         data_source_rendered = MongoDataSource.parse_obj(data_source)
         data_source_rendered.query = normalize_query(data_source.query, data_source.parameters)
         del data_source_rendered.parameters
-        return data_source
+        return data_source_rendered.dict()
 
 
 def _format_explain_result(explain_result):

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -405,6 +405,14 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         """
         return self.json()
 
+    def _render_datasource(self, data_source: ToucanDataSource):
+        data_source_rendered = nosql_apply_parameters_to_query(
+            data_source.dict(), data_source.parameters, handle_errors=True
+        )
+        del data_source_rendered['parameters']
+
+        return data_source_rendered
+
     def get_cache_key(
         self,
         data_source: Optional[ToucanDataSource] = None,
@@ -426,11 +434,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         }
 
         if data_source is not None:
-            data_source_rendered = nosql_apply_parameters_to_query(
-                data_source.dict(), data_source.parameters, handle_errors=True
-            )
-            del data_source_rendered['parameters']
-            unique_identifier['datasource'] = data_source_rendered
+            unique_identifier['datasource'] = self._render_datasource(data_source)
 
         json_uid = JsonWrapper.dumps(unique_identifier, sort_keys=True)
         string_uid = str(uuid.uuid3(uuid.NAMESPACE_OID, json_uid))

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -405,7 +405,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         """
         return self.json()
 
-    def _render_datasource(self, data_source: ToucanDataSource):
+    def _render_datasource(self, data_source: ToucanDataSource) -> dict:
         data_source_rendered = nosql_apply_parameters_to_query(
             data_source.dict(), data_source.parameters, handle_errors=True
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

this PR adds a `_render_datasource` method that is used to render the datasource, and compute a more specific key for the cache
It also adds  such a method for the mongo connector.

## Related issue number


## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
