### PR TITLE
fix(postgres): not using hostname any more (host is enough) TCTC-1603

### DIFF
--- a/doc/connectors/postgres.md
+++ b/doc/connectors/postgres.md
@@ -7,9 +7,7 @@ Import data from PostgreSQL.
 * `type`: `"Postgres"`
 * `name`: str, required
 * `user`: str, required
-* `host` or `hostname` : str, required
-  - If you have a host name (eg aeaze.toucan.com), use the `hostname` parameter
-  - If you have an IP address (e.g. 1.2.3.4), use the `host` parameter
+* `host` : str, required - either a host name (eg aeaze.toucan.com) or anIP address (e.g. 1.2.3.4)
 * `charset`: str
 * `password`: str
 * `port`: int
@@ -21,7 +19,6 @@ DATA_PROVIDERS: [
   name:    '<name>'
   user:    '<user>'
   host:    '<host>'
-  hostname:    '<hostname>'
   charset:    '<charset>'
   password:    '<password>'
   port:    <port>

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='1.3.39',
+    version='1.3.40',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=1.3.39
+sonar.projectVersion=1.3.40
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors

--- a/tests/postgres/test_postgres.py
+++ b/tests/postgres/test_postgres.py
@@ -44,7 +44,7 @@ def test_get_status_all_good(postgres_connector):
     assert postgres_connector.get_status() == ConnectorStatus(
         status=True,
         details=[
-            ('Hostname resolved', True),
+            ('Host resolved', True),
             ('Port opened', True),
             ('Host connection', True),
             ('Authenticated', True),
@@ -57,7 +57,7 @@ def test_get_status_bad_host(postgres_connector):
     status = postgres_connector.get_status()
     assert status.status is False
     assert status.details == [
-        ('Hostname resolved', False),
+        ('Host resolved', False),
         ('Port opened', None),
         ('Host connection', None),
         ('Authenticated', None),
@@ -70,7 +70,7 @@ def test_get_status_bad_port(postgres_connector):
     status = postgres_connector.get_status()
     assert status.status is False
     assert status.details == [
-        ('Hostname resolved', True),
+        ('Host resolved', True),
         ('Port opened', False),
         ('Host connection', None),
         ('Authenticated', None),
@@ -87,7 +87,7 @@ def test_get_status_bad_connection(postgres_connector, unused_port, mocker):
     status = postgres_connector.get_status()
     assert status.status is False
     assert status.details == [
-        ('Hostname resolved', True),
+        ('Host resolved', True),
         ('Port opened', True),
         ('Host connection', False),
         ('Authenticated', None),
@@ -100,7 +100,7 @@ def test_get_status_bad_authentication(postgres_connector):
     status = postgres_connector.get_status()
     assert status.status is False
     assert status.details == [
-        ('Hostname resolved', True),
+        ('Host resolved', True),
         ('Port opened', True),
         ('Host connection', True),
         ('Authenticated', False),

--- a/tests/postgres/test_postgres.py
+++ b/tests/postgres/test_postgres.py
@@ -46,7 +46,7 @@ def test_get_status_all_good(postgres_connector):
         details=[
             ('Host resolved', True),
             ('Port opened', True),
-            ('Host connection', True),
+            ('Connected to PostgreSQL', True),
             ('Authenticated', True),
         ],
     )
@@ -59,7 +59,7 @@ def test_get_status_bad_host(postgres_connector):
     assert status.details == [
         ('Host resolved', False),
         ('Port opened', None),
-        ('Host connection', None),
+        ('Connected to PostgreSQL', None),
         ('Authenticated', None),
     ]
     assert status.error == '[Errno -3] Temporary failure in name resolution'
@@ -72,7 +72,7 @@ def test_get_status_bad_port(postgres_connector):
     assert status.details == [
         ('Host resolved', True),
         ('Port opened', False),
-        ('Host connection', None),
+        ('Connected to PostgreSQL', None),
         ('Authenticated', None),
     ]
     assert status.error == '[Errno 111] Connection refused'
@@ -89,7 +89,7 @@ def test_get_status_bad_connection(postgres_connector, unused_port, mocker):
     assert status.details == [
         ('Host resolved', True),
         ('Port opened', True),
-        ('Host connection', False),
+        ('Connected to PostgreSQL', False),
         ('Authenticated', None),
     ]
     assert 'Connection refused' in status.error
@@ -102,7 +102,7 @@ def test_get_status_bad_authentication(postgres_connector):
     assert status.details == [
         ('Host resolved', True),
         ('Port opened', True),
-        ('Host connection', True),
+        ('Connected to PostgreSQL', True),
         ('Authenticated', False),
     ]
     assert 'password authentication failed for user "pika"' in status.error

--- a/toucan_connectors/postgres/postgresql_connector.py
+++ b/toucan_connectors/postgres/postgresql_connector.py
@@ -76,15 +76,8 @@ class PostgresConnector(ToucanConnector):
 
     data_source_model: PostgresDataSource
 
-    hostname: str = Field(
-        None,
-        description='Use this parameter if you have a domain name (preferred option as more dynamic). '
-        'If not, please use the "host" parameter',
-    )
     host: str = Field(
-        None,
-        description='Use this parameter if you have an IP address. '
-        'If not, please use the "hostname" parameter (preferred option as more dynamic)',
+        None, description='The listening address of your database server (IP adress or hostname)'
     )
     port: int = Field(None, description='The listening port of your database server')
     user: str = Field(..., description='Your login username')
@@ -100,7 +93,7 @@ class PostgresConnector(ToucanConnector):
     def get_connection_params(self, *, database='postgres'):
         con_params = dict(
             user=self.user,
-            host=self.host if self.host else self.hostname,
+            host=self.host,
             client_encoding=self.charset,
             dbname=database,
             password=self.password.get_secret_value() if self.password else None,
@@ -124,7 +117,7 @@ class PostgresConnector(ToucanConnector):
 
     @staticmethod
     def _get_details(index: int, status: Optional[bool]):
-        checks = ['Hostname resolved', 'Port opened', 'Host connection', 'Authenticated']
+        checks = ['Host resolved', 'Port opened', 'Host connection', 'Authenticated']
         ok_checks = [(c, True) for i, c in enumerate(checks) if i < index]
         new_check = (checks[index], status)
         not_validated_checks = [(c, None) for i, c in enumerate(checks) if i > index]

--- a/toucan_connectors/postgres/postgresql_connector.py
+++ b/toucan_connectors/postgres/postgresql_connector.py
@@ -117,7 +117,7 @@ class PostgresConnector(ToucanConnector):
 
     @staticmethod
     def _get_details(index: int, status: Optional[bool]):
-        checks = ['Host resolved', 'Port opened', 'Host connection', 'Authenticated']
+        checks = ['Host resolved', 'Port opened', 'Connected to PostgreSQL', 'Authenticated']
         ok_checks = [(c, True) for i, c in enumerate(checks) if i < index]
         new_check = (checks[index], status)
         not_validated_checks = [(c, None) for i, c in enumerate(checks) if i > index]


### PR DESCRIPTION
https://github.com/ToucanToco/toucan-connectors/pull/527 introduced a status check for postgres, that appeared alays red in cas the parameter `hostname` were used.
I actually noticed that only `host` was enough, so I suggest we only keep this one.

A migration will be needed from hostname to host for existing connections.