### PR TITLE
chore(deps): Pin googleads>11.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require = {
     'facebook': ['facebook-sdk'],
     'github': ['python_graphql_client'],
     'google_analytics': ['google-api-python-client', 'oauth2client'],
-    'google_adwords': ['googleads'],
+    'google_adwords': ['googleads>11.0.0'],
     # google_big_query v3 uses Nullable types (https://pandas.pydata.org/docs/user_guide/integer_na.html) which are
     # not compatible with eval. Once the formula will be compatible with these types, we can upgrade to v3
     'google_big_query': ['google-cloud-bigquery[bqstorage,pandas]==2.*'],


### PR DESCRIPTION
This release removed the suds-jurko dependency, which is unmaintained, and
a pain to install.

https://github.com/googleads/googleads-python-lib/

FYI, I checked on our deployment, and since the versions were unspecified anyway, we have `googleads` 31.0.0 installed (11.0 is from 2018)