### PR TITLE
feat(googlebigquery): parse dates as datetime dtype [TCTC-2521]

### DIFF
--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -99,6 +99,7 @@ class GoogleBigQueryConnector(ToucanConnector):
                 .result()
                 .to_dataframe(
                     create_bqstorage_client=True,
+                    date_as_object=False,  # so date columns get dtype 'datetime64[ns]' instead of 'object'
                 )  # Use to generate directly a dataframe pandas
             )
             end = timer()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

without date_as_object=False, date columns get dtype 'object' instead of 'datetime64[ns]'

<!-- Please give a short summary of the changes. -->
