### PR TITLE
chore: bump from 1.3.43 to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog (Pypi package)
 
-## [1.3.44] 2022-01-19
+## [2.0.0] 2022-01-19
 
 ### Changed
 
@@ -19,5 +19,5 @@ Some DataStats properties changed in the naming and some of them was added, see 
 - Added a dev container for developping safely on connectors.
 
 
-[1.3.44]: https://github.com/ToucanToco/toucan-connectors/compare/v1.3.40...v1.3.44
+[2.0.0]: https://github.com/ToucanToco/toucan-connectors/compare/v1.3.40...v2.0.0
 [1.3.43]: https://github.com/ToucanToco/toucan-connectors/compare/v1.3.40...v1.3.44

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## [1.3.44] 2022-01-19
 
-### Added
-
-- Add filenames_to_match param to extract multiple files on connectors sharepoint and onedrive.
-- Added a dev container for developping safely on connectors.
-
 ### Changed
 
 Some DataStats properties changed in the naming and some of them was added, see [HERE](https://github.com/ToucanToco/toucan-connectors/commit/9d74efb6a6e37c6fbcd951743ac418aa84911704) for more informations.
@@ -16,5 +11,13 @@ Some DataStats properties changed in the naming and some of them was added, see 
 - Fixes on sql/snowflake (don't run count for DESCRIBE or SHOW queries + don't use -1 as default rows count)
 - Fixes on sharepoint and onedrive connectors.
 
+## [1.3.43] 2022-01-17
+
+### Added
+
+- Added filenames_to_match param to extract multiple files on connectors sharepoint and onedrive.
+- Added a dev container for developping safely on connectors.
+
 
 [1.3.44]: https://github.com/ToucanToco/toucan-connectors/compare/v1.3.40...v1.3.44
+[1.3.43]: https://github.com/ToucanToco/toucan-connectors/compare/v1.3.40...v1.3.44

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog (Pypi package)
+
+## [1.3.44] 2022-01-19
+
+### Added
+
+- Add filenames_to_match param to extract multiple files on connectors sharepoint and onedrive.
+- Added a dev container for developping safely on connectors.
+
+### Changed
+
+Some DataStats properties changed in the naming and some of them was added, see [HERE](https://github.com/ToucanToco/toucan-connectors/commit/9d74efb6a6e37c6fbcd951743ac418aa84911704) for more informations.
+
+### Fixed
+
+- Fixes on sql/snowflake (don't run count for DESCRIBE or SHOW queries + don't use -1 as default rows count)
+- Fixes on sharepoint and onedrive connectors.
+
+
+[1.3.44]: https://github.com/ToucanToco/toucan-connectors/compare/v1.3.40...v1.3.44

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='1.3.44',
+    version='2.0.0',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='1.3.43',
+    version='1.3.44',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=1.3.44
+sonar.projectVersion=2.0.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=1.3.43
+sonar.projectVersion=1.3.44
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors


### PR DESCRIPTION
## What
- Bump on toucan-connectors from 1.3.43 to 2.0.0.
- Added a changelog file for this repo.