### PR TITLE
feat(one drive): append multiple sheets

### DIFF
--- a/tests/one_drive/test_one_drive.py
+++ b/tests/one_drive/test_one_drive.py
@@ -67,6 +67,19 @@ def ds_with_site():
 
 
 @fixture
+def ds_with_site_sheme():
+    return OneDriveDataSource(
+        name='test_name',
+        domain='test_domain',
+        file='test_file',
+        sheet='test_sheet',
+        range='A2:B3',
+        site_url='https://company_name.sharepoint.com/sites/site_name/',
+        document_library='Documents',
+    )
+
+
+@fixture
 def ds_with_site_without_range():
     return OneDriveDataSource(
         name='test_name',
@@ -231,7 +244,8 @@ def test_run_fetch(con, mocker):
 
 
 @responses.activate
-def test_get_site_id(con, mocker, ds_with_site):
+def test_get_site_id(con, mocker, ds_with_site, ds_with_site_sheme):
+    """It should return a site id from a site url (including or not the https:// prefix, ending or not with /)"""
     responses.add(
         responses.GET,
         'https://graph.microsoft.com/v1.0/sites/company_name.sharepoint.com:/sites/site_name',
@@ -240,6 +254,9 @@ def test_get_site_id(con, mocker, ds_with_site):
     )
 
     id = con._get_site_id(ds_with_site)
+    assert id == 1
+
+    id = con._get_site_id(ds_with_site_sheme)
     assert id == 1
 
 

--- a/toucan_connectors/one_drive/one_drive_connector.py
+++ b/toucan_connectors/one_drive/one_drive_connector.py
@@ -26,7 +26,12 @@ class OneDriveDataSource(ToucanDataSource):
         placeholder='Only for SharePoint',
     )
     file: str
-    sheet: str
+    sheet: str = Field(
+        None,
+        Title='Sheets',
+        description='Read one sheet or append multiple sheets',
+        placeholder='Enter a sheet or a comma separated list of sheets',
+    )
     range: Optional[str]
 
 
@@ -133,16 +138,16 @@ class OneDriveConnector(ToucanConnector):
             if library['displayName'] == data_source.document_library:
                 return library['id']
 
-    def _format_url(self, data_source):
+    def _format_url(self, data_source, sheet):
         logging.getLogger(__name__).debug('_format_url')
 
         if data_source.site_url and data_source.document_library:
             site_id = self._get_site_id(data_source)
             list_id = self._get_list_id(data_source, site_id)
 
-            url = f'https://graph.microsoft.com/v1.0/sites/{site_id}/lists/{list_id}/drive/root:/{data_source.file}:/workbook/worksheets/{data_source.sheet}/'
+            url = f'https://graph.microsoft.com/v1.0/sites/{site_id}/lists/{list_id}/drive/root:/{data_source.file}:/workbook/worksheets/{sheet}/'
         else:
-            url = f'https://graph.microsoft.com/v1.0/me/drive/root:/{data_source.file}:/workbook/worksheets/{data_source.sheet}/'
+            url = f'https://graph.microsoft.com/v1.0/me/drive/root:/{data_source.file}:/workbook/worksheets/{sheet}/'
 
         if data_source.range is None:
             url = url + 'usedRange(valuesOnly=true)'
@@ -163,17 +168,29 @@ class OneDriveConnector(ToucanConnector):
 
     def _retrieve_data(self, data_source: OneDriveDataSource) -> pd.DataFrame:
         logging.getLogger(__name__).debug('_retrieve_data')
-        url = self._format_url(data_source)
 
-        response = self._run_fetch(url)
+        df_sheet_all = pd.DataFrame()
 
-        data = response.get('values')
+        sheet_list = data_source.sheet.replace(', ', ',').split(',')
 
-        if not data:
-            logging.getLogger(__name__).debug('No data retrieved from response')
-            return pd.DataFrame()
+        for sheet in sheet_list:
+            url = self._format_url(data_source, sheet)
 
-        cols = data[0]
-        data.pop(0)
+            response = self._run_fetch(url)
 
-        return pd.DataFrame(data, columns=cols)
+            data = response.get('values')
+
+            if not data:
+                logging.getLogger(__name__).debug('No data retrieved from response')
+                return pd.DataFrame()
+
+            cols = data[0]
+            data.pop(0)
+
+            df_sheet_current = pd.DataFrame(data, columns=cols)
+            if len(sheet_list) > 1:
+                df_sheet_current['__sheetname__'] = sheet
+
+            df_sheet_all = df_sheet_all.append(df_sheet_current)
+
+        return df_sheet_all

--- a/toucan_connectors/one_drive/one_drive_connector.py
+++ b/toucan_connectors/one_drive/one_drive_connector.py
@@ -25,7 +25,11 @@ class OneDriveDataSource(ToucanDataSource):
         description='Access a sharePoint library (Documents)',
         placeholder='Only for SharePoint',
     )
-    file: str
+    file: str = Field(
+        None,
+        Title='File',
+        placeholder='Enter your path file',
+    )
     sheet: str = Field(
         None,
         Title='Sheets',
@@ -117,8 +121,9 @@ class OneDriveConnector(ToucanConnector):
         access_token = self._get_access_token()
         headers = {'Authorization': f'Bearer {access_token}'}
 
-        baseroute = data_source.site_url.split('/', 1)[0]
-        endpoint = data_source.site_url.split('/', 1)[1]
+        site_url = data_source.site_url.replace('https://', '').rstrip('/')
+        baseroute = site_url.split('/', 1)[0]
+        endpoint = site_url.split('/', 1)[1]
 
         url = f'https://graph.microsoft.com/v1.0/sites/{baseroute}:/{endpoint}'
         response = requests.get(url, headers=headers)


### PR DESCRIPTION
Hi Toucan,

Here is my PR to append multiple sheets in One Drive.
The user can specify a singe sheet or a comma separeted list of sheets (ie: "sheet1, sheet2" or "sheet1,sheet2").
If multiple sheets are defiened by the user, a ` __sheetname__` column containing the sheet name will be created.
