### PR TITLE
fix(bigquery): fix client lib to v2 TCTC-2444

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='3.1.10',
+    version='3.1.11',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,9 @@ extras_require = {
     'github': ['python_graphql_client'],
     'google_analytics': ['google-api-python-client', 'oauth2client'],
     'google_adwords': ['googleads'],
-    'google_big_query': ['google-cloud-bigquery[bqstorage,pandas]'],
+    # google_big_query v3 uses Nullable types (https://pandas.pydata.org/docs/user_guide/integer_na.html) which are
+    # not compatible with eval. Once the formula will be compatible with these types, we can upgrade to v3
+    'google_big_query': ['google-cloud-bigquery[bqstorage,pandas]==2.*'],
     'google_cloud_mysql': ['PyMySQL>=0.8.0'],
     'google_my_business': ['google-api-python-client>=1.7.5'],
     'google_sheets': ['google-api-python-client>=2'],

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=3.1.10
+sonar.projectVersion=3.1.11
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors


### PR DESCRIPTION
The upgrade of bigquery client from 2 to 3 changed the dtypes used for nullable integers.

These types, quite experimental by now according to [docs](https://pandas.pydata.org/docs/user_guide/integer_na.html), are not compatible with eval and some other operations.

While we or pandas support these types in the eval / formula step of weaverbird, I suggest pinning this dep to v2