### PR TITLE
fix(sql queries): table is always an optionnal field

### DIFF
--- a/tests/clickhouse/test_clickhouse.py
+++ b/tests/clickhouse/test_clickhouse.py
@@ -165,6 +165,7 @@ def test_get_form_query_with_good_database(clickhouse_connector):
         'type': 'string',
         'enum': ['city'],
     }
+    assert form['required'] == ['domain', 'name', 'database']
 
 
 def test_get_form_connection_fails(mocker, clickhouse_connector):

--- a/tests/mssql/test_mssql.py
+++ b/tests/mssql/test_mssql.py
@@ -232,3 +232,4 @@ def test_get_form_query_with_good_database(mssql_connector):
     }
     assert form['properties']['table'] == {'$ref': '#/definitions/table'}
     assert 'City' in form['definitions']['table']['enum']
+    assert form['required'] == ['domain', 'name', 'database']

--- a/tests/mssql_TLSv1_0/test_mssql_TLSv1_0.py
+++ b/tests/mssql_TLSv1_0/test_mssql_TLSv1_0.py
@@ -236,3 +236,4 @@ def test_get_form_query_with_good_database(mssql_connector):
     }
     assert form['properties']['table'] == {'$ref': '#/definitions/table'}
     assert 'City' in form['definitions']['table']['enum']
+    assert form['required'] == ['domain', 'name', 'database']

--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -366,6 +366,7 @@ def test_get_form_query_with_good_database(mysql_connector):
         'type': 'string',
         'enum': ['City', 'Country', 'CountryLanguage'],
     }
+    assert form['required'] == ['domain', 'name', 'database']
 
 
 def test_handle_date_0():

--- a/tests/oracle_sql/test_oracle_sql.py
+++ b/tests/oracle_sql/test_oracle_sql.py
@@ -103,6 +103,7 @@ def test_get_form_empty_query(oracle_connector):
     current_config = {}
     form = OracleSQLDataSource.get_form(oracle_connector, current_config)
     assert 'CITY' in form['definitions']['table']['enum']
+    assert form['required'] == ['domain', 'name']
 
 
 def test_datasource():

--- a/toucan_connectors/clickhouse/clickhouse_connector.py
+++ b/toucan_connectors/clickhouse/clickhouse_connector.py
@@ -72,7 +72,7 @@ class ClickhouseDataSource(ToucanDataSource):
                     )
                     res = cursor.fetchall()
                     available_tables = [table[0] for table in res]
-                    constraints['table'] = strlist_to_enum('table', available_tables)
+                    constraints['table'] = strlist_to_enum('table', available_tables, None)
 
         return create_model('FormSchema', **constraints, __base__=cls).schema()
 

--- a/toucan_connectors/mssql/mssql_connector.py
+++ b/toucan_connectors/mssql/mssql_connector.py
@@ -63,7 +63,7 @@ class MSSQLDataSource(ToucanDataSource):
                     cursor.execute('SELECT TABLE_NAME FROM  INFORMATION_SCHEMA.TABLES;')
                     res = cursor.fetchall()
                     available_tables = [table_name for (table_name,) in res]
-                    constraints['table'] = strlist_to_enum('table', available_tables)
+                    constraints['table'] = strlist_to_enum('table', available_tables, None)
 
         return create_model('FormSchema', **constraints, __base__=cls).schema()
 

--- a/toucan_connectors/mssql_TLSv1_0/mssql_connector.py
+++ b/toucan_connectors/mssql_TLSv1_0/mssql_connector.py
@@ -64,7 +64,7 @@ class MSSQLDataSource(ToucanDataSource):
                     cursor.execute('SELECT TABLE_NAME FROM  INFORMATION_SCHEMA.TABLES;')
                     res = cursor.fetchall()
                     available_tables = [table_name for (table_name,) in res]
-                    constraints['table'] = strlist_to_enum('table', available_tables)
+                    constraints['table'] = strlist_to_enum('table', available_tables, None)
 
         return create_model('FormSchema', **constraints, __base__=cls).schema()
 

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -82,7 +82,7 @@ class MySQLDataSource(ToucanDataSource):
                     cursor.execute('SHOW TABLES;')
                     res = cursor.fetchall()
                     available_tables = [table_name for (table_name,) in res]
-                    constraints['table'] = strlist_to_enum('table', available_tables)
+                    constraints['table'] = strlist_to_enum('table', available_tables, None)
 
         return create_model('FormSchema', **constraints, __base__=cls).schema()
 

--- a/toucan_connectors/oracle_sql/oracle_sql_connector.py
+++ b/toucan_connectors/oracle_sql/oracle_sql_connector.py
@@ -45,7 +45,7 @@ class OracleSQLDataSource(ToucanDataSource):
                 # Filter tables starting with an '_' because strlist_to_enum cannot
                 # set attributes starting with '_'
                 available_tables = [table_name for (table_name,) in res if table_name[0] != '_']
-                constraints['table'] = strlist_to_enum('table', available_tables)
+                constraints['table'] = strlist_to_enum('table', available_tables, None)
 
         return create_model('FormSchema', **constraints, __base__=cls).schema()
 


### PR DESCRIPTION
## Change Summary

Same than https://github.com/ToucanToco/toucan-connectors/pull/498 for every other connectors that got a "table" field that should be optional.

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
