### PR TITLE
fix(multiple_queries): remove multiple queries one execute

### DIFF
--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -254,7 +254,7 @@ def test_retrieve_data(
 ):
     df_result: DataFrame = snowflake_connector._retrieve_data(snowflake_datasource)
 
-    assert eq.call_count == 2  # +1 for each data request
+    assert eq.call_count == 3  # +1 for each data request
     assert 11 == len(df_result)
     SnowflakeConnector.get_snowflake_connection_manager().force_clean()
 
@@ -267,7 +267,7 @@ def test_retrieve_data_slice(
     eq, is_closed, close, connect, snowflake_connector, snowflake_datasource, mocker
 ):
     df_result: DataSlice = snowflake_connector.get_slice(snowflake_datasource)
-    assert eq.call_count == 2  # +1 select database and warehouse
+    assert eq.call_count == 3  # +1 select database and warehouse
     assert 11 == len(df_result.df)
     SnowflakeConnector.get_snowflake_connection_manager().force_clean()
 
@@ -280,7 +280,7 @@ def test_retrieve_data_slice_offset_limit(
     eq, is_closed, close, connect, snowflake_connector, snowflake_datasource, mocker
 ):
     df_result: DataSlice = snowflake_connector.get_slice(snowflake_datasource, offset=5, limit=3)
-    assert eq.call_count == 2  # +1 select database and warehouse
+    assert eq.call_count == 3  # +1 select database and warehouse
     assert 11 == len(df_result.df)
     assert 11 == df_result.stats.total_returned_rows
     SnowflakeConnector.get_snowflake_connection_manager().force_clean()
@@ -294,7 +294,7 @@ def test_retrieve_data_slice_too_much(
     eq, is_closed, close, connect, snowflake_connector, snowflake_datasource, mocker
 ):
     df_result: DataSlice = snowflake_connector.get_slice(snowflake_datasource, offset=10, limit=20)
-    assert eq.call_count == 2  # +1 select database and warehouse
+    assert eq.call_count == 3  # +1 select database and warehouse
     assert 11 == len(df_result.df)
     SnowflakeConnector.get_snowflake_connection_manager().force_clean()
 
@@ -307,7 +307,7 @@ def test_retrieve_data_fetch(
     eq, is_closed, close, connect, snowflake_connector, snowflake_datasource, mocker
 ):
     df_result = snowflake_connector._fetch_data(snowflake_datasource)
-    assert eq.call_count == 2  # +1 select database and warehouse
+    assert eq.call_count == 3  # +1 select database and warehouse
     assert 11 == len(df_result)
     SnowflakeConnector.get_snowflake_connection_manager().force_clean()
 
@@ -320,7 +320,7 @@ def test_retrieve_data_fetch_offset_limit(
     eq, is_closed, close, connect, snowflake_connector, snowflake_datasource, mocker
 ):
     df_result: DataSlice = snowflake_connector._fetch_data(snowflake_datasource, offset=5, limit=3)
-    assert eq.call_count == 2  # +1 select database and warehouse
+    assert eq.call_count == 3  # +1 select database and warehouse
     assert 11 == len(df_result)
     SnowflakeConnector.get_snowflake_connection_manager().force_clean()
 
