### PR TITLE
feat(mongo-connector): allow search on multiple columns [TCTC-2532]

### DIFF
--- a/tests/mongo/fixtures/docs.json
+++ b/tests/mongo/fixtures/docs.json
@@ -16,5 +16,11 @@
     "country": "Germany",
     "language": "German",
     "value": 17
+  }, 
+  {
+    "domain": "domain1",
+    "country": "USA",
+    "language":"English",
+    "value": 28
   }
 ]

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -312,8 +312,12 @@ def test_get_slice_max_count(mongo_connector, mongo_datasource, mocker):
 
 def test_get_slice_with_regex(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
-    slice = mongo_connector.get_slice_with_regex(datasource, fields=['country', 'language'], regex=re.compile('g'))
-    pd.testing.assert_series_equal(slice.df['country'], pd.Series(['England', 'Germany', 'USA'], name='country'))
+    slice = mongo_connector.get_slice_with_regex(
+        datasource, fields=['country', 'language'], regex=re.compile('g')
+    )
+    pd.testing.assert_series_equal(
+        slice.df['country'], pd.Series(['England', 'Germany', 'USA'], name='country')
+    )
 
 
 def test_get_df_with_regex(mongo_connector, mongo_datasource):

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -115,7 +115,7 @@ def test_get_df_no_query(mongo_connector, mongo_datasource):
     """It should return the whole collection by default"""
     ds = mongo_datasource(collection='test_col')
     df = mongo_connector.get_df(ds)
-    assert df.shape == (3, 5)
+    assert df.shape == (4, 5)
 
 
 def test_get_df(mocker):
@@ -180,12 +180,12 @@ def test_get_df_live(mongo_connector, mongo_datasource):
     df = mongo_connector.get_df(datasource)
     expected = pd.DataFrame(
         {
-            'country': ['France', 'England', 'Germany'],
-            'language': ['French', 'English', 'German'],
-            'value': [20, 14, 17],
+            'country': ['France', 'England', 'Germany', 'USA'],
+            'language': ['French', 'English', 'German', 'English'],
+            'value': [20, 14, 17, 28],
         }
     )
-    assert df.shape == (3, 5)
+    assert df.shape == (4, 5)
     assert set(df.columns) == {'_id', 'country', 'domain', 'language', 'value'}
     assert df[['country', 'language', 'value']].equals(expected)
 
@@ -225,30 +225,30 @@ def test_get_df_with_permissions(mongo_connector, mongo_datasource):
 def test_get_slice(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
     res = mongo_connector.get_slice(datasource)
-    assert res.stats.total_returned_rows == 3
-    assert res.stats.total_rows == 3
-    assert res.df.shape == (3, 5)
-    assert res.df['country'].tolist() == ['France', 'England', 'Germany']
+    assert res.stats.total_returned_rows == 4
+    assert res.stats.total_rows == 4
+    assert res.df.shape == (4, 5)
+    assert res.df['country'].tolist() == ['France', 'England', 'Germany', 'USA']
 
     # With a limit
     res = mongo_connector.get_slice(datasource, limit=1)
     expected = pd.DataFrame({'country': ['France'], 'language': ['French'], 'value': [20]})
-    assert res.stats.total_returned_rows == 3
-    assert res.stats.total_rows == 3
+    assert res.stats.total_returned_rows == 4
+    assert res.stats.total_rows == 4
     assert res.df.shape == (1, 5)
     assert res.df[['country', 'language', 'value']].equals(expected)
 
     # With a offset
     res = mongo_connector.get_slice(datasource, offset=1)
-    assert res.stats.total_returned_rows == 3
-    assert res.stats.total_rows == 3
-    assert res.df.shape == (2, 5)
-    assert res.df['country'].tolist() == ['England', 'Germany']
+    assert res.stats.total_returned_rows == 4
+    assert res.stats.total_rows == 4
+    assert res.df.shape == (3, 5)
+    assert res.df['country'].tolist() == ['England', 'Germany', 'USA']
 
     # With both
     res = mongo_connector.get_slice(datasource, offset=1, limit=1)
-    assert res.stats.total_returned_rows == 3
-    assert res.stats.total_rows == 3
+    assert res.stats.total_returned_rows == 4
+    assert res.stats.total_rows == 4
     assert res.df.shape == (1, 5)
     assert res.df.loc[0, 'country'] == 'England'
 
@@ -264,8 +264,8 @@ def test_get_slice_with_group_agg(mongo_connector, mongo_datasource):
         ],
     )
     dataslice = mongo_connector.get_slice(datasource, limit=1)
-    assert dataslice.stats.total_returned_rows == 3
-    assert dataslice.stats.total_rows == 3
+    assert dataslice.stats.total_returned_rows == 4
+    assert dataslice.stats.total_rows == 4
     assert dataslice.df.shape == (1, 1)
     assert dataslice.df.iloc[0].pays in ['France', 'England', 'Germany']
 
