### PR TITLE
chore: enable autocommit & release 1.3.37 for redshift

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='1.3.36',
+    version='1.3.37',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=1.3.36
+sonar.projectVersion=1.3.37
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors

--- a/toucan_connectors/redshift/redshift_database_connector.py
+++ b/toucan_connectors/redshift/redshift_database_connector.py
@@ -200,11 +200,13 @@ class RedshiftConnector(ToucanConnector):
         """Establish a connection to an Amazon Redshift cluster."""
 
         def connect_function() -> redshift_connector.Connection:
-            return redshift_connector.connect(
+            con = redshift_connector.connect(
                 **self._get_connection_params(
                     database=datasource.database if datasource is not None else None,
-                )
+                ),
             )
+            con.autocommit = True  # see https://stackoverflow.com/q/22019154
+            return con
 
         def alive_function(connection) -> bool:
             logger.info(f'Alive Redshift connection: {connection}')


### PR DESCRIPTION
Releasing the 1337 version + set autocommit to true in redshift connector. see: https://stackoverflow.com/q/22019154 
It was causing issues because, with autocommit off, failing queries blocked further valid queries. 

