### PR TITLE
feat(onedrive, sharepoint): add filenames_to_match param to extract m…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='1.3.42',
+    version='1.3.43',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=1.3.42
+sonar.projectVersion=1.3.43
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors

--- a/tests/one_drive/test_one_drive.py
+++ b/tests/one_drive/test_one_drive.py
@@ -8,7 +8,11 @@ from pytest import fixture
 from tests.one_drive.fixtures import FAKE_LIBRARIES, FAKE_SHEET
 from toucan_connectors.common import HttpError
 from toucan_connectors.oauth2_connector.oauth2connector import OAuth2Connector
-from toucan_connectors.one_drive.one_drive_connector import OneDriveConnector, OneDriveDataSource
+from toucan_connectors.one_drive.one_drive_connector import (
+    NotFoundError,
+    OneDriveConnector,
+    OneDriveDataSource,
+)
 
 import_path = 'toucan_connectors.one_drive.one_drive_connector'
 
@@ -114,6 +118,19 @@ def ds_with_site():
         domain='test_domain',
         file='test_file',
         sheet='test_sheet',
+        range='A2:B3',
+        site_url='company_name.sharepoint.com/sites/site_name',
+        document_library='Documents',
+    )
+
+
+@fixture
+def ds_with_site_with_filename_pattern():
+    return OneDriveDataSource(
+        name='test_name',
+        domain='test_domain',
+        filenames_to_match=r'.*\.jpg',
+        sheet='test_sheet, other_sheet',
         range='A2:B3',
         site_url='company_name.sharepoint.com/sites/site_name',
         document_library='Documents',
@@ -298,6 +315,44 @@ def test_multiple_sheets_success(mocker, con, ds_with_multiple_sheets, ds_with_m
     ]
 
 
+def test_multiple_files_sheets_success(mocker, con, ds_with_site_with_filename_pattern):
+    """It should return a dataframe"""
+    mocker.patch.object(OneDriveConnector, '_retrieve_files', return_value=['foo', 'bar'])
+    run_fetch = mocker.patch.object(OneDriveConnector, '_run_fetch', side_effect=fake_sheet)
+    mocker.patch.object(OneDriveConnector, '_get_site_id', return_value='1234')
+    mocker.patch.object(OneDriveConnector, '_get_list_id', return_value='abcd')
+    df = con.get_df(ds_with_site_with_filename_pattern)
+    assert run_fetch.call_count == 4
+    assert run_fetch.call_args_list[0][0][0] == (
+        'https://graph.microsoft.com/v1.0/sites/1234/lists/abcd/drive/root:/foo:'
+        "/workbook/worksheets/test_sheet/range(address='A2:B3')"
+    )
+    assert run_fetch.call_args_list[1][0][0] == (
+        'https://graph.microsoft.com/v1.0/sites/1234/lists/abcd/drive/root:/bar:'
+        "/workbook/worksheets/test_sheet/range(address='A2:B3')"
+    )
+    assert run_fetch.call_args_list[2][0][0] == (
+        'https://graph.microsoft.com/v1.0/sites/1234/lists/abcd/drive/root:/foo:'
+        "/workbook/worksheets/other_sheet/range(address='A2:B3')"
+    )
+    assert run_fetch.call_args_list[3][0][0] == (
+        'https://graph.microsoft.com/v1.0/sites/1234/lists/abcd/drive/root:/bar:'
+        "/workbook/worksheets/other_sheet/range(address='A2:B3')"
+    )
+    assert df.shape == (8, 9)
+    assert df.columns.tolist() == [
+        'col_text',
+        'col_int',
+        'col_float',
+        'col_money',
+        'col_date',
+        'col_datetime',
+        'col_datetime_bis',
+        'col_mixed_type',
+        '__sheetname__',
+    ]
+
+
 def test_sheets_without_date(mocker, con, ds):
     mocker.patch.object(OneDriveConnector, '_run_fetch', side_effect=fake_sheet)
 
@@ -344,11 +399,11 @@ def test_url_with_range(mocker, con, ds):
     """It should format the url when a range is provided"""
     mocker.patch.object(OneDriveConnector, '_run_fetch', side_effect=fake_sheet)
 
-    url = con._format_url(ds, 'test_sheet')
+    url = con._format_url(ds, 'test_sheet', ds.file)
 
     assert (
-        url
-        == "https://graph.microsoft.com/v1.0/me/drive/root:/test_file:/workbook/worksheets/test_sheet/range(address='A2:B3')"
+        url == 'https://graph.microsoft.com/v1.0/me/drive'
+        "/root:/test_file:/workbook/worksheets/test_sheet/range(address='A2:B3')"
     )
 
 
@@ -356,11 +411,11 @@ def test_url_without_range(mocker, con, ds_without_range):
     """It should format the url when no range is provided"""
     mocker.patch.object(OneDriveConnector, '_run_fetch', side_effect=fake_sheet)
 
-    url = con._format_url(ds_without_range, 'test_sheet')
+    url = con._format_url(ds_without_range, 'test_sheet', ds_without_range.file)
 
     assert (
-        url
-        == 'https://graph.microsoft.com/v1.0/me/drive/root:/test_file:/workbook/worksheets/test_sheet/usedRange(valuesOnly=true)'
+        url == 'https://graph.microsoft.com/v1.0/me/drive/'
+        'root:/test_file:/workbook/worksheets/test_sheet/usedRange(valuesOnly=true)'
     )
 
 
@@ -368,7 +423,7 @@ def test_url_with_table(mocker, con, ds_with_table):
     """It should format the url when a table is provided"""
     mocker.patch.object(OneDriveConnector, '_run_fetch', side_effect=fake_sheet)
 
-    url = con._format_url(ds_with_table, 'test_table')
+    url = con._format_url(ds_with_table, 'test_table', ds_with_table.file)
 
     assert (
         url
@@ -382,11 +437,12 @@ def test_url_with_site_with_range(mocker, con, ds_with_site):
     mocker.patch.object(OneDriveConnector, '_get_site_id', return_value='1234')
     mocker.patch.object(OneDriveConnector, '_get_list_id', return_value='abcd')
 
-    url = con._format_url(ds_with_site, 'test_sheet')
+    url = con._format_url(ds_with_site, 'test_sheet', ds_with_site.file)
 
     assert (
-        url
-        == "https://graph.microsoft.com/v1.0/sites/1234/lists/abcd/drive/root:/test_file:/workbook/worksheets/test_sheet/range(address='A2:B3')"
+        url == 'https://graph.microsoft.com/v1.0/sites/1234/lists/abcd/drive/'
+        'root:/test_file:/workbook/worksheets'
+        "/test_sheet/range(address='A2:B3')"
     )
 
 
@@ -396,11 +452,12 @@ def test_url_with_site_without_range(mocker, con, ds_with_site_without_range):
     mocker.patch.object(OneDriveConnector, '_get_site_id', return_value='1234')
     mocker.patch.object(OneDriveConnector, '_get_list_id', return_value='abcd')
 
-    url = con._format_url(ds_with_site_without_range, 'test_sheet')
+    url = con._format_url(ds_with_site_without_range, 'test_sheet', ds_with_site_without_range.file)
 
     assert (
         url
-        == 'https://graph.microsoft.com/v1.0/sites/1234/lists/abcd/drive/root:/test_file:/workbook/worksheets/test_sheet/usedRange(valuesOnly=true)'
+        == 'https://graph.microsoft.com/v1.0/sites/1234/lists/abcd/drive/root:/test_file:/workbook/worksheets'
+        '/test_sheet/usedRange(valuesOnly=true)'
     )
 
 
@@ -447,6 +504,46 @@ def test_run_fetch(con, mocker):
     con._run_fetch('https://jsonplaceholder.typicode.com/posts')
 
     mock_oauth2_connector.get_access_token.assert_called()
+
+
+@responses.activate
+def test__retrieve_files(con, mocker, ds_with_site_with_filename_pattern):
+    """Check that _retrieve_files returns a list of files"""
+    responses.add(
+        responses.GET,
+        'https://graph.microsoft.com/v1.0/sites/1234/lists/abcd/drive/root:/children',
+        status=200,
+        json={
+            'value': [
+                {'name': 'myfile.jpg', 'size': 2048, 'file': {}},
+                {'name': 'Documents', 'folder': {'childCount': 4}},
+                {'name': 'Photos', 'folder': {'childCount': 203}},
+                {'name': 'my sheet(1).xlsx', 'size': 197},
+            ],
+            '@odata.nextLink': 'https://...',
+        },
+    )
+    mocker.patch.object(OneDriveConnector, '_get_site_id', return_value='1234')
+    mocker.patch.object(OneDriveConnector, '_get_list_id', return_value='abcd')
+    assert con._retrieve_files(ds_with_site_with_filename_pattern) == ['myfile.jpg']
+
+
+@responses.activate
+def test__retrieve_files_empty(con, mocker, ds_with_site_with_filename_pattern):
+    """Check that _retrieve_files returns a list of files"""
+    responses.add(
+        responses.GET,
+        'https://graph.microsoft.com/v1.0/sites/1234/lists/abcd/drive/root:/children',
+        status=200,
+        json={
+            'value': [],
+            '@odata.nextLink': 'https://...',
+        },
+    )
+    mocker.patch.object(OneDriveConnector, '_get_site_id', return_value='1234')
+    mocker.patch.object(OneDriveConnector, '_get_list_id', return_value='abcd')
+    with pytest.raises(NotFoundError):
+        con._retrieve_files(ds_with_site_with_filename_pattern)
 
 
 @responses.activate

--- a/toucan_connectors/one_drive/one_drive_connector.py
+++ b/toucan_connectors/one_drive/one_drive_connector.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import List, Optional
 
 import pandas as pd
@@ -11,6 +12,10 @@ from toucan_connectors.oauth2_connector.oauth2connector import (
     OAuth2ConnectorConfig,
 )
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
+
+
+class NotFoundError(Exception):
+    """ """
 
 
 class OneDriveDataSource(ToucanDataSource):
@@ -30,6 +35,12 @@ class OneDriveDataSource(ToucanDataSource):
         None,
         Title='File',
         placeholder='Enter your path file',
+    )
+    filenames_to_match: str = Field(
+        None,
+        Title='Pattern to match for filenames',
+        description='Provide a pattern to find matching filenames in directory',
+        placeholder='.*\.jpg'
     )
     sheet: Optional[str] = Field(
         None,
@@ -52,8 +63,18 @@ class OneDriveDataSource(ToucanDataSource):
     )
 
 
-class OneDriveConnector(ToucanConnector):
+def _prepare_workbook_elements(data_source):
+    if data_source.sheet:
+        workbook_elements_list = data_source.sheet
+        workbook_key_column = '__sheetname__'
+    else:
+        workbook_elements_list = data_source.table
+        workbook_key_column = '__tablename__'
+    workbook_elements_list = workbook_elements_list.replace(', ', ',').split(',')
+    return workbook_elements_list, workbook_key_column
 
+
+class OneDriveConnector(ToucanConnector):
     data_source_model: OneDriveDataSource
 
     _auth_flow = 'oauth2'
@@ -156,18 +177,11 @@ class OneDriveConnector(ToucanConnector):
             if library['displayName'] == data_source.document_library:
                 return library['id']
 
-    def _format_url(self, data_source, workbook_element):
+    def _format_url(self, data_source, workbook_element, file):
         logging.getLogger(__name__).debug('_format_url')
 
-        # Baseroute for Share Point
-        if data_source.site_url and data_source.document_library:
-            site_id = self._get_site_id(data_source)
-            list_id = self._get_list_id(data_source, site_id)
-
-            url = f'https://graph.microsoft.com/v1.0/sites/{site_id}/lists/{list_id}/drive/root:/{data_source.file}:/workbook/'
-        # Baseroute for One Drive
-        else:
-            url = f'https://graph.microsoft.com/v1.0/me/drive/root:/{data_source.file}:/workbook/'
+        url = self._build_url_root(data_source)
+        url += f'/{file}:/workbook/'
 
         # Endpoint for Sheet
         if data_source.sheet:
@@ -185,6 +199,22 @@ class OneDriveConnector(ToucanConnector):
 
         return url
 
+    def _format_urls(self, data_source, workbook_element, filenames):
+        logging.getLogger(__name__).debug('_format_url')
+        return [self._format_url(data_source, workbook_element, file) for file in filenames]
+
+    def _build_url_root(self, data_source):
+        # Baseroute for Share Point
+        if data_source.site_url and data_source.document_library:
+            site_id = self._get_site_id(data_source)
+            list_id = self._get_list_id(data_source, site_id)
+
+            url = f'https://graph.microsoft.com/v1.0/sites/{site_id}/lists/{list_id}/drive/root:'
+        # Baseroute for One Drive
+        else:
+            url = 'https://graph.microsoft.com/v1.0/me/drive/root:'
+        return url
+
     def _run_fetch(self, url):
         logging.getLogger(__name__).debug('_run_fetch')
         access_token = self._get_access_token()
@@ -194,6 +224,29 @@ class OneDriveConnector(ToucanConnector):
         response.raise_for_status()
 
         return response.json()
+
+    def _retrieve_files(self, data_source: OneDriveDataSource) -> List[str]:
+        logging.getLogger(__name__).debug('_retrieve_files')
+        url = self._build_url_root(data_source)
+        url += '/children'
+        response = requests.get(
+            url,
+            headers={
+                'Content-Type': 'application/json',
+                'Authorization': f'Bearer {self._get_access_token()}',
+            },
+        )
+        response.raise_for_status()
+        children = response.json().get('value')
+        if children:
+            return list(
+                filter(
+                    lambda f: re.match(re.compile(data_source.filenames_to_match), f),
+                    [c['name'] for c in children if 'folder' not in c],
+                )
+            )
+        else:
+            raise NotFoundError('No matching file name')
 
     def _retrieve_data(self, data_source: OneDriveDataSource) -> pd.DataFrame:
         logging.getLogger(__name__).debug('_retrieve_data')
@@ -207,37 +260,31 @@ class OneDriveConnector(ToucanConnector):
         if not data_source.sheet and not data_source.table:
             raise ValueError('You must specify at least a sheet or a table')
 
-        df_all = pd.DataFrame()
+        file_names = []
+        if data_source.filenames_to_match:
+            file_names = self._retrieve_files(data_source)
 
-        workbook_elements_list = []
-        workbook_key_column = ''
-        if data_source.sheet:
-            workbook_elements_list = data_source.sheet
-            workbook_key_column = '__sheetname__'
-        else:
-            workbook_elements_list = data_source.table
-            workbook_key_column = '__tablename__'
-        workbook_elements_list = workbook_elements_list.replace(', ', ',').split(',')
+        df_all = pd.DataFrame()
+        workbook_elements_list, workbook_key_column = _prepare_workbook_elements(
+            data_source
+        )
 
         for workbook_element in workbook_elements_list:
-            url = self._format_url(data_source, workbook_element)
+            if file_names:
+                urls = self._format_urls(data_source, workbook_element, file_names)
+            else:
+                urls = [self._format_url(data_source, workbook_element, data_source.file)]
 
-            response = self._run_fetch(url)
+            data = [self._run_fetch(url).get('values') for url in urls]
 
-            data = response.get('values')
+            for d in [d for d in data if d]:
+                cols = d[0]
+                d.pop(0)
+                df_current = pd.DataFrame(d, columns=cols)
 
-            if not data:
-                logging.getLogger(__name__).debug('No data retrieved from response')
-                return pd.DataFrame()
-
-            cols = data[0]
-            data.pop(0)
-
-            df_current = pd.DataFrame(data, columns=cols)
-            if len(workbook_elements_list) > 1:
-                df_current[workbook_key_column] = workbook_element
-
-            df_all = df_all.append(df_current)
+                if len(workbook_elements_list) > 1:
+                    df_current[workbook_key_column] = workbook_element
+                df_all = df_all.append(df_current)
 
         if data_source.parse_dates:
             for date_col in data_source.parse_dates:


### PR DESCRIPTION

https://user-images.githubusercontent.com/71276735/149930328-4e158722-b3fe-4b27-96c9-8bbc46c92b06.mp4

As multiple files can be stored in a sharepoint or onedrive folder, we add a `filename_to_match` parameter such as it can handle a regex & thus match multiple files.

## Change Summary

- add a `Match` boolean data source field
- add logic to handle files retrieval and extraction 

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
