### PR TITLE
fix(bigquery): ignore database extra attribute

### DIFF
--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -40,6 +40,9 @@ class GoogleBigQueryDataSource(ToucanDataSource):
     language: str = Field('sql', **{'ui.hidden': True})
     database: str = Field(None)  # Needed for graphical selection in frontend but not used
 
+    class Config:
+        extra = 'ignore'
+
     @classmethod
     def get_form(cls, connector: 'GoogleBigQueryConnector', current_config: dict[str, Any]):
         schema = create_model('FormSchema', __base__=cls).schema()


### PR DESCRIPTION
As the frontend sends the 'Database' attribute for graphical interface we need to ignore it when validating the model.