### PR TITLE
Feat/postgres describe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='1.3.32',
+    version='1.3.33',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## Change Summary

In order to enable a "Postgres/Redshift" VQB translator, we need to provide a `describe` method to the Postgres connector.
My implementation is quite naive (opening an adhoc connection) but it should do the job.

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