@@ -273,15 +273,15 @@ def test_get_slice_with_group_agg(mongo_connector, mongo_datasource):
 def test_get_slice_no_limit(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
     ds = mongo_connector.get_slice(datasource, limit=None)
-    assert ds.stats.total_returned_rows == 3
+    assert ds.stats.total_returned_rows == 4
     expected = pd.DataFrame(
         {
-            'country': ['France', 'England', 'Germany'],
-            'language': ['French', 'English', 'German'],
-            'value': [20, 14, 17],
+            'country': ['France', 'England', 'Germany', 'USA'],
+            'language': ['French', 'English', 'German', 'English'],
+            'value': [20, 14, 17, 28],
         }
     )
-    assert ds.df.shape == (3, 5)
+    assert ds.df.shape == (4, 5)
     assert ds.df[['country', 'language', 'value']].equals(expected)
 
 

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -309,6 +309,11 @@ def test_get_slice_max_count(mongo_connector, mongo_datasource, mocker):
     assert '$limit' in aggregate.call_args[0][1][1]['$facet']['count'][0]
     assert aggregate.call_args[0][1][1]['$facet']['count'][0]['$limit'] > 0
 
+def test_get_slice_with_regex(mongo_connector, mongo_datasource):
+    datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
+    slice = mongo_connector.get_slice_with_regex(datasource, fields=['country', 'language'], regex=re.compile('g'))
+    pd.testing.assert_series_equal(slice.df['country'], pd.Series(['England', 'Germany', 'USA'], name='country'))
+
 
 def test_get_df_with_regex(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
@@ -358,6 +363,12 @@ def test_get_df_with_regex_with_limit(mongo_connector, mongo_datasource):
     )
     pd.testing.assert_series_equal(df['country'], pd.Series(['France'], name='country'))
 
+def test_get_df_with_regex_with_offset_and_limit(mongo_connector, mongo_datasource):
+    datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
+    df = mongo_connector.get_df_with_regex(
+        datasource, field='country', regex=re.compile('r.*a'), limit=1, offset=1
+    )
+    pd.testing.assert_series_equal(df['country'], pd.Series(['Germany'], name='country'))
 
 def test_explain(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -309,6 +309,7 @@ def test_get_slice_max_count(mongo_connector, mongo_datasource, mocker):
     assert '$limit' in aggregate.call_args[0][1][1]['$facet']['count'][0]
     assert aggregate.call_args[0][1][1]['$facet']['count'][0]['$limit'] > 0
 
+
 def test_get_slice_with_regex(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
     slice = mongo_connector.get_slice_with_regex(datasource, fields=['country', 'language'], regex=re.compile('g'))
@@ -363,12 +364,14 @@ def test_get_df_with_regex_with_limit(mongo_connector, mongo_datasource):
     )
     pd.testing.assert_series_equal(df['country'], pd.Series(['France'], name='country'))
 
+
 def test_get_df_with_regex_with_offset_and_limit(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
     df = mongo_connector.get_df_with_regex(
         datasource, field='country', regex=re.compile('r.*a'), limit=1, offset=1
     )
     pd.testing.assert_series_equal(df['country'], pd.Series(['Germany'], name='country'))
+
 
 def test_explain(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -250,7 +250,7 @@ class MongoConnector(ToucanConnector):
         permissions: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-    ) -> pd.DataFrame:
+    ) -> DataSlice:
         # Create a copy in order to keep the original (deepcopy-like)
         data_source = MongoDataSource.parse_obj(data_source)
         data_source.query = normalize_query(data_source.query, data_source.parameters)

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -1,5 +1,5 @@
 from functools import _lru_cache_wrapper, lru_cache
-from typing import Optional, Pattern, Union
+from typing import List, Optional, Pattern, Union
 
 import pandas as pd
 import pymongo
@@ -242,13 +242,14 @@ class MongoConnector(ToucanConnector):
             df, stats=DataStats(total_returned_rows=total_count, total_rows=total_count)
         )
 
-    def get_df_with_regex(
+    def get_slice_with_regex(
         self,
         data_source: MongoDataSource,
-        field: str,
+        fields: List[str],
         regex: Pattern,
         permissions: Optional[str] = None,
         limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> pd.DataFrame:
         # Create a copy in order to keep the original (deepcopy-like)
         data_source = MongoDataSource.parse_obj(data_source)
@@ -259,15 +260,38 @@ class MongoConnector(ToucanConnector):
         # Since Mongo '$regex' operator doesn't work with integer values, we need to check the stringified versions
         regex_step = {
             '$expr': {
-                '$regexMatch': {
-                    'input': {'$toString': f'${field}'},
-                    'regex': regex.pattern,
-                    'options': 'i',  # i -> Case insensitivity
-                }
+                '$or': [
+                    {
+                        '$regexMatch': {
+                            'input': {'$toString': f'${field}'},
+                            'regex': regex.pattern,
+                            'options': 'i',  # i -> Case insensitivity
+                        }
+                    }
+                    for field in fields
+                ]
             }
         }
         data_source.query.append({'$match': regex_step})
-        return self.get_slice(data_source, permissions, limit=limit).df
+        return self.get_slice(data_source, permissions, limit=limit, offset=offset)
+
+    def get_df_with_regex(
+        self,
+        data_source: MongoDataSource,
+        field: str,
+        regex: Pattern,
+        permissions: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> pd.DataFrame:
+        return self.get_slice_with_regex(
+            data_source=data_source,
+            fields=[field],
+            regex=regex,
+            permissions=permissions,
+            limit=limit,
+            offset=offset,
+        ).df
 
     @decorate_func_with_retry
     def explain(self, data_source, permissions=None):


### PR DESCRIPTION
## Description 
With the `get_df_with_regex` we could only search for a string on a single field given as a param. We couldn't also get the whole slice of data. That's why we needed to create a new function that returns the slice and allows searching for a string on multiple columns given as an array of strings in the params. 

Feature needed for https://toucantoco.atlassian.net/jira/software/c/projects/TCTC/boards/13?modal=detail&selectedIssue=TCTC-2532&quickFilter=87