### PR TITLE
feat(cache key): the connector itself is rendered with `datasource.parameters` as a context (TCTC-1882)

### DIFF
--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -480,7 +480,7 @@ def test_get_cache_key(connector, auth, data_source):
     data_source.parameters = {'first_name': 'raphael'}
     key = connector.get_cache_key(data_source)
 
-    assert key == 'b35e0189-a527-3f9c-827d-b0c54e23b780'
+    assert key == '4c4090ab-27fa-3785-aca0-dfc9458d6325'
 
     data_source.headers = {'name': '{{ first_name }}'}  # change the templating style
     key2 = connector.get_cache_key(data_source)

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -480,7 +480,7 @@ def test_get_cache_key(connector, auth, data_source):
     data_source.parameters = {'first_name': 'raphael'}
     key = connector.get_cache_key(data_source)
 
-    assert key == '4c4090ab-27fa-3785-aca0-dfc9458d6325'
+    assert key == 'e11ff01f-2a53-32b1-baa0-3c27faae0200'
 
     data_source.headers = {'name': '{{ first_name }}'}  # change the templating style
     key2 = connector.get_cache_key(data_source)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -130,7 +130,7 @@ def test_get_cache_key():
     key = connector.get_cache_key(ds)
     # We should get a deterministic identifier:
     # /!\ the identifier will change if the model of the connector or the datasource changes
-    assert key == '01837031-04d9-3e16-8639-89ce92b2dd7b'
+    assert key == '71c8bdbe-b719-3b19-8249-1a0d2b3cd12d'
 
     ds.query = 'wow'
     key2 = connector.get_cache_key(ds)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -19,11 +19,13 @@ from toucan_connectors.toucan_connector import (
 
 class DataSource(ToucanDataSource):
     query: str
+    parameters: dict = {}
 
 
 class DataConnector(ToucanConnector):
     type = 'MyDB'
     data_source_model: DataSource
+    a_parameter: str = ''
 
     def _retrieve_data(self, data_source):
         pass
@@ -128,7 +130,7 @@ def test_get_cache_key():
     key = connector.get_cache_key(ds)
     # We should get a deterministic identifier:
     # /!\ the identifier will change if the model of the connector or the datasource changes
-    assert key == '0e302d62-fab4-3855-8aed-05bcd641302a'
+    assert key == '01837031-04d9-3e16-8639-89ce92b2dd7b'
 
     ds.query = 'wow'
     key2 = connector.get_cache_key(ds)
@@ -294,3 +296,13 @@ def test_get_df_int_column(mocker):
 
     dc = DataConnector(name='bla')
     assert dc.get_df(mocker.MagicMock()).columns == ['0']
+
+
+def test_get_cache_key_should_be_different_with_different_parameters():
+    connector_a1 = DataConnector(name='a', a_parameter='{{ a }}')
+    ds_1 = DataSource(name='ds_1', parameters={'a': 1}, domain='foo', query='bar')
+    ds_2 = DataSource(name='ds_1', parameters={'a': 2}, domain='foo', query='bar')
+    key_a1 = connector_a1.get_cache_key(ds_1)
+    key_a2 = connector_a1.get_cache_key(ds_2)
+
+    assert key_a1 != key_a2

--- a/tests/test_json_wrapper.py
+++ b/tests/test_json_wrapper.py
@@ -2,8 +2,9 @@ import os
 from json import JSONDecodeError
 
 import pytest
+from pydantic import SecretStr
 
-from toucan_connectors.json_wrapper import JsonWrapper
+from toucan_connectors.json_wrapper import JsonWrapper, custom_json_serializer
 
 json_not_string = None
 json_string = '{"key1":"value1","key2":"value2"}'
@@ -53,3 +54,8 @@ def test_json_load():
 def test_json_load_file_not_found():
     with pytest.raises(FileNotFoundError):
         JsonWrapper.load(open(path_not_found, 'r'))
+
+
+def test_custom_json_serializer():
+    assert custom_json_serializer(SecretStr('foobar')) == 'foobar'
+    assert custom_json_serializer(42) == 42

--- a/toucan_connectors/json_wrapper.py
+++ b/toucan_connectors/json_wrapper.py
@@ -2,6 +2,14 @@ import json
 import logging
 from typing import Dict
 
+from pydantic import SecretStr
+
+
+def custom_json_serializer(obj):
+    if isinstance(obj, SecretStr):
+        return obj.get_secret_value()
+    return obj
+
 
 class JsonWrapper:
     @staticmethod
@@ -16,7 +24,7 @@ class JsonWrapper:
         cls=None,
         indent=None,
         # separators=None,
-        default=None,
+        default=custom_json_serializer,
         sort_keys=False,
         **kwargs,
     ):
