### PR TITLE
feat(snowflake): add hidden field to store query as object

### DIFF
--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -85,6 +85,7 @@ def snowflake_datasource():
         database='database_1',
         warehouse='warehouse_1',
         query='test_query with %(foo)s and %(pokemon)s',
+        query_object={"schema": "SHOW_SCHEMA", "table": "MY_TABLE", "columns": ["col1", "col2"]},
         parameters={'foo': 'bar', 'pokemon': 'pikachu'},
     )
 

--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -717,6 +717,7 @@ def test_render_datasource():
         database='database_1',
         warehouse='warehouse_1',
         query='test_query with %(foo)s and %(pokemon)s',
+        query_object={'schema': 'SHOW_SCHEMA', 'table': 'MY_TABLE', 'columns': ['col1', 'col2']},
         parameters={'foo': 'bar', 'pokemon': 'pikachu'},
     )
     key = snowflake_connector.get_cache_key(datasource)
@@ -727,6 +728,7 @@ def test_render_datasource():
         database='database_1',
         warehouse='warehouse_1',
         query='test_query with %(foo)s and %(pokemon)s',
+        query_object={'schema': 'SHOW_SCHEMA', 'table': 'MY_TABLE', 'columns': ['col1', 'col2']},
         parameters={'foo': 'bar', 'pokemon': 'pikachu', 'foo': 'bar'},
     )
     key2 = snowflake_connector.get_cache_key(datasource2)
@@ -739,6 +741,7 @@ def test_render_datasource():
         database='database_2',
         warehouse='warehouse_1',
         query='test_query with %(foo)s and %(pokemon)s',
+        query_object={'schema': 'SHOW_SCHEMA', 'table': 'MY_TABLE', 'columns': ['col1', 'col2']},
         parameters={'foo': 'bar', 'pokemon': 'pikachu'},
     )
 

--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -85,7 +85,7 @@ def snowflake_datasource():
         database='database_1',
         warehouse='warehouse_1',
         query='test_query with %(foo)s and %(pokemon)s',
-        query_object={"schema": "SHOW_SCHEMA", "table": "MY_TABLE", "columns": ["col1", "col2"]},
+        query_object={'schema': 'SHOW_SCHEMA', 'table': 'MY_TABLE', 'columns': ['col1', 'col2']},
         parameters={'foo': 'bar', 'pokemon': 'pikachu'},
     )
 

--- a/tests/snowflake_oauth2/test_snowflake_oauth2.py
+++ b/tests/snowflake_oauth2/test_snowflake_oauth2.py
@@ -48,6 +48,7 @@ def snowflake_oauth2_datasource():
         database='database_1',
         warehouse='warehouse_1',
         query='test_query with %(foo)s and %(pokemon)s',
+        query_object={"schema": "SHOW_SCHEMA", "table": "MY_TABLE", "columns": ["col1", "col2"]},
         parameters={'foo': 'bar', 'pokemon': 'pikachu'},
     )
 

--- a/tests/snowflake_oauth2/test_snowflake_oauth2.py
+++ b/tests/snowflake_oauth2/test_snowflake_oauth2.py
@@ -48,7 +48,7 @@ def snowflake_oauth2_datasource():
         database='database_1',
         warehouse='warehouse_1',
         query='test_query with %(foo)s and %(pokemon)s',
-        query_object={"schema": "SHOW_SCHEMA", "table": "MY_TABLE", "columns": ["col1", "col2"]},
+        query_object={'schema': 'SHOW_SCHEMA', 'table': 'MY_TABLE', 'columns': ['col1', 'col2']},
         parameters={'foo': 'bar', 'pokemon': 'pikachu'},
     )
 

--- a/tests/test_snowflake_common.py
+++ b/tests/test_snowflake_common.py
@@ -19,6 +19,7 @@ def snowflake_datasource():
         database='database_1',
         warehouse='warehouse_1',
         query='select * from my_table where toto=%(foo);',
+        query_object={"schema": "SHOW_SCHEMA", "table": "MY_TABLE", "columns": ["col1", "col2"]},
         parameters={'foo': 'bar', 'pokemon': 'pikachu'},
     )
 

--- a/tests/test_snowflake_common.py
+++ b/tests/test_snowflake_common.py
@@ -19,7 +19,7 @@ def snowflake_datasource():
         database='database_1',
         warehouse='warehouse_1',
         query='select * from my_table where toto=%(foo);',
-        query_object={"schema": "SHOW_SCHEMA", "table": "MY_TABLE", "columns": ["col1", "col2"]},
+        query_object={'schema': 'SHOW_SCHEMA', 'table': 'MY_TABLE', 'columns': ['col1', 'col2']},
         parameters={'foo': 'bar', 'pokemon': 'pikachu'},
     )
 

--- a/toucan_connectors/snowflake_common.py
+++ b/toucan_connectors/snowflake_common.py
@@ -50,7 +50,7 @@ class SfDataSource(ToucanDataSource):
         ...,
         description='An object describing a simple select query'
         'For example '
-        '{"schema": "SOMW_SCHEMA", "table": "MY_TABLE", columns: ["col1", "col2"]} '
+        '{"schema": "SHOW_SCHEMA", "table": "MY_TABLE", "columns": ["col1", "col2"]}'
         'This field is used internally',
         **{'ui.hidden': True},
     )

--- a/toucan_connectors/snowflake_common.py
+++ b/toucan_connectors/snowflake_common.py
@@ -46,6 +46,15 @@ class SfDataSource(ToucanDataSource):
         ..., description='You can write your SQL query here', widget='sql'
     )
 
+    query_object: Dict = Field(
+        ...,
+        description='An object describing a simple select query'
+        'For example '
+        '{"schema": "SOMW_SCHEMA", "table": "MY_TABLE", columns: ["col1", "col2"]} '
+        'This field is used internally',
+        **{'ui.hidden': True}
+    )
+
 
 class SnowflakeCommon:
     def __init__(self):

--- a/toucan_connectors/snowflake_common.py
+++ b/toucan_connectors/snowflake_common.py
@@ -47,7 +47,7 @@ class SfDataSource(ToucanDataSource):
     )
 
     query_object: Dict = Field(
-        ...,
+        None,
         description='An object describing a simple select query'
         'For example '
         '{"schema": "SHOW_SCHEMA", "table": "MY_TABLE", "columns": ["col1", "col2"]}'

--- a/toucan_connectors/snowflake_common.py
+++ b/toucan_connectors/snowflake_common.py
@@ -52,7 +52,7 @@ class SfDataSource(ToucanDataSource):
         'For example '
         '{"schema": "SOMW_SCHEMA", "table": "MY_TABLE", columns: ["col1", "col2"]} '
         'This field is used internally',
-        **{'ui.hidden': True}
+        **{'ui.hidden': True},
     )
 
 


### PR DESCRIPTION
## Change Summary
For Snowflake connection only

In some cases we want to store the query as an object (table, schema, columns) instead of a string.
Adding this as a hidden field so we can store the query object in db

## Related issue number

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
