### PR TITLE
fix(snowflake): do not switch to data source warehouse if none

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='1.3.23',
+    version='1.3.24',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/tests/test_snowflake_common.py
+++ b/tests/test_snowflake_common.py
@@ -411,3 +411,25 @@ def test_retrieve_total_rows():
     sc = SnowflakeCommon()
     sc.set_total_returned_rows_count(20)
     assert sc.total_returned_rows_count == 20
+
+
+@patch(
+    'toucan_connectors.snowflake_common.SnowflakeCommon._execute_query',
+)
+@patch(
+    'toucan_connectors.snowflake_common.SnowflakeCommon._execute_parallelized_queries',
+)
+@patch('snowflake.connector.connect', return_value=snowflake.connector.SnowflakeConnection)
+def test_fetch_data_warehouse_none(execute_query, execute_parallelized, connect):
+    """The connection's warehouse should not be switched to datasource's if none"""
+    s = SnowflakeDataSource(
+        name='test_name',
+        domain='test_domain',
+        database='database_1',
+        warehouse=None,
+        query='select * from my_table where toto=%(foo);',
+        query_object={'schema': 'SHOW_SCHEMA', 'table': 'MY_TABLE', 'columns': ['col1', 'col2']},
+        parameters={'foo': 'bar', 'pokemon': 'pikachu'},
+    )
+    SnowflakeCommon().fetch_data(connect, s)
+    assert execute_query.call_count == 0

--- a/toucan_connectors/snowflake_common.py
+++ b/toucan_connectors/snowflake_common.py
@@ -201,7 +201,7 @@ class SnowflakeCommon:
         if data_source.database != connection.database:
             self.logger.info(f'Connection changed to use database {connection.database}')
             self._execute_query(connection, f'USE DATABASE {data_source.database}')
-        if data_source.warehouse != connection.warehouse:
+        if data_source.warehouse and data_source.warehouse != connection.warehouse:
             self.logger.info(f'Connection changed to use  warehouse {connection.warehouse}')
             self._execute_query(connection, f'USE WAREHOUSE {data_source.warehouse}')
 


### PR DESCRIPTION
Fix an issue on Snowflake's connectors when the data source's connector is None.

If Data Source Warehouse is None, it might be != than available open connection BUT we do not want to switch to a None warehouse in connection.
In this case, continue to use the available connection.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%