### PR TITLE
fix(ealsticsearch): pin elastic client to <8 to avoid breaking change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require = {
     'azure_mssql': ['pyodbc>=3'],
     'clickhouse': ['clickhouse_driver', 'sqlalchemy'],
     'dataiku': ['dataiku-api-client'],
-    'elasticsearch': ['elasticsearch'],
+    'elasticsearch': ['elasticsearch<8'],
     'facebook': ['facebook-sdk'],
     'github': ['python_graphql_client'],
     'google_analytics': ['google-api-python-client', 'oauth2client'],


### PR DESCRIPTION
The send_body_as_get arg has been removed

A fix to make it work with the version 8 will come later (jira issue created)