### PR TITLE
fix(postgres): format all result from get model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='3.1.4',
+    version='3.1.5',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=3.1.4
+sonar.projectVersion=3.1.5
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors

--- a/toucan_connectors/postgres/postgresql_connector.py
+++ b/toucan_connectors/postgres/postgresql_connector.py
@@ -182,4 +182,4 @@ class PostgresConnector(ToucanConnector):
                     cursor.execute(build_database_model_extraction_query())
                     res = cursor.fetchall()
                     databases_tree += res
-            return format_db_model(res)
+            return format_db_model(databases_tree)


### PR DESCRIPTION
## Change Summary
issue on postgres: only the last DB tree was returned when calling `get-model`
