### PR TITLE
fix: dependencies (accordingly to laputa)  [TCTC-2752]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,11 @@ new_connector:  # $ make new_connector type=Magento
 .PHONY: build
 build:
 	# /!\ Discovered that sometimes, this is missing !
-	pip3 install wheel
+	python -m pip install wheel
 	python setup.py sdist bdist_wheel
 
 .PHONY: upload
 upload:
 	# /!\ Discovered that sometimes, this is missing !
-	pip3 install twine
+	python -m pip install twine
 	twine upload dist/*

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,12 @@ new_connector:  # $ make new_connector type=Magento
 
 .PHONY: build
 build:
+	# /!\ Discovered that sometimes, this is missing !
+	pip3 install wheel
 	python setup.py sdist bdist_wheel
 
 .PHONY: upload
 upload:
+	# /!\ Discovered that sometimes, this is missing !
+	pip3 install twine
 	twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='3.5.1.1',
+    version='3.5.2',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-auth_deps = ['oauthlib==3.1.0', 'requests-oauthlib==1.3.0']
+auth_deps = ['oauthlib==3.2.0', 'requests-oauthlib==1.3.1']
 bearer_deps = ['bearer==3.1.0']
 
 extras_require = {
@@ -80,7 +80,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='3.5.1',
+    version='3.5.1.1',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=3.5.1.1
+sonar.projectVersion=3.5.2
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=3.5.1
+sonar.projectVersion=3.5.1.1
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors


### PR DESCRIPTION
## What:

Dependencies fix :

- Upgrade requests-oauthlib & oauthlib on a minor version to match laputa
- Bump toucan-connectors from 3.5.1 to 3.5.2

PS: Already bumped (was to sync dependencies with laputa and test laputa migration from pip to poetry support here : https://github.com/ToucanToco/laputa/pull/5135 )