### PR TITLE
fix: support custom variables syntax in default cache key TCTC-1903

### DIFF
--- a/tests/snowflake/test_snowflake.py
+++ b/tests/snowflake/test_snowflake.py
@@ -721,7 +721,7 @@ def test_describe(is_closed, close, connect, mocker, snowflake_datasource, snowf
     cm.force_clean()
 
 
-def test_render_datasource():
+def test_get_unique_datasource_identifier():
     snowflake_connector = SnowflakeConnector(
         identifier='snowflake_test',
         name='test_name',

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -130,7 +130,7 @@ def test_get_cache_key():
     key = connector.get_cache_key(ds)
     # We should get a deterministic identifier:
     # /!\ the identifier will change if the model of the connector or the datasource changes
-    assert key == '7b1ecd94-86e1-3e76-b9e1-44e97375a4e8'
+    assert key == '3ffe037e-3559-3a17-aede-c4ab0669cc25'
 
     ds.query = 'wow'
     key2 = connector.get_cache_key(ds)
@@ -152,6 +152,17 @@ def test_get_cache_key_connector_alone():
 
     assert key_a1 == key_a2
     assert key_a1 != key_b
+
+
+def test_get_cache_key_with_custom_variable_syntax():
+    connector_a1 = DataConnector(name='a')
+    # sample with Google BigQuery `@my_var` syntax
+    ds_1 = DataSource(name='ds_1', parameters={'a': 1}, domain='foo', query='bar=@a')
+    ds_2 = DataSource(name='ds_1', parameters={'a': 2}, domain='foo', query='bar=@a')
+    key_a1 = connector_a1.get_cache_key(ds_1)
+    key_a2 = connector_a1.get_cache_key(ds_2)
+
+    assert key_a1 != key_a2
 
 
 def test_get_cache_key_should_be_different_with_different_permissions():

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -154,6 +154,17 @@ def test_get_cache_key_connector_alone():
     assert key_a1 != key_b
 
 
+def test_get_cache_key_should_be_different_with_different_permissions():
+    connector_a1 = DataConnector(name='a')
+    ds_1 = DataSource(name='ds_1', parameters={'a': 1}, domain='foo', query='bar')
+    ds_2 = DataSource(name='ds_1', parameters={'a': 2}, domain='foo', query='bar')
+    permissions = {'column': 'a_group', 'value': '{{ a }}', 'operator': 'in'}
+    key_a1 = connector_a1.get_cache_key(ds_1, permissions=permissions)
+    key_a2 = connector_a1.get_cache_key(ds_2, permissions=permissions)
+
+    assert key_a1 != key_a2
+
+
 class UnreliableDataConnector(ToucanConnector):
     type = 'MyUnreliableDB'
     data_source_model: DataSource
@@ -296,14 +307,3 @@ def test_get_df_int_column(mocker):
 
     dc = DataConnector(name='bla')
     assert dc.get_df(mocker.MagicMock()).columns == ['0']
-
-
-def test_get_cache_key_should_be_different_with_different_permissions():
-    connector_a1 = DataConnector(name='a')
-    ds_1 = DataSource(name='ds_1', parameters={'a': 1}, domain='foo', query='bar')
-    ds_2 = DataSource(name='ds_1', parameters={'a': 2}, domain='foo', query='bar')
-    permissions = {'column': 'a_group', 'value': '{{ a }}', 'operator': 'in'}
-    key_a1 = connector_a1.get_cache_key(ds_1, permissions=permissions)
-    key_a2 = connector_a1.get_cache_key(ds_2, permissions=permissions)
-
-    assert key_a1 != key_a2

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -190,7 +190,7 @@ class HttpAPIConnector(ToucanConnector):
                 query[k] = template[k]
         return query
 
-    def _render_datasource(self, data_source: ToucanDataSource) -> dict:
+    def _get_unique_datasource_identifier(self, data_source: ToucanDataSource) -> dict:
         query = self._render_query(data_source)
         del query['parameters']
         return query

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -293,7 +293,7 @@ class MongoConnector(ToucanConnector):
             exclude={'client'}
         )  # client is a MongoClient instance, not json serializable
 
-    def _render_datasource(self, data_source: MongoDataSource) -> dict:
+    def _get_unique_datasource_identifier(self, data_source: MongoDataSource) -> dict:
         # let's make a copy first
         data_source_rendered = MongoDataSource.parse_obj(data_source)
         data_source_rendered.query = normalize_query(data_source.query, data_source.parameters)

--- a/toucan_connectors/snowflake/snowflake_connector.py
+++ b/toucan_connectors/snowflake/snowflake_connector.py
@@ -416,7 +416,7 @@ class SnowflakeConnector(ToucanConnector):
             result = SnowflakeCommon().describe(connection, data_source.query)
         return result
 
-    def _render_datasource(self, data_source: SnowflakeDataSource) -> dict:
+    def _get_unique_datasource_identifier(self, data_source: SnowflakeDataSource) -> dict:
         return SnowflakeCommon().render_datasource(data_source)
 
     @staticmethod

--- a/toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py
+++ b/toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py
@@ -226,7 +226,7 @@ class SnowflakeoAuth2Connector(ToucanConnector):
         string_uid = str(uuid.uuid3(uuid.NAMESPACE_OID, json_uid))
         return string_uid
 
-    def _render_datasource(self, data_source: SnowflakeDataSource) -> dict:
+    def _get_unique_datasource_identifier(self, data_source: SnowflakeDataSource) -> dict:
         return SnowflakeCommon().render_datasource(data_source)
 
     def _get_warehouses(self, warehouse_name: Optional[str] = None) -> List[str]:

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -428,9 +428,9 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
 
     def _get_unique_datasource_identifier(self, data_source: ToucanDataSource) -> dict:
         # By default we don't know which variable syntax is be supported by the inheriting connector,
-        # so calling `nosql_apply_parameters_to_query` is wrong and will produce the same cache key 
+        # so calling `nosql_apply_parameters_to_query` is wrong and will produce the same cache key
         # for different queries when using custom variable syntax !
-        # Overwrite this method to improve the cache key at places where supported syntaxes are clear. 
+        # Overwrite this method to improve the cache key at places where supported syntaxes are clear.
         return data_source.dict()
 
     def get_cache_key(

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -427,12 +427,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         return self.json()
 
     def _render_datasource(self, data_source: ToucanDataSource) -> dict:
-        data_source_rendered = nosql_apply_parameters_to_query(
-            data_source.dict(), data_source.parameters, handle_errors=True
-        )
-        del data_source_rendered['parameters']
-
-        return data_source_rendered
+        return data_source.dict()
 
     def get_cache_key(
         self,

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -426,7 +426,11 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         """
         return self.json()
 
-    def _render_datasource(self, data_source: ToucanDataSource) -> dict:
+    def _get_unique_datasource_identifier(self, data_source: ToucanDataSource) -> dict:
+        # By default we don't know which variable syntax is be supported by the inheriting connector,
+        # so calling `nosql_apply_parameters_to_query` is wrong and will produce the same cache key 
+        # for different queries when using custom variable syntax !
+        # Overwrite this method to improve the cache key at places where supported syntaxes are clear. 
         return data_source.dict()
 
     def get_cache_key(
@@ -452,7 +456,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         }
 
         if data_source is not None:
-            unique_identifier['datasource'] = self._render_datasource(data_source)
+            unique_identifier['datasource'] = self._get_unique_datasource_identifier(data_source)
         json_uid = JsonWrapper.dumps(unique_identifier, sort_keys=True, default=hash)
         string_uid = str(uuid.uuid3(uuid.NAMESPACE_OID, json_uid))
         return string_uid


### PR DESCRIPTION
## Change Summary

Fix a issue on Google Big Queries request using the custom variable syntax `@my_var` 
by making the default cache key "dumber" to produce different cache key for queries using custom variable syntax
(other than `{{ }}` & `@()`.

Resolution path considered but not chosen includes : 

- dropping support for this custom syntax on user side -> would require checking is the query does not use this syntax & do this for every connector with specific variable syntax, nope
-  overwriting `_render_datasource` for BigQuery like it was done for Mongo, Snowflake & Http -> apparently not possible, the BigQuery client does not seem to have a method returning interpolated query.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
* [X] Documentation reflects the changes where applicable
