### PR TITLE
fix(snowflake): require dependency with pyjwt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='1.3.20',
+    version='1.3.21',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=1.3.20
+sonar.projectVersion=1.3.21
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors


### PR DESCRIPTION
When the jwt support has been added to SnowflakeConector, the dependency has not been added to this connector's requirements.
This means, that, even with a clean install of `toucan-connectors[snowflake]` with pip, the statement `import jwt` could fail, and the connector will not be available. 
