### PR TITLE
fix(install_scripts): databricks use toucantoco repository

### DIFF
--- a/toucan_connectors/install_scripts/databricks.sh
+++ b/toucan_connectors/install_scripts/databricks.sh
@@ -11,7 +11,7 @@ apt-get install -fyq libsasl2-modules-gssapi-mit wget unzip
 mkdir -p /tmp/databricks
 # The next link was extracted from an email received after
 # filling: https://databricks.com/spark/odbc-driver-download
-wget 'https://databricks.com/wp-content/uploads/2.6.4.1004/SimbaSparkODBC-2.6.4.1004-Debian-64bit.zip' \
+wget 'https://public-package.toucantoco.com/connectors_sources/databricks/SimbaSparkODBC-2.6.4.1004-Debian-64bit.zip' \
      -O /tmp/databricks/simbaspark.zip
 unzip /tmp/databricks/simbaspark.zip -d /tmp/databricks
 dpkg -i /tmp/databricks/SimbaSparkODBC-2.6.4.1004-Debian-64bit/simbaspark_2.6.4.1004-2_amd64.deb


### PR DESCRIPTION
Just a basic change to use the Toucan Toco repository instead of the databricks one