### PR TITLE
Add .devcontainer definition

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,8 +2,7 @@ ARG VARIANT=3.8
 FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
 # System update/upgrade
-RUN apt-get update
-RUN apt-get -y upgrade
+RUN apt-get update && apt-get -y upgrade
 
 # Install dependencies
 RUN apt-get install -y libxml2-dev libxslt-dev libxslt1-dev unixodbc-dev libpq-dev libssl-dev libffi-dev libcurl4-openssl-dev libblas-dev libatlas-base-dev libsasl2-dev

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,7 +29,6 @@ ARG NONROOT_USER=vscode
 # Default to root only access to the Docker socket, set up non-root init script
 RUN touch /var/run/docker-host.sock \
     && ln -s /var/run/docker-host.sock /var/run/docker.sock \
-    && apt-get update \
     && apt-get -y install socat
 
 # Create docker-init.sh to spin up socat

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -y upgrade
 
 # Install dependencies
 RUN apt-get install -y libxml2-dev libxslt-dev libxslt1-dev unixodbc-dev libpq-dev libssl-dev libffi-dev libcurl4-openssl-dev libblas-dev libatlas-base-dev libsasl2-dev
-RUN apt-get install -y make python3-pip python3-dev
+RUN apt-get install -y make python3-dev python3-pip
 
 # Docker
 RUN apt-get update \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,46 @@
+ARG VARIANT=3.8
+FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
+
+# System update/upgrade
+RUN apt-get update
+RUN apt-get -y upgrade
+
+# Install dependencies
+RUN apt-get install -y libxml2-dev libxslt-dev libxslt1-dev unixodbc-dev libpq-dev libssl-dev libffi-dev libcurl4-openssl-dev libblas-dev libatlas-base-dev libsasl2-dev
+RUN apt-get install -y make python3-pip python3-dev
+
+# Docker
+RUN apt-get update \
+    && apt-get install -y apt-transport-https ca-certificates curl gnupg2 lsb-release \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
+    && echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \
+        $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Install Docker Compose
+RUN LATEST_COMPOSE_VERSION=$(curl -sSL "https://api.github.com/repos/docker/compose/releases/latest" | grep -o -P '(?<="tag_name": ").+(?=")') \
+    && curl -sSL "https://github.com/docker/compose/releases/download/${LATEST_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/docker-compose
+
+# Setup Docker exchange
+ARG NONROOT_USER=vscode
+
+# Default to root only access to the Docker socket, set up non-root init script
+RUN touch /var/run/docker-host.sock \
+    && ln -s /var/run/docker-host.sock /var/run/docker.sock \
+    && apt-get update \
+    && apt-get -y install socat
+
+# Create docker-init.sh to spin up socat
+RUN echo "#!/bin/sh\n\
+    sudoIf() { if [ \"\$(id -u)\" -ne 0 ]; then sudo \"\$@\"; else \"\$@\"; fi }\n\
+    sudoIf rm -rf /var/run/docker.sock\n\
+    ((sudoIf socat UNIX-LISTEN:/var/run/docker.sock,fork,mode=660,user=${NONROOT_USER} UNIX-CONNECT:/var/run/docker-host.sock) 2>&1 >> /tmp/vscr-docker-from-docker.log) & > /dev/null\n\
+    \"\$@\"" >> /usr/local/share/docker-init.sh \
+    && chmod +x /usr/local/share/docker-init.sh
+
+# Entrypoint
+ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
+CMD [ "sleep", "infinity" ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,8 +9,7 @@ RUN apt-get install -y libxml2-dev libxslt-dev libxslt1-dev unixodbc-dev libpq-d
 RUN apt-get install -y make python3-dev python3-pip
 
 # Docker
-RUN apt-get update \
-    && apt-get install -y apt-transport-https ca-certificates curl gnupg2 lsb-release \
+RUN apt-get install -y apt-transport-https ca-certificates curl gnupg2 lsb-release \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
     && echo \
         "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+	"name": "ToucanTouco",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": { "VARIANT": "3.8" }
+	},
+	"runArgs": [
+		"--init",
+		"--network=host",
+	],
+	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
+	"remoteUser": "vscode",
+	"remoteEnv": { "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}" },
+	"overrideCommand": false,
+	"settings": { 
+		"python.defaultInterpreterPath": "/usr/local/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+	},
+	"extensions": [
+		"ms-azuretools.vscode-docker",
+		"ms-python.python",
+		"ms-python.vscode-pylance",
+	],
+}

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ There is a shortcut called `all` to install all the dependencies for all the con
 pip install -e ".[all]"
 ```
 
+You may face issues when instally the repo locally due to dependencies.
+That's why a dev container is available to be used with visual studio.
+Refer to [this doc](https://code.visualstudio.com/docs/remote/containers) to use it.
+
+
 ### System packages
 
 Some connectors dependencies require specific system packages. As each connector can define its dependencies separatly you do not need this until you want to use these specific connectors.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,8 +76,14 @@ def container_starter(request, docker, docker_pull):
             docker.pull(image)
 
         # Use in devcontainer to allow volumes access
-        if getenv("LOCAL_WORKSPACE_FOLDER") is not None:
-            volumes = [vol.replace('/workspaces/toucan-connectors/tests/.', f'{getenv("LOCAL_WORKSPACE_FOLDER")}/tests') for vol in volumes]
+        if getenv('LOCAL_WORKSPACE_FOLDER') is not None:
+            volumes = [
+                vol.replace(
+                    '/workspaces/toucan-connectors/tests/.',
+                    f'{getenv("LOCAL_WORKSPACE_FOLDER")}/tests',
+                )
+                for vol in volumes
+            ]
 
         host_config = docker.create_host_config(
             port_bindings={internal_port: host_port}, binds=volumes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,10 @@ def container_starter(request, docker, docker_pull):
             print(f'Pulling {image} image')
             docker.pull(image)
 
+        # Use in devcontainer to allow volumes access
+        if getenv("LOCAL_WORKSPACE_FOLDER") is not None:
+            volumes = [vol.replace('/workspaces/toucan-connectors/tests/.', f'{getenv("LOCAL_WORKSPACE_FOLDER")}/tests') for vol in volumes]
+
         host_config = docker.create_host_config(
             port_bindings={internal_port: host_port}, binds=volumes
         )


### PR DESCRIPTION
Add a dev container to be used with vscode to ease the collaboration with external contributors.


## Change Summary

Installing the repo locally can be tricky, thus the devcontainer can be use to have an independant dev environment without having to deal with dependencies issues.