### PR TITLE
feat(http): support for custom auth-schemes when using custom_token_server

### DIFF
--- a/toucan_connectors/auth.py
+++ b/toucan_connectors/auth.py
@@ -81,7 +81,12 @@ class CustomTokenServer(AuthBase):
         res = session.request(**self.request_kwargs)
         token = pyjq.first(self.filter, res.json())
 
-        r.headers['Authorization'] = f'Bearer {token}'
+        # If a single string is returned by the filter default
+        # on OAuth "Bearer" auth-scheme.
+        if len(f'{token}'.split(maxsplit=2)) == 1:
+            token = f'Bearer {token}'
+
+        r.headers['Authorization'] = token
         return r
 
 


### PR DESCRIPTION
## Change Summary

RFC 2617 standard on HTTP Authentication states that credentials should consist of at least a scheme and arbitrary parameters:

`credentials = auth-scheme #auth-param`

In practice auth-scheme is often "Bearer" because it is used in the OAuth2 standard [1, 2]. This is our default, the initial request made to the `custom_token_server` will be used in the the Authorization header after the Bearer auth-scheme.

This PR adds support for alternative auth-schemes in this case the `filter` should emit the compltete value of the Authorization header. For example : 

```json
{"token": "<some token>"}
```


```cson
filter : '"AnaplanAuthToken \(.token)"'
```

will result in a header that looks like this : 


```
Authorization: AnaplanAuthToken <some token>
```

This change is backward compatible (keep the same behaviour, make it a default that can be extended).

[1] https://datatracker.ietf.org/doc/html/rfc6750#section-2.1
[2] https://stackoverflow.com/a/53228252

## Related issue number


## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
