### PR TITLE
chore(PG, SF, RS): add language & query_object attributes [TCTC-1715]

### DIFF
--- a/tests/postgres/test_postgres.py
+++ b/tests/postgres/test_postgres.py
@@ -138,6 +138,8 @@ def test_datasource():
 
     ds = PostgresDataSource(name='mycon', domain='mydomain', database='ubuntu', table='test')
     assert ds.query == 'select * from test;'
+    assert ds.language == 'sql'
+    assert hasattr(ds, 'query_object')
 
 
 def test_postgress_get_df(mocker):

--- a/tests/redshift/test_redshift.py
+++ b/tests/redshift/test_redshift.py
@@ -102,6 +102,8 @@ def test_redshiftdatasource_init_(redshift_datasource):
     ds = RedshiftDataSource(domain='test', name='redshift', database='test', table='table_test')
     assert ds.query == 'select * from table_test;'
     assert ds.table == 'table_test'
+    assert ds.language == 'sql'
+    assert hasattr(ds, 'query_object')
 
 
 def test_redshiftdatasource_init_none_values(redshift_datasource):

--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -125,6 +125,12 @@ def test_datasource_get_databases(
     result = snowflake_datasource._get_databases(snowflake_connector)
     assert len(result) == 2
     assert result[1] == 'database_2'
+    assert snowflake_datasource.language == 'sql'
+    assert snowflake_datasource.query_object == {
+        'schema': 'SHOW_SCHEMA',
+        'table': 'MY_TABLE',
+        'columns': ['col1', 'col2'],
+    }
     SnowflakeConnector.get_snowflake_connection_manager().force_clean()
 
 

--- a/toucan_connectors/postgres/postgresql_connector.py
+++ b/toucan_connectors/postgres/postgresql_connector.py
@@ -1,5 +1,5 @@
 from contextlib import suppress
-from typing import Optional
+from typing import Dict, Optional
 
 import psycopg2 as pgsql
 from pydantic import Field, SecretStr, constr, create_model
@@ -18,12 +18,18 @@ class PostgresDataSource(ToucanDataSource):
         'the "table" parameter',
         widget='sql',
     )
+    query_object: Dict = Field(
+        None,
+        description='An object describing a simple select query' 'This field is used internally',
+        **{'ui.hidden': True},
+    )
     table: constr(min_length=1) = Field(
         None,
         description='The name of the data table that you want to '
         'get (equivalent to "SELECT * FROM '
         'your_table")',
     )
+    language: str = Field('sql', **{'ui.hidden': True})
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/toucan_connectors/redshift/redshift_database_connector.py
+++ b/toucan_connectors/redshift/redshift_database_connector.py
@@ -75,12 +75,18 @@ class RedshiftDataSource(ToucanDataSource):
         'the table parameter',
         widget='sql',
     )
+    query_object: Dict = Field(
+        None,
+        description='An object describing a simple select query' 'This field is used internally',
+        **{'ui.hidden': True},
+    )
     table: constr(min_length=1) = Field(
         None,
         description='The name of the data table that you want to '
         'get (equivalent to "SELECT * FROM '
         'your_table")',
     )
+    language: str = Field('sql', **{'ui.hidden': True})
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/toucan_connectors/redshift/redshift_database_connector.py
+++ b/toucan_connectors/redshift/redshift_database_connector.py
@@ -77,7 +77,7 @@ class RedshiftDataSource(ToucanDataSource):
     )
     query_object: Dict = Field(
         None,
-        description='An object describing a simple select query' 'This field is used internally',
+        description='An object describing a simple select query, this field is used internally',
         **{'ui.hidden': True},
     )
     table: constr(min_length=1) = Field(

--- a/toucan_connectors/snowflake_common.py
+++ b/toucan_connectors/snowflake_common.py
@@ -54,6 +54,7 @@ class SfDataSource(ToucanDataSource):
         'This field is used internally',
         **{'ui.hidden': True},
     )
+    language: str = Field('sql', **{'ui.hidden': True})
 
 
 class SnowflakeCommon:


### PR DESCRIPTION
## Change Summary

Add `language` & `query_object` attributes to snowflake, redshift & Postgres

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
