### PR TITLE
fix: databricks get status

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='3.4.0',
+    version='3.4.1',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=3.4.0
+sonar.projectVersion=3.4.1
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors

--- a/tests/databricks/test_databricks.py
+++ b/tests/databricks/test_databricks.py
@@ -1,3 +1,5 @@
+from unittest.mock import call
+
 import pyodbc
 import pytest
 import responses
@@ -165,12 +167,18 @@ def test_get_status_all(databricks_connector: DatabricksConnector, mocker: MockF
             ('Authenticated', False),
         ],
     )
-    mocker.patch('pyodbc.connect')
+    mocked_connect = mocker.patch('pyodbc.connect')
     mocker.patch('toucan_connectors.databricks.databricks_connector.DatabricksConnector.check_port')
     mocker.patch(
         'toucan_connectors.databricks.databricks_connector.DatabricksConnector.check_hostname'
     )
     assert databricks_connector.get_status() == CONNECTION_STATUS_OK
+    assert mocked_connect.call_args_list[0] == call(
+        'Driver=/opt/simba/spark/lib/64/libsparkodbc_sb64.so;'
+        'Host=127.0.0.1;Port=443;HTTPPath=foo/path;ThriftTransport=2;SSL=1;AuthMech=3;UID=token;PWD=12345',
+        autocommit=True,
+        ansi=False,
+    )
 
 
 @responses.activate

--- a/toucan_connectors/databricks/databricks_connector.py
+++ b/toucan_connectors/databricks/databricks_connector.py
@@ -79,7 +79,7 @@ class DatabricksConnector(ToucanConnector):
         except Exception as e:
             return ConnectorStatus(status=False, details=self._get_details(1, False), error=str(e))
         try:
-            pyodbc.connect(self._build_connection_string())
+            pyodbc.connect(self._build_connection_string(), autocommit=True, ansi=self.ansi)
         except pyodbc.InterfaceError as e:
             details = self._get_details(3, False)
             return ConnectorStatus(status=False, details=details, error=e.args[0])


### PR DESCRIPTION
## Change Summary
Databricks `get_status` needs to use an autocommit connection.