### PR TITLE
fix(sql): get row count for queries using aggregation methods TCTC-1567

### DIFF
--- a/tests/redshift/test_redshift.py
+++ b/tests/redshift/test_redshift.py
@@ -339,7 +339,6 @@ def test_redshiftconnector_retrieve_data(
     mock_SqlQueryHelper, mock_get_connection, redshift_connector, redshift_datasource
 ):
     mock_response = Mock()
-    mock_SqlQueryHelper.count_request_needed.return_value = True
     mock_SqlQueryHelper.prepare_limit_query.return_value = Mock(), Mock()
     mock_SqlQueryHelper.prepare_count_query.return_value = Mock(), Mock()
     mock_get_connection().__enter__().cursor().__enter__().fetch_dataframe.return_value = (
@@ -354,7 +353,6 @@ def test_redshiftconnector_retrieve_data(
 def test_redshiftconnector_retrieve_data_empty_result(
     mock_SqlQueryHelper, mock_get_connection, redshift_connector, redshift_datasource
 ):
-    mock_SqlQueryHelper.count_request_needed.return_value = True
     mock_SqlQueryHelper.prepare_limit_query.return_value = Mock(), Mock()
     mock_SqlQueryHelper.prepare_count_query.return_value = Mock(), Mock()
     mock_get_connection().__enter__().cursor().__enter__().fetch_dataframe.return_value = None

--- a/tests/test_sql_query_helper.py
+++ b/tests/test_sql_query_helper.py
@@ -136,21 +136,3 @@ def test_extract_offset():
     request = 'SELECT * FROM (SELECT * FROM communes OFFSET)'
     result = SqlQueryHelper().extract_offset(request)
     assert result is None
-
-
-def test_count_request_needed():
-    request_select = 'SELECT * FROM communes;'
-    result = SqlQueryHelper().count_request_needed(request_select, True)
-    assert result is True
-
-    request_select = 'SELECT * FROM communes;'
-    result = SqlQueryHelper().count_request_needed(request_select, False)
-    assert result is False
-
-    request_select = 'SHOW DATABASES;'
-    result = SqlQueryHelper().count_request_needed(request_select, True)
-    assert result is False
-
-    request_select = 'SHOW DATABASES;'
-    result = SqlQueryHelper().count_request_needed(request_select, False)
-    assert result is False

--- a/tests/test_sql_query_helper.py
+++ b/tests/test_sql_query_helper.py
@@ -37,29 +37,7 @@ def test_prepare_query_show():
     assert 'show schemas' == new_request[0]
 
 
-def test_prepare_count_query_no_change():
-    request_sum = 'SELECT SUM(population_2010) FROM communes;'
-    new_request_sum = SqlQueryHelper().prepare_count_query(query_string=request_sum)
-    assert new_request_sum[0] == request_sum
-
-    request_sum = 'SELECT COUNT(population_2010) FROM communes;'
-    new_request_sum = SqlQueryHelper().prepare_count_query(query_string=request_sum)
-    assert new_request_sum[0] == request_sum
-
-    request_sum = 'SELECT MIN(population_2010) FROM communes;'
-    new_request_sum = SqlQueryHelper().prepare_count_query(query_string=request_sum)
-    assert new_request_sum[0] == request_sum
-
-    request_sum = 'SELECT MAX(population_2010) FROM communes;'
-    new_request_sum = SqlQueryHelper().prepare_count_query(query_string=request_sum)
-    assert new_request_sum[0] == request_sum
-
-    request_sum = 'SELECT AVG(population_2010) FROM communes;'
-    new_request_sum = SqlQueryHelper().prepare_count_query(query_string=request_sum)
-    assert new_request_sum[0] == request_sum
-
-
-def test_prepare_count_query_with_change():
+def test_prepare_count_query():
     request_sum = 'SELECT nom, num_departement, surface FROM communes ORDER BY surface LIMIT 10;'
     new_request_sum = SqlQueryHelper().prepare_count_query(query_string=request_sum)
     assert (

--- a/toucan_connectors/redshift/redshift_database_connector.py
+++ b/toucan_connectors/redshift/redshift_database_connector.py
@@ -288,11 +288,7 @@ class RedshiftConnector(ToucanConnector):
         df: pd.DataFrame = self._retrieve_data(data_source, False, offset, limit)
         total_returned_rows = len(df) if df is not None else 0
 
-        is_count_request_needed = SqlQueryHelper.count_request_needed(
-            data_source.query, get_row_count
-        )
-
-        if is_count_request_needed:
+        if get_row_count:
             df_count: pd.DataFrame = self._retrieve_data(data_source, True)
             total_rows = (
                 df_count.total_rows[0]

--- a/toucan_connectors/snowflake_common.py
+++ b/toucan_connectors/snowflake_common.py
@@ -153,10 +153,9 @@ class SnowflakeCommon:
     ) -> DataSlice:
         """Call parallelized execute query to extract data & row count from query"""
 
-        is_count_request_needed = SqlQueryHelper.count_request_needed(query, get_row_count)
-        self.logger.info(f'Execute count request: {is_count_request_needed}')
+        self.logger.info(f'Execute count request: {get_row_count}')
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=2 if is_count_request_needed else 1
+            max_workers=2 if get_row_count else 1
         ) as executor:
             prepared_query, prepared_query_parameters = SqlQueryHelper.prepare_limit_query(
                 query, query_parameters, offset, limit
@@ -170,7 +169,7 @@ class SnowflakeCommon:
             future_1.add_done_callback(self.set_data)
             futures = [future_1]
 
-            if is_count_request_needed:
+            if get_row_count:
                 (
                     prepared_query_count,
                     prepared_query_parameters_count,

--- a/toucan_connectors/snowflake_common.py
+++ b/toucan_connectors/snowflake_common.py
@@ -60,8 +60,8 @@ class SnowflakeCommon:
     def __init__(self):
         self.logger = logging.getLogger(__name__)
         self.data: pd.DataFrame
-        self.total_rows_count: Optional[int] = -1
-        self.total_returned_rows_count: Optional[int] = -1
+        self.total_rows_count: Optional[int] = None
+        self.total_returned_rows_count: Optional[int] = None
         self.execution_time: Optional[float] = None
         self.conversion_time: Optional[float] = None
         self.column_names_and_types: Optional[Dict[str, str]] = None

--- a/toucan_connectors/sql_query_helper.py
+++ b/toucan_connectors/sql_query_helper.py
@@ -49,19 +49,6 @@ class SqlQueryHelper:
         return converted_query, ordered_values
 
     @staticmethod
-    def count_request_needed(
-        query: str,
-        get_row_count: bool,
-    ) -> bool:
-        if (
-            get_row_count
-            and re.search(r'select.*', query, re.I)
-            and len(re.findall(r'(?i).*( sum| max| count| min| avg).*', query)) == 0
-        ):
-            return True
-        return False
-
-    @staticmethod
     def extract_offset(query: str) -> Optional[int]:
         m = re.search(r'(?<=\soffset)\s*\d*\s*', query, re.I)
         if m:

--- a/toucan_connectors/sql_query_helper.py
+++ b/toucan_connectors/sql_query_helper.py
@@ -14,9 +14,8 @@ class SqlQueryHelper:
         prepared_query, prepared_values = SqlQueryHelper.prepare_query(
             query_string, query_parameters
         )
-        if len(re.findall(r'(?i)select.*( sum| max| count| min| avg).*', prepared_query)) == 0:
-            prepared_query = prepared_query.replace(';', '')
-            prepared_query = f'SELECT COUNT(*) AS TOTAL_ROWS FROM ({prepared_query});'
+        prepared_query = prepared_query.replace(';', '')
+        prepared_query = f'SELECT COUNT(*) AS TOTAL_ROWS FROM ({prepared_query});'
         return prepared_query, prepared_values
 
     @staticmethod


### PR DESCRIPTION
## Change Summary

Fix a feature introduced in https://github.com/ToucanToco/toucan-connectors/pull/443 that was apparently based on wrong assumption : preventing count requests when an SQL query contained an aggregation method (sum, avg, min, etc.).

The pagination is entirely based on having the total row count. So not having it completely break the end user experience in pipeline editors.

Also, it was initialized at -1 instead of None, not a "true optional" field.
Last but not least, the regex looking for aggregation methods was not accurate enough to make the difference with the "count" method and a column named "country" :sweat_smile: 

![image](https://user-images.githubusercontent.com/3978482/148953617-9f323924-a809-4dca-8f0e-1f040998b8f5.png)


## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
