### PR TITLE
feat(base connector): always set df memory size TCTC-1472

### DIFF
--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -362,24 +362,15 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
             rows from a request, before limit (Snowflake)
         """
         df = self.get_df(data_source, permissions)
-        if limit is not None:
-            return DataSlice(
-                df[offset : offset + limit],
-                stats=DataStats(
-                    total_returned_rows=len(df),
-                    total_rows=len(df),
-                    df_memory_size=df.memory_usage().sum(),
-                ),
-            )
-        else:
-            return DataSlice(
-                df[offset:],
-                stats=DataStats(
-                    total_returned_rows=len(df),
-                    total_rows=len(df),
-                    df_memory_size=df.memory_usage().sum(),
-                ),
-            )
+        truncated_df = df[offset : offset + limit] if limit is not None else df[offset:]
+        return DataSlice(
+            truncated_df,
+            stats=DataStats(
+                total_returned_rows=len(df),
+                total_rows=len(df),
+                df_memory_size=df.memory_usage().sum(),
+            ),
+        )
 
     def explain(self, data_source: ToucanDataSource, permissions: Optional[dict] = None):
         """Method to give metrics about the query"""

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -365,11 +365,20 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         if limit is not None:
             return DataSlice(
                 df[offset : offset + limit],
-                stats=DataStats(total_returned_rows=len(df), total_rows=len(df)),
+                stats=DataStats(
+                    total_returned_rows=len(df),
+                    total_rows=len(df),
+                    df_memory_size=df.memory_usage().sum(),
+                ),
             )
         else:
             return DataSlice(
-                df[offset:], stats=DataStats(total_returned_rows=len(df), total_rows=len(df))
+                df[offset:],
+                stats=DataStats(
+                    total_returned_rows=len(df),
+                    total_rows=len(df),
+                    df_memory_size=df.memory_usage().sum(),
+                ),
             )
 
     def explain(self, data_source: ToucanDataSource, permissions: Optional[dict] = None):


### PR DESCRIPTION
## Change Summary

The `df_memory_size` field of the DataStats class is so useful to know the size of the downloaded/extracted dataframe before "pagination truncation" that we should have it set all the time !

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
