### PR TITLE
fix: http api json decode error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='3.5.2',
+    version='3.5.3',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=3.5.2
+sonar.projectVersion=3.5.3
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -1,3 +1,4 @@
+import json
 from enum import Enum
 from typing import Any, Dict, List, Type, Union
 from xml.etree.ElementTree import ParseError, fromstring, tostring
@@ -156,9 +157,14 @@ class HttpAPIConnector(ToucanConnector):
             try:
                 data = res.json()
             except ValueError:
-                HttpAPIConnector.logger.error(f'Could not decode {res.content!r}')
-                raise
-
+                HttpAPIConnector.logger.error('Could not decode content using response.json()')
+                try:
+                    HttpAPIConnector.logger.error('Trying with json.loads(res.content)')
+                    # sometimes when the content is too big res.json() fails but json.loads works
+                    data = json.loads(res.content)
+                except ValueError:
+                    HttpAPIConnector.logger.error('Cannot decode response content')
+                    raise
         try:
             return transform_with_jq(data, jq_filter)
         except ValueError:


### PR DESCRIPTION
## Change Summary
Fix an issue where `resp.json()` is not working in http api connector

## Checklist

* [X] Unit tests for the changes exist
* [X] Tests pass on CI and coverage remains at 100%