@@ -335,7 +335,7 @@ def test_retrieve_data_fetch_too_much(
     df_result: DataSlice = snowflake_connector._fetch_data(
         snowflake_datasource, offset=10, limit=20
     )
-    assert eq.call_count == 2  # +1 select database and warehouse
+    assert eq.call_count == 3  # +1 select database and warehouse
     assert 11 == len(df_result)
     SnowflakeConnector.get_snowflake_connection_manager().force_clean()
 

--- a/tests/snowflake_oauth2/test_snowflake_oauth2.py
+++ b/tests/snowflake_oauth2/test_snowflake_oauth2.py
@@ -204,7 +204,7 @@ def test_retrieve_data(
     snowflake_oauth2_datasource,
 ):
     df_result: DataFrame = snowflake_oauth2_connector._retrieve_data(snowflake_oauth2_datasource)
-    assert eq.call_count == 2  # +1 select database and warehouse
+    assert eq.call_count == 3  # +1 select database and warehouse
     assert 11 == len(df_result)
     SnowflakeoAuth2Connector.get_connection_manager().force_clean()
 
@@ -229,7 +229,7 @@ def test_retrieve_data_slice(
     df_result: DataSlice = snowflake_oauth2_connector.get_slice(
         snowflake_oauth2_datasource, offset=0, limit=10
     )
-    assert eq.call_count == 2  # +1 select database and warehouse
+    assert eq.call_count == 3  # +1 select database and warehouse
     assert 11 == len(df_result.df)
     assert 11 == df_result.stats.total_returned_rows
     SnowflakeoAuth2Connector.get_connection_manager().force_clean()
@@ -255,7 +255,7 @@ def test_retrieve_data_slice_with_limit(
     df_result: DataSlice = snowflake_oauth2_connector.get_slice(
         snowflake_oauth2_datasource, offset=5, limit=3
     )
-    assert eq.call_count == 2  # +1 select database and warehouse
+    assert eq.call_count == 3  # +1 select database and warehouse
     assert 11 == len(df_result.df)
     assert 11 == df_result.stats.total_returned_rows
     SnowflakeoAuth2Connector.get_connection_manager().force_clean()
@@ -281,7 +281,7 @@ def test_retrieve_data_slice_too_much(
     df_result: DataSlice = snowflake_oauth2_connector.get_slice(
         snowflake_oauth2_datasource, offset=10, limit=20
     )
-    assert eq.call_count == 2  # +1 select database and warehouse
+    assert eq.call_count == 3  # +1 select database and warehouse
     assert 11 == len(df_result.df)
     assert 11 == df_result.stats.total_returned_rows
     SnowflakeoAuth2Connector.get_connection_manager().force_clean()

--- a/tests/test_snowflake_common.py
+++ b/tests/test_snowflake_common.py
@@ -140,7 +140,7 @@ def test_get_warehouse_with_filter_one_result(warehouse_result, execute_query, c
 )
 def test_retrieve_data(result, execute_query, connect, snowflake_datasource):
     df: pd.DataFrame = SnowflakeCommon().retrieve_data(connect, snowflake_datasource)
-    assert result.call_count == 2
+    assert result.call_count == 3
     assert len(df) == 14
 
 
@@ -154,7 +154,7 @@ def test_get_slice_without_limit_without_offset(
     result, execute_query, connect, snowflake_datasource
 ):
     ds: DataSlice = SnowflakeCommon().get_slice(connect, snowflake_datasource)
-    assert result.call_count == 2
+    assert result.call_count == 3
     assert len(ds.df) == 14
     assert ds.stats.total_returned_rows == 14
 
@@ -167,7 +167,7 @@ def test_get_slice_without_limit_without_offset(
 )
 def test_get_slice_with_limit_without_offset(result, execute_query, connect, snowflake_datasource):
     ds: DataSlice = SnowflakeCommon().get_slice(connect, snowflake_datasource, limit=5)
-    assert result.call_count == 2
+    assert result.call_count == 3
     assert len(ds.df) == 5
     assert ds.stats.total_returned_rows == 5
 
@@ -182,7 +182,7 @@ def test_get_slice_with_limit_without_offset_no_data(
     result, execute_query, connect, snowflake_datasource
 ):
     ds: DataSlice = SnowflakeCommon().get_slice(connect, snowflake_datasource, limit=5)
-    assert result.call_count == 2
+    assert result.call_count == 3
     assert len(ds.df) == 0
     assert ds.stats.total_returned_rows == 0
 
@@ -197,7 +197,7 @@ def test_get_slice_with_limit_without_offset_not_enough_data(
     result, execute_query, connect, snowflake_datasource
 ):
     ds: DataSlice = SnowflakeCommon().get_slice(connect, snowflake_datasource, limit=5)
-    assert result.call_count == 2
+    assert result.call_count == 3
     assert len(ds.df) == 1
     assert ds.stats.total_returned_rows == 1
 
@@ -210,7 +210,7 @@ def test_get_slice_with_limit_without_offset_not_enough_data(
 )
 def test_get_slice_with_limit_with_offset(result, execute_query, connect, snowflake_datasource):
     ds: DataSlice = SnowflakeCommon().get_slice(connect, snowflake_datasource, offset=5, limit=5)
-    assert result.call_count == 2
+    assert result.call_count == 3
     assert len(ds.df) == 14
     assert ds.stats.total_returned_rows == 14
 
@@ -225,7 +225,7 @@ def test_get_slice_with_limit_with_offset_no_data(
     result, execute_query, connect, snowflake_datasource
 ):
     ds: DataSlice = SnowflakeCommon().get_slice(connect, snowflake_datasource, offset=5, limit=5)
-    assert result.call_count == 2
+    assert result.call_count == 3
     assert len(ds.df) == 0
     assert ds.stats.total_returned_rows == 0
 
@@ -240,7 +240,7 @@ def test_get_slice_with_limit_with_offset_not_enough_data(
     result, execute_query, connect, snowflake_datasource
 ):
     ds: DataSlice = SnowflakeCommon().get_slice(connect, snowflake_datasource, offset=5, limit=5)
-    assert result.call_count == 2
+    assert result.call_count == 3
     assert len(ds.df) == 1
     assert ds.stats.total_returned_rows == 1
 
@@ -253,7 +253,7 @@ def test_get_slice_with_limit_with_offset_not_enough_data(
 )
 def test_get_slice_without_limit_with_offset(result, execute_query, connect, snowflake_datasource):
     ds: DataSlice = SnowflakeCommon().get_slice(connect, snowflake_datasource, offset=5)
-    assert result.call_count == 2
+    assert result.call_count == 3
     assert len(ds.df) == 14
     assert ds.stats.total_returned_rows == 14
 
@@ -283,7 +283,7 @@ def test_get_slice_metadata_no_select_in_query(result, snowflake_datasource, moc
     )
     connect = mocker.MagicMock()
     ds: DataSlice = SnowflakeCommon().get_slice(connect, snowflake_datasource)
-    assert result.call_count == 2
+    assert result.call_count == 3
     assert ds
 
 

--- a/tests/test_snowflake_common.py
+++ b/tests/test_snowflake_common.py
@@ -390,6 +390,7 @@ def test__describe_api_didnt_describe(connect, mocker):
     'pandas.DataFrame.from_dict',
     side_effect=[
         None,
+        None,
         pd.DataFrame(data_result_all),
         pd.DataFrame({'TOTAL_ROWS': 20}, index=[0]),
     ],
@@ -399,7 +400,7 @@ def test_retrieve_data_with_row_count_limit_in_query(connect, fetchmany, snowfla
     snowflake_datasource.query = 'select name from favourite_drinks limit 10;'
     sc = SnowflakeCommon()
     sc.retrieve_data(connect, snowflake_datasource, get_row_count=True)
-    assert fetchmany.call_count == 3  # +1 to select database and warehouse
+    assert fetchmany.call_count == 4  # +1 to select database and warehouse
     assert sc.total_rows_count == 20
 
 

--- a/toucan_connectors/snowflake_common.py
+++ b/toucan_connectors/snowflake_common.py
@@ -177,7 +177,6 @@ class SnowflakeCommon:
         limit: Optional[int] = None,
         get_row_count: bool = False,
     ) -> pd.DataFrame:
-        # prepare_query: List = []
         if data_source.database != connection.database:
             self.logger.info(f'Connection changed to use database {connection.database}')
             self._execute_query(connection, f'USE DATABASE {data_source.database}')

--- a/toucan_connectors/snowflake_common.py
+++ b/toucan_connectors/snowflake_common.py
@@ -177,16 +177,13 @@ class SnowflakeCommon:
         limit: Optional[int] = None,
         get_row_count: bool = False,
     ) -> pd.DataFrame:
-        prepare_query: List = []
+        # prepare_query: List = []
         if data_source.database != connection.database:
-            prepare_query.append(f'USE DATABASE {data_source.database}')
+            self.logger.info(f'Connection changed to use database {connection.database}')
+            self._execute_query(connection, f'USE DATABASE {data_source.database}')
         if data_source.warehouse != connection.warehouse:
-            prepare_query.append(f'USE WAREHOUSE {data_source.warehouse}')
-        if len(prepare_query) > 0:
-            self._execute_query(connection, ';'.join(prepare_query) + ';')
-            self.logger.info(
-                f'Connection changed to use database {connection.database} and warehouse {connection.warehouse}'
-            )
+            self.logger.info(f'Connection changed to use  warehouse {connection.warehouse}')
+            self._execute_query(connection, f'USE WAREHOUSE {data_source.warehouse}')
 
         ds = self._execute_parallelized_queries(
             connection, data_source.query, data_source.parameters, offset, limit, get_row_count


### PR DESCRIPTION
Snowflake doesn't accept multiple queries in a single execution.
## Change Summary

To use specific database and a specific warehouse, we made : 
- 'USE WAREHOUSE my_warehouse; USE DATABASE my_datebase'

The new format is : 
- 'USE WAREHOUSE my_warehouse'
- 'USE DATABASE my_database'

## Related issue number

https://trello.com/c/gPj8WUrq/1238-snowflake-connector-fix-query-fail-because-of-multiple-statement-query

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
