### PR TITLE
fix(mongo connector): mongo `get_slice` method now return total count in `total_rows` and returned count in `total_returned_rows`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='1.3.25',
+    version='1.3.26',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -226,25 +226,29 @@ def test_get_slice(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
     res = mongo_connector.get_slice(datasource)
     assert res.stats.total_returned_rows == 3
+    assert res.stats.total_rows == 3
     assert res.df.shape == (3, 5)
     assert res.df['country'].tolist() == ['France', 'England', 'Germany']
 
     # With a limit
     res = mongo_connector.get_slice(datasource, limit=1)
     expected = pd.DataFrame({'country': ['France'], 'language': ['French'], 'value': [20]})
-    assert res.stats.total_returned_rows == 3
+    assert res.stats.total_returned_rows == 1
+    assert res.stats.total_rows == 3
     assert res.df.shape == (1, 5)
     assert res.df[['country', 'language', 'value']].equals(expected)
 
     # With a offset
     res = mongo_connector.get_slice(datasource, offset=1)
-    assert res.stats.total_returned_rows == 3
+    assert res.stats.total_returned_rows == 2
+    assert res.stats.total_rows == 3
     assert res.df.shape == (2, 5)
     assert res.df['country'].tolist() == ['England', 'Germany']
 
     # With both
     res = mongo_connector.get_slice(datasource, offset=1, limit=1)
-    assert res.stats.total_returned_rows == 3
+    assert res.stats.total_returned_rows == 1
+    assert res.stats.total_rows == 3
     assert res.df.shape == (1, 5)
     assert res.df.loc[0, 'country'] == 'England'
 
@@ -260,7 +264,8 @@ def test_get_slice_with_group_agg(mongo_connector, mongo_datasource):
         ],
     )
     dataslice = mongo_connector.get_slice(datasource, limit=1)
-    assert dataslice.stats.total_returned_rows == 3
+    assert dataslice.stats.total_returned_rows == 1
+    assert dataslice.stats.total_rows == 3
     assert dataslice.df.shape == (1, 1)
     assert dataslice.df.iloc[0].pays in ['France', 'England', 'Germany']
 

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -233,21 +233,21 @@ def test_get_slice(mongo_connector, mongo_datasource):
     # With a limit
     res = mongo_connector.get_slice(datasource, limit=1)
     expected = pd.DataFrame({'country': ['France'], 'language': ['French'], 'value': [20]})
-    assert res.stats.total_returned_rows == 1
+    assert res.stats.total_returned_rows == 3
     assert res.stats.total_rows == 3
     assert res.df.shape == (1, 5)
     assert res.df[['country', 'language', 'value']].equals(expected)
 
     # With a offset
     res = mongo_connector.get_slice(datasource, offset=1)
-    assert res.stats.total_returned_rows == 2
+    assert res.stats.total_returned_rows == 3
     assert res.stats.total_rows == 3
     assert res.df.shape == (2, 5)
     assert res.df['country'].tolist() == ['England', 'Germany']
 
     # With both
     res = mongo_connector.get_slice(datasource, offset=1, limit=1)
-    assert res.stats.total_returned_rows == 1
+    assert res.stats.total_returned_rows == 3
     assert res.stats.total_rows == 3
     assert res.df.shape == (1, 5)
     assert res.df.loc[0, 'country'] == 'England'
@@ -264,7 +264,7 @@ def test_get_slice_with_group_agg(mongo_connector, mongo_datasource):
         ],
     )
     dataslice = mongo_connector.get_slice(datasource, limit=1)
-    assert dataslice.stats.total_returned_rows == 1
+    assert dataslice.stats.total_returned_rows == 3
     assert dataslice.stats.total_rows == 3
     assert dataslice.df.shape == (1, 1)
     assert dataslice.df.iloc[0].pays in ['France', 'England', 'Germany']

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -238,7 +238,7 @@ class MongoConnector(ToucanConnector):
         else:
             df = self.get_df(data_source, permissions)
             total_count = len(df)
-        return DataSlice(df, stats=DataStats(total_returned_rows=total_count))
+        return DataSlice(df, stats=DataStats(total_returned_rows=len(df), total_rows=total_count))
 
     def get_df_with_regex(
         self,

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -238,7 +238,9 @@ class MongoConnector(ToucanConnector):
         else:
             df = self.get_df(data_source, permissions)
             total_count = len(df)
-        return DataSlice(df, stats=DataStats(total_returned_rows=total_count, total_rows=total_count))
+        return DataSlice(
+            df, stats=DataStats(total_returned_rows=total_count, total_rows=total_count)
+        )
 
     def get_df_with_regex(
         self,

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -238,7 +238,7 @@ class MongoConnector(ToucanConnector):
         else:
             df = self.get_df(data_source, permissions)
             total_count = len(df)
-        return DataSlice(df, stats=DataStats(total_returned_rows=len(df), total_rows=total_count))
+        return DataSlice(df, stats=DataStats(total_returned_rows=total_count, total_rows=total_count))
 
     def get_df_with_regex(
         self,


### PR DESCRIPTION
## Change Summary

The mongo connector was not filling metadatas properly.
`total_returned_rows` was the size of the collection.
`total_rows` was empty

Now, `total_rows` is the len of the collection
`total_returned_rows` is not modified by this PR, but should be deprecated at some point


## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
