### PR TITLE
fix(deps) upgrade aiohttp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 
 install_requires = [
     'authlib',
-    'aiohttp<3.7.0',
+    'aiohttp>=3.7.4',
     'cached_property',
     'jinja2',
     'pydantic',


### PR DESCRIPTION
## Change Summary

Upgrade `aoihttp` following this alert : https://github.com/ToucanToco/toucan-connectors/security/dependabot/setup.py/aiohttp/open

It was pinned by Florent here : https://github.com/ToucanToco/toucan-connectors/commit/bf8e03061f5fd811fa70e3c8cc70010bd774e6a4 but I don't know why.

## Related issue

https://github.com/ToucanToco/toucan-connectors/security/dependabot/setup.py/aiohttp/open

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
