### PR TITLE
fix(snowflake common): fix describe result logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='1.2.1',
+    version='1.2.7',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/tests/test_snowflake_common.py
+++ b/tests/test_snowflake_common.py
@@ -335,6 +335,7 @@ def test_describe(connect, mocker):
 def test__describe(connect, mocker):
     mocked_cursor = mocker.MagicMock()
     mocked_describe = mocked_cursor.describe
+    mocker.patch('toucan_connectors.snowflake_common.json.dumps')
 
     class fake_result:
         def __init__(self, name, type_code):
@@ -356,6 +357,7 @@ def test__describe(connect, mocker):
 def test__describe_api_changed(connect, mocker):
     mocked_cursor = mocker.MagicMock()
     mocked_describe = mocked_cursor.describe
+    mocker.patch('toucan_connectors.snowflake_common.json.dumps')
 
     class fake_result:
         def __init__(self, name, type_code):

--- a/toucan_connectors/snowflake_common.py
+++ b/toucan_connectors/snowflake_common.py
@@ -1,4 +1,5 @@
 import concurrent
+import json
 import logging
 from timeit import default_timer as timer
 from typing import Dict, List, Optional
@@ -256,7 +257,7 @@ class SnowflakeCommon:
                     'execution_time': description_time,
                     'connector': 'snowflake',
                     'query': query,
-                    'result': describe_res,
+                    'result': json.dumps(describe_res),
                 }
             },
         )


### PR DESCRIPTION
## Change Summary

Fix this issue: 

`--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.8/logging/__init__.py", line 1085, in emit
    msg = self.format(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 929, in format
    return fmt.format(record)
  File "/home/raphael/PycharmProjects/laputa/laputa/common/log.py", line 188, in format
    return json_serializer.dumps(log_object).decode('utf-8')
  File "/home/raphael/PycharmProjects/laputa/laputa/common/utils/json_serializer.py", line 59, in dumps
    return orjson.dumps(
TypeError: Type is not JSON serializable: ResultMetadata
`