### PR TITLE
(feature) odbc add autocommit option

### DIFF
--- a/doc/connectors/odbcconnector.md
+++ b/doc/connectors/odbcconnector.md
@@ -9,6 +9,7 @@ Be aware that this connector needs a specific driver to be installed on the serv
 * `type`: `"Odbc"`
 * `name`: str, required
 * `connection_string`: str, required
+* `autocommit`: bool, default to False
 * `ansi`: bool, default to False
 * `connect_timeout`: int
 

--- a/tests/odbc/test_odbc.py
+++ b/tests/odbc/test_odbc.py
@@ -64,7 +64,11 @@ def test_odbc_connector_autocommit(mocker):
     mocker.patch('pandas.read_sql')
 
     odbc_connector = OdbcConnector(name='test', connection_string='blah', autocommit=True)
-    ds = OdbcDataSource( domain='test', name='test', query='SELECT 1;',)
+    ds = OdbcDataSource(
+        domain='test',
+        name='test',
+        query='SELECT 1;',
+    )
     odbc_connector.get_df(ds)
 
     mock_pyodbc_connect.assert_called_once_with('blah', autocommit=True, ansi=False)

--- a/tests/odbc/test_odbc.py
+++ b/tests/odbc/test_odbc.py
@@ -58,6 +58,18 @@ def test_raise_on_empty_query():
         OdbcDataSource(domain='test', name='test', database='postgres_db', query='')
 
 
+def test_odbc_connector_autocommit(mocker):
+    """Test that we are passing the autocommit param properly"""
+    mock_pyodbc_connect = mocker.patch('pyodbc.connect')
+    mocker.patch('pandas.read_sql')
+
+    odbc_connector = OdbcConnector(name='test', connection_string='blah', autocommit=True)
+    ds = OdbcDataSource( domain='test', name='test', query='SELECT 1;',)
+    odbc_connector.get_df(ds)
+
+    mock_pyodbc_connect.assert_called_once_with('blah', autocommit=True, ansi=False)
+
+
 def test_odbc_get_df(mocker):
     mock_pyodbc_connect = mocker.patch('pyodbc.connect')
     mock_pandas_read_sql = mocker.patch('pandas.read_sql')

--- a/toucan_connectors/odbc/odbc_connector.py
+++ b/toucan_connectors/odbc/odbc_connector.py
@@ -20,12 +20,13 @@ class OdbcConnector(ToucanConnector):
     data_source_model: OdbcDataSource
 
     connection_string: str = Field(..., description='The connection string')
+    autocommit: bool = False
     ansi: bool = False
     connect_timeout: int = None
 
     def get_connection_params(self):
         con_params = {
-            'autocommit': False,
+            'autocommit': self.autocommit,
             'ansi': self.ansi,
             'timeout': self.connect_timeout,
         }


### PR DESCRIPTION
## Change Summary

Add `autocommit` option, keep the connector default (False).

https://github.com/mkleehammer/pyodbc/wiki/Connection#autocommit

## Related issue

https://github.com/ToucanToco/toucan-connectors/issues/573

## Checklist

* [X] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
