### PR TITLE
feat(google-sheets): order fields & list available sheets in datasource form TCTC-1819

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='3.0.0',
+    version='3.1.0',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=3.0.0
+sonar.projectVersion=3.1.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors

--- a/tests/google_sheets/test_google_sheets.py
+++ b/tests/google_sheets/test_google_sheets.py
@@ -261,3 +261,38 @@ def test_schema_fields_order():
     assert schema_props_keys[0] == 'domain'
     assert schema_props_keys[1] == 'spreadsheet_id'
     assert schema_props_keys[2] == 'sheet'
+
+
+def test_get_form(mocker):
+    """It should return a list of spreadsheet titles."""
+    mocker.patch(
+        'toucan_connectors.google_sheets.google_sheets_connector.GoogleSheetsConnector._google_client_request_kwargs',
+        side_effect=[
+            {  # First request to get sheet names
+                'http': HttpMock(
+                    path.join(path.dirname(__file__), './spreadsheet-sheets-properties.json'),
+                    {'status': '200'},
+                )
+            },
+        ],
+    )
+
+    gsheet_connector = GoogleSheetsConnector(
+        name='test_connector',
+        retrieve_token=lambda _a, _b: 'test_access_token',
+        auth_id='test_auth_id',
+    )
+
+    data_source = GoogleSheetsDataSource(
+        name='test_datasource',
+        domain='test_domain',
+        spreadsheet_id='test_spreadsheet_id',
+        sheet='sample data',
+    )
+
+    schema = data_source.get_form(
+        connector=gsheet_connector,
+        current_config={'spreadsheet_id': 'test_spreadsheet_id'},
+    )
+    expected_results = ['sample data', 'animals']
+    assert schema['definitions']['sheet']['enum'] == expected_results

--- a/tests/google_sheets/test_google_sheets.py
+++ b/tests/google_sheets/test_google_sheets.py
@@ -15,6 +15,7 @@ from toucan_connectors.google_sheets.google_sheets_connector import (
     GoogleSheetsConnector,
     GoogleSheetsDataSource,
 )
+from toucan_connectors.json_wrapper import JsonWrapper
 
 
 def test_retrieve_data_with_dates(mocker: MockFixture):
@@ -251,3 +252,12 @@ def test_get_status_api_down(mocker):
     )
     connector_status = gsheet_connector.get_status()
     assert connector_status.status is False
+
+
+def test_schema_fields_order():
+    schema_props_keys = list(
+        JsonWrapper.loads(GoogleSheetsDataSource.schema_json())['properties'].keys()
+    )
+    assert schema_props_keys[0] == 'domain'
+    assert schema_props_keys[1] == 'spreadsheet_id'
+    assert schema_props_keys[2] == 'sheet'

--- a/toucan_connectors/google_sheets/google_sheets_connector.py
+++ b/toucan_connectors/google_sheets/google_sheets_connector.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Type
 
 import pandas as pd
 from dateutil.relativedelta import relativedelta
@@ -29,6 +29,14 @@ class GoogleSheetsDataSource(ToucanDataSource):
     header_row: int = Field(
         0, title='Header row', description='Row of the header of the spreadsheet'
     )
+
+    class Config:
+        @staticmethod
+        def schema_extra(schema: Dict[str, Any], model: Type['GoogleSheetsDataSource']) -> None:
+            keys = schema['properties'].keys()
+            prio_keys = ['domain', 'spreadsheet_id', 'sheet']
+            new_keys = prio_keys + [k for k in keys if k not in prio_keys]
+            schema['properties'] = {k: schema['properties'][k] for k in new_keys}
 
 
 class GoogleSheetsConnector(ToucanConnector):

--- a/toucan_connectors/google_sheets/google_sheets_connector.py
+++ b/toucan_connectors/google_sheets/google_sheets_connector.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Type
 
@@ -6,10 +7,10 @@ from dateutil.relativedelta import relativedelta
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import Error as GoogleApiClientError
-from pydantic import Field, PrivateAttr, SecretStr
+from pydantic import Field, PrivateAttr, SecretStr, create_model
 
 from toucan_connectors.common import ConnectorStatus
-from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
+from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource, strlist_to_enum
 
 
 class GoogleSheetsDataSource(ToucanDataSource):
@@ -37,6 +38,17 @@ class GoogleSheetsDataSource(ToucanDataSource):
             prio_keys = ['domain', 'spreadsheet_id', 'sheet']
             new_keys = prio_keys + [k for k in keys if k not in prio_keys]
             schema['properties'] = {k: schema['properties'][k] for k in new_keys}
+
+    @classmethod
+    def get_form(cls, connector: 'GoogleSheetsConnector', current_config, **kwargs):
+        """Retrieve a form filled with suggestions of available sheets."""
+        # Always add the suggestions for the available sheets
+        constraints = {}
+        with suppress(Exception):
+            available_sheets = connector.list_sheets(current_config['spreadsheet_id'])
+            constraints['sheet'] = strlist_to_enum('sheet', available_sheets)
+
+        return create_model('FormSchema', **constraints, __base__=cls).schema()
 
 
 class GoogleSheetsConnector(ToucanConnector):


### PR DESCRIPTION
## Change Summary

Reproduce some feature of GoogleSheets2 datasource form in the GoogleSheets connector: 

- order fields to display "domain", "spreadsheet_id" & "sheet" above "validation rules" & "parameters"
- provide available sheets list when "spreadsheet_id" have been filed

## Related issue number

:no_entry_sign: 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