@@ -48,7 +56,7 @@ class JsonWrapper:
         cls=None,
         indent=None,
         # separators=None,
-        default=None,
+        default=custom_json_serializer,
         sort_keys=False,
         **kwargs,
     ):

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -288,10 +288,17 @@ class MongoConnector(ToucanConnector):
         )
         return _format_explain_result(result)
 
-    def get_unique_identifier(self) -> dict:
-        return self.json(
-            exclude={'client'}
-        )  # client is a MongoClient instance, not json serializable
+    def get_unique_identifier(self, data_source: Optional[ToucanDataSource] = None) -> str:
+        if data_source is not None:
+            return JsonWrapper.dumps(
+                nosql_apply_parameters_to_query(
+                    self.dict(exclude={'client'}), data_source.parameters
+                )
+            )
+        else:
+            return self.json(
+                exclude={'client'}
+            )  # client is a MongoClient instance, not json serializable
 
     def _render_datasource(self, data_source: MongoDataSource) -> dict:
         # let's make a copy first

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -415,7 +415,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         """
         return ConnectorStatus()
 
-    def get_unique_identifier(self, data_source: Optional[ToucanDataSource] = None) -> dict:
+    def get_unique_identifier(self, data_source: Optional[ToucanDataSource] = None) -> str:
         """
         Returns a serialized version of the connector's config.
         Override this method in connectors which have not-serializable properties.
@@ -423,9 +423,11 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         Used by `get_cache_key` method.
         """
         if data_source is not None:
-            return nosql_apply_parameters_to_query(self.dict(), data_source.parameters)
+            return JsonWrapper.dumps(
+                nosql_apply_parameters_to_query(self.dict(), data_source.parameters)
+            )
         else:
-            return self.dict()
+            return self.json()
 
     def _render_datasource(self, data_source: ToucanDataSource) -> dict:
         data_source_rendered = nosql_apply_parameters_to_query(

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -415,14 +415,17 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         """
         return ConnectorStatus()
 
-    def get_unique_identifier(self) -> dict:
+    def get_unique_identifier(self, data_source: Optional[ToucanDataSource] = None) -> dict:
         """
         Returns a serialized version of the connector's config.
         Override this method in connectors which have not-serializable properties.
 
         Used by `get_cache_key` method.
         """
-        return self.json()
+        if data_source is not None:
+            return nosql_apply_parameters_to_query(self.dict(), data_source.parameters)
+        else:
+            return self.dict()
 
     def _render_datasource(self, data_source: ToucanDataSource) -> dict:
         data_source_rendered = nosql_apply_parameters_to_query(
@@ -446,7 +449,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         This identifier will then be used as a cache key.
         """
         unique_identifier = {
-            'connector': self.get_unique_identifier(),
+            'connector': self.get_unique_identifier(data_source),
             'permissions': permissions,
             'offset': offset,
             'limit': limit,


### PR DESCRIPTION
## Change Summary
if the connector itself is using jinja template, different datasources might have the same cache key.
To solve this issue, the connector is rendered before computing the cache key

## Related issue number
TCTC-1882


## Checklist

* [X] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
