### PR TITLE
fix(clickhouse): add information_schema db to tests

### DIFF
--- a/tests/clickhouse/test_clickhouse.py
+++ b/tests/clickhouse/test_clickhouse.py
@@ -155,7 +155,7 @@ def test_get_form_query_with_good_database(clickhouse_connector):
     assert form['definitions']['database'] == {
         'title': 'database',
         'description': 'An enumeration.',
-        'enum': ['clickhouse_db', 'default'],
+        'enum': ['INFORMATION_SCHEMA', 'clickhouse_db', 'default', 'information_schema'],
         'type': 'string',
     }
     assert form['properties']['table'] == {'$ref': '#/definitions/table'}


### PR DESCRIPTION
## Change Summary

The latest ClickHouse release https://github.com/ClickHouse/ClickHouse/blob/master/CHANGELOG.md#new-feature adds an `INFORMATION_SCHEMA` database and we see this in an assertion in our tests, this PR updates the test so that it does not fail.

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
