### PR TITLE
feat(cache key): add `_render_datasource` for HTTP connector

### DIFF
--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -480,7 +480,7 @@ def test_get_cache_key(connector, data_source):
     data_source.parameters = {'first_name': 'raphael'}
     key = connector.get_cache_key(data_source)
 
-    assert key == '07d5e581-598f-3729-bc99-d24425945e0a'
+    assert key == 'b35e0189-a527-3f9c-827d-b0c54e23b780'
 
     data_source.headers = {'name': '{{ first_name }}'}  # change the templating style
     key2 = connector.get_cache_key(data_source)

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -187,3 +187,16 @@ class HttpAPIConnector(ToucanConnector):
         if data_source.flatten_column:
             return json_to_table(res, columns=[data_source.flatten_column])
         return res
+
+    def _render_datasource(self, data_source: ToucanDataSource) -> dict:
+        query = nosql_apply_parameters_to_query(
+            data_source.dict(by_alias=True), data_source.parameters, handle_errors=True
+        )
+        if self.template:
+            template = {k: v for k, v in self.template.dict(by_alias=True).items() if v}
+            for k in query.keys() & template.keys():
+                if query[k]:
+                    template[k].update(query[k])
+                query[k] = template[k]
+        del query['parameters']
+        return query


### PR DESCRIPTION
## Change Summary

add a specialized `_render_datasource` for HTTP connector

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
