### PR TITLE
fix(df columns type): force returned df columns to str

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='1.3.22',
+    version='1.3.23',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/tests/google_sheets/test_google_sheets.py
+++ b/tests/google_sheets/test_google_sheets.py
@@ -75,7 +75,7 @@ def test_set_columns(mocker, con, ds):
     df = con.get_df(ds)
     assert df.to_dict() == {
         'Animateur': {1: 'pika', 2: 'bulbi'},
-        1: {1: '', 2: ''},
-        2: {1: 'a', 2: ''},
+        '1': {1: '', 2: ''},
+        '2': {1: 'a', 2: ''},
         'Week': {1: 'W1', 2: 'W2'},
     }

--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -149,8 +149,8 @@ def test_set_columns(mocker, con, ds):
     df = con.get_df(ds)
     assert df.to_dict() == {
         'Animateur': {1: 'pika', 2: 'bulbi'},
-        1: {1: '', 2: ''},
-        2: {1: 'a', 2: ''},
+        '1': {1: '', 2: ''},
+        '2': {1: 'a', 2: ''},
         'Week': {1: 'W1', 2: 'W2'},
     }
 

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -333,6 +333,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         filtered by permissions
         """
         res = self._retrieve_data(data_source)
+        res.columns = res.columns.astype(str)
 
         if permissions is not None:
             permissions_query = PandasConditionTranslator.translate(permissions)


### PR DESCRIPTION
This PR fixes an issue encountered in data prep: 
our open source data prep pipeline ("youPrep") for mongo doesn't allow manipulating columns named with numbers.
To ensure we have the same behaviour with "youPrep" for pandas we force all column names to strings. 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%