### PR TITLE
chore: bump awswrangler to support pandas >=1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ def get_static_file_paths():
 
 setup(
     name='toucan_connectors',
-    version='3.7.0',
+    version='3.8.0',
     description='Toucan Toco Connectors',
     long_description=(HERE / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,7 @@ bearer_deps = ['bearer==3.1.0']
 extras_require = {
     'adobe': ['adobe_analytics'],
     'aircall': bearer_deps,
-    # awswrangler>=2.15.1 requires pyarrow>=7.0, which might be
-    # incompatible with other requirements
-    'awsathena': ['awswrangler>=2.14,<2.15'],
+    'awsathena': ['awswrangler>=2.15'],
     'azure_mssql': ['pyodbc>=3'],
     'clickhouse': ['clickhouse_driver'],
     'dataiku': ['dataiku-api-client'],
@@ -42,7 +40,10 @@ extras_require = {
     'ROK': ['requests', 'pyjwt', 'simplejson'],
     'sap_hana': ['pyhdb>=0.3.4'],
     'soap': ['zeep', 'lxml==4.6.5'],
-    'snowflake': ['snowflake-connector-python>=2.5', 'pyjwt'],
+    # snowflake requires pyarrow<7
+    # (cf. https://github.com/snowflakedb/snowflake-connector-python/issues/1144),
+    # so let's enforce it here:
+    'snowflake': ['snowflake-connector-python>=2.5', 'pyjwt', 'pyarrow<7'],
     'toucan_toco': ['toucan_client'],
 }
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=3.7.0
+sonar.projectVersion=3.8.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary
- bump awswrangler to >= 2.15 in order to support pandas >= 1.3
- pin explicitly pyarrow<7 when installing snowflake, otherwise it doesnt seem to be taken in account :shrug: despite being specified here: https://github.com/snowflakedb/snowflake-connector-python/blob/v2.7.8/pyproject.toml#L9

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
