### PR TITLE
chore: bump from 3.10 to 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog (Pypi package)
 
+## [3.11.0] 2022-06-17
+
+### Changed
+
+Add support for elasticsearch >= 8 on the ElasticsearchConnector.
+
 ## [3.0.0] 2022-02-03
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ multi_line_output = 3
 
 [tool.poetry]
 name = "toucan-connectors"
-version = "3.10.0"
+version = "3.11.0"
 description = "Toucan Toco Connectors"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 license = "BSD"


### PR DESCRIPTION
## WHAT

Bump connectors from 3.10 to 3.11
Changes related to https://github.com/ToucanToco/toucan-connectors/pull/609