### PR TITLE
fix(redshift): filter duplicate sys table from get-model query

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='3.1.5',
+    version='3.1.6',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=3.1.5
+sonar.projectVersion=3.1.6
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors

--- a/toucan_connectors/redshift/redshift_database_connector.py
+++ b/toucan_connectors/redshift/redshift_database_connector.py
@@ -349,7 +349,11 @@ class RedshiftConnector(ToucanConnector):
 
     def get_model(self, db_name: str):
         with self._get_cursor(database=db_name) as cursor:
-            cursor.execute("""select datname from pg_database where datistemplate = false;""")
+            # redshift has a weird system db called padb_harvest duplicating the content of 'dev' database
+            # https://bit.ly/3GQJCdy, we have to filter it
+            cursor.execute(
+                """select datname from pg_database where datistemplate = false and datname != 'padb_harvest';"""
+            )
             available_dbs = [db_name for (db_name,) in cursor.fetchall()]
             databases_tree = []
         for db in available_dbs:


### PR DESCRIPTION
## Change Summary
Fix the query used in `get-model` to retrieve database model. 
It filters the `padb_harvest` database that seems to be a mere duplicate of `dev` database.
