### PR TITLE
feat(snowflake): add a default order by at the end of the query TCTC-659

### DIFF
--- a/tests/test_snowflake_common.py
+++ b/tests/test_snowflake_common.py
@@ -437,10 +437,17 @@ def test_fetch_data_warehouse_none(execute_query, execute_parallelized, connect)
 
 def test_add_default_order_if_needed():
     """Test if the add of a default order works as expected"""
-    query_with_order_by = SnowflakeCommon().add_default_order_if_needed('WITH SELECT_STEP_... ORDER BY X', ['COLUMN'])
-    query_with_columns = SnowflakeCommon().add_default_order_if_needed('WITH SELECT_STEP_...', ['COLUMN'])
+    query_with_order_by = SnowflakeCommon().add_default_order_if_needed(
+        'WITH SELECT_STEP_... ORDER BY X', ['COLUMN']
+    )
+    query_with_columns = SnowflakeCommon().add_default_order_if_needed(
+        'WITH SELECT_STEP_...', ['COLUMN']
+    )
     query_without_columns = SnowflakeCommon().add_default_order_if_needed('WITH SELECT_STEP_...')
 
     assert query_with_order_by == 'WITH SELECT_STEP_... ORDER BY X'
-    assert query_with_columns == 'WITH SELECT_STEP_... ORDER BY ROW_NUMBER() OVER (ORDER BY COLUMN ASC)'
+    assert (
+        query_with_columns
+        == 'WITH SELECT_STEP_... ORDER BY ROW_NUMBER() OVER (ORDER BY COLUMN ASC)'
+    )
     assert query_without_columns == 'WITH SELECT_STEP_...'

--- a/tests/test_snowflake_common.py
+++ b/tests/test_snowflake_common.py
@@ -438,16 +438,25 @@ def test_fetch_data_warehouse_none(execute_query, execute_parallelized, connect)
 def test_add_default_order_if_needed():
     """Test if the add of a default order works as expected"""
     query_with_order_by = SnowflakeCommon().add_default_order_if_needed(
-        'WITH SELECT_STEP_... ORDER BY X', ['COLUMN']
+        'SELECT ... ORDER BY X', ['COLUMN']
+    )
+    query_with_order_by_break_line = SnowflakeCommon().add_default_order_if_needed(
+        """SELECT
+... ORDER
+BY X""",
+        ['COLUMN'],
     )
     query_with_columns = SnowflakeCommon().add_default_order_if_needed(
-        'WITH SELECT_STEP_...', ['COLUMN']
+        'SELECT ...', ['COLUMN', 'COLUMN2']
     )
-    query_without_columns = SnowflakeCommon().add_default_order_if_needed('WITH SELECT_STEP_...')
+    query_without_columns = SnowflakeCommon().add_default_order_if_needed('SELECT ...')
 
-    assert query_with_order_by == 'WITH SELECT_STEP_... ORDER BY X'
+    assert query_with_order_by == 'SELECT ... ORDER BY X'
     assert (
-        query_with_columns
-        == 'WITH SELECT_STEP_... ORDER BY ROW_NUMBER() OVER (ORDER BY COLUMN ASC)'
+        query_with_order_by_break_line
+        == """SELECT
+... ORDER
+BY X"""
     )
-    assert query_without_columns == 'WITH SELECT_STEP_...'
+    assert query_with_columns == 'SELECT ... ORDER BY COLUMN, COLUMN2'
+    assert query_without_columns == 'SELECT ...'

--- a/tests/test_snowflake_common.py
+++ b/tests/test_snowflake_common.py
@@ -433,3 +433,14 @@ def test_fetch_data_warehouse_none(execute_query, execute_parallelized, connect)
     )
     SnowflakeCommon().fetch_data(connect, s)
     assert execute_query.call_count == 0
+
+
+def test_add_default_order_if_needed():
+    """Test if the add of a default order works as expected"""
+    query_with_order_by = SnowflakeCommon().add_default_order_if_needed('WITH SELECT_STEP_... ORDER BY X', ['COLUMN'])
+    query_with_columns = SnowflakeCommon().add_default_order_if_needed('WITH SELECT_STEP_...', ['COLUMN'])
+    query_without_columns = SnowflakeCommon().add_default_order_if_needed('WITH SELECT_STEP_...')
+
+    assert query_with_order_by == 'WITH SELECT_STEP_... ORDER BY X'
+    assert query_with_columns == 'WITH SELECT_STEP_... ORDER BY ROW_NUMBER() OVER (ORDER BY COLUMN ASC)'
+    assert query_without_columns == 'WITH SELECT_STEP_...'

--- a/toucan_connectors/snowflake_common.py
+++ b/toucan_connectors/snowflake_common.py
@@ -147,13 +147,8 @@ class SnowflakeCommon:
         query: str,
         query_columns: Optional[List] = None,
     ):
-        """
-        if it's a SELECT type query and there is not an 'ORDER BY' inside,
-        we sort with the first column of the dataset
-
-        query: the query sting
-        query_columns: the query's columns
-        """
+        """If it's a SELECT type query and there is not an 'ORDER BY' inside, we sort with the first column of the
+        dataset"""
 
         if query_columns and 'WITH SELECT_STEP_' in query and ' ORDER BY ' not in query:
             # we append the order from row_number on the first column

--- a/toucan_connectors/sql_query_helper.py
+++ b/toucan_connectors/sql_query_helper.py
@@ -32,12 +32,9 @@ class SqlQueryHelper:
         )
         query_check = prepared_query.strip().lower()
         if not query_check.startswith('show') and not query_check.startswith('describe'):
-            if limit and offset:
-                prepared_query = prepared_query.replace(';', '')
-                prepared_query = f'SELECT * FROM ({prepared_query}) LIMIT {limit} OFFSET {offset};'
-            elif limit:
-                prepared_query = prepared_query.replace(';', '')
-                prepared_query = f'SELECT * FROM ({prepared_query}) LIMIT {limit};'
+            if limit:
+                prepared_query = f'SELECT * FROM ({prepared_query.replace(";", "")}) LIMIT {limit}'
+                prepared_query += f' OFFSET {offset};' if offset else ';'
 
         return prepared_query, prepared_values
 


### PR DESCRIPTION
## Change Summary
- Added a default Order By at the end of a Snowflake query for consistent pagination
- Cleaned the prepare_limit_query function from sql_query_helper

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Coverage of the code
