### PR TITLE
feat(parameters): now handle the case where some parameters in a datasource are quoted, especially for SQL.

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -14,6 +14,7 @@ from toucan_connectors.common import (
     convert_to_qmark_paramstyle,
     extract_table_name,
     fetch,
+    get_param_name,
     is_interpolating_table_name,
     nosql_apply_parameters_to_query,
     pandas_read_sql,
@@ -414,3 +415,17 @@ def test_pandas_read_sql_error(mocker: MockFixture):
             params={'max_pop': 1_000_000},
         )
     assert 'Some error' in str(e.value)
+
+
+def test_get_param_name():
+    assert get_param_name("'%(FOOBAR)s'") == 'FOOBAR'
+    assert get_param_name('%(FOOBAR)s') == 'FOOBAR'
+
+
+def test_convert_to_qmark():
+    assert convert_to_qmark_paramstyle(
+        'SELECT * FROM foobar WHERE x = %(value)s', {'value': 42}
+    ) == ('SELECT * FROM foobar WHERE x = ?', [42])
+    assert convert_to_qmark_paramstyle(
+        "SELECT * FROM foobar WHERE x = '%(value)s'", {'value': 42}
+    ) == ('SELECT * FROM foobar WHERE x = ?', [42])


### PR DESCRIPTION
…
let's say that we have the following query:
`SELECT foo FROM bar WHERE x = %(VARIABLE)`. 
It must be translated to `SELECT foo FROM bar WHERE x = ?` 

The issue is that our templates are string. 

So we could get the query `SELECT foo FROM bar WHERE x = '%(VARIABLE)'` when using the weaverbird SQL generator, wich would be translated to  `SELECT foo FROM bar WHERE x = '?'` leading to literal ? in the results


* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
