### PR TITLE
feat: multi-column filtering [TCTC-3332]

### DIFF
--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -320,7 +320,7 @@ def test_get_slice_with_regex(mongo_connector, mongo_datasource):
                 {'country': regex},
                 {'language': regex},
             ]
-        }
+        },
     )
     pd.testing.assert_series_equal(
         slice.df['country'], pd.Series(['England', 'Germany', 'USA'], name='country')
@@ -329,11 +329,7 @@ def test_get_slice_with_regex(mongo_connector, mongo_datasource):
 
 def test_get_df_with_regex(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
-    df = mongo_connector.get_df_with_regex(
-        datasource,
-        {
-            'and': [{'country': re.compile('r.*a')}]
-        })
+    df = mongo_connector.get_df_with_regex(datasource, {'and': [{'country': re.compile('r.*a')}]})
     pd.testing.assert_series_equal(df['country'], pd.Series(['France', 'Germany'], name='country'))
 
 
@@ -355,8 +351,7 @@ def test_get_df_with_regex_with_integers(mongo_connector, mongo_datasource):
         collection='test_col',
         query=[{'$match': {'domain': 'domain1'}}],
     )
-    df = mongo_connector.get_df_with_regex(datasource,
-    {'and': [{'value': re.compile('^20$')}]})
+    df = mongo_connector.get_df_with_regex(datasource, {'and': [{'value': re.compile('^20$')}]})
     assert df.drop(columns='_id').to_dict(orient='records') == [
         {'domain': 'domain1', 'country': 'France', 'language': 'French', 'value': 20}
     ]
@@ -367,7 +362,9 @@ def test_get_df_with_regex_case_sensitiveness(mongo_connector, mongo_datasource)
         collection='test_col',
         query=[{'$match': {'domain': 'domain1'}}],
     )
-    df = mongo_connector.get_df_with_regex(datasource,{'and': [{'country': re.compile('^FrAn.*')}]})
+    df = mongo_connector.get_df_with_regex(
+        datasource, {'and': [{'country': re.compile('^FrAn.*')}]}
+    )
     assert df.drop(columns='_id').to_dict(orient='records') == [
         {'domain': 'domain1', 'country': 'France', 'language': 'French', 'value': 20}
     ]
@@ -376,8 +373,7 @@ def test_get_df_with_regex_case_sensitiveness(mongo_connector, mongo_datasource)
 def test_get_df_with_regex_with_limit(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
     df = mongo_connector.get_df_with_regex(
-        datasource,
-        {'and': [{'country': re.compile('r.*a')}]}, limit=1
+        datasource, {'and': [{'country': re.compile('r.*a')}]}, limit=1
     )
     pd.testing.assert_series_equal(df['country'], pd.Series(['France'], name='country'))
 
@@ -385,7 +381,7 @@ def test_get_df_with_regex_with_limit(mongo_connector, mongo_datasource):
 def test_get_df_with_regex_with_offset_and_limit(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
     df = mongo_connector.get_df_with_regex(
-        datasource,{'and': [{'country': re.compile('r.*a')}]}, limit=1, offset=1
+        datasource, {'and': [{'country': re.compile('r.*a')}]}, limit=1, offset=1
     )
     pd.testing.assert_series_equal(df['country'], pd.Series(['Germany'], name='country'))
 

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -245,8 +245,7 @@ class MongoConnector(ToucanConnector):
     def get_slice_with_regex(
         self,
         data_source: MongoDataSource,
-        fields: List[str],
-        regex: Pattern,
+        search: dict[List[dict[str, Pattern]]],
         permissions: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
@@ -258,36 +257,34 @@ class MongoConnector(ToucanConnector):
         # Mongo will then optimize the pipeline to move the match regex to its most convenient position
         # (c.f https://docs.mongodb.com/manual/core/aggregation-pipeline-optimization/#pipeline-sequence-optimization)
         # Since Mongo '$regex' operator doesn't work with integer values, we need to check the stringified versions
-        regex_step = {
-            '$expr': {
-                '$or': [
-                    {
-                        '$regexMatch': {
-                            'input': {'$toString': f'${field}'},
-                            'regex': regex.pattern,
-                            'options': 'i',  # i -> Case insensitivity
+        search_steps = {}
+        for condition in search:
+            search_steps[f'${condition}'] = []  # convert "and"/"or" to "$and"/"$or"
+            for column in search[condition]:
+                for col, regex in column.items():
+                    search_steps[f'${condition}'].append(
+                        {
+                            '$regexMatch': {
+                                'input': {'$toString': f'${col}'},
+                                'regex': regex.pattern,
+                                'options': 'i',  # i -> Case insensitivity
+                            }
                         }
-                    }
-                    for field in fields
-                ]
-            }
-        }
-        data_source.query.append({'$match': regex_step})
+                    )
+        data_source.query.append({'$match': {'$expr': search_steps}})
         return self.get_slice(data_source, permissions, limit=limit, offset=offset)
 
     def get_df_with_regex(
         self,
         data_source: MongoDataSource,
-        field: str,
-        regex: Pattern,
+        search: dict[List[dict[str, Pattern]]],
         permissions: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
     ) -> pd.DataFrame:
         return self.get_slice_with_regex(
             data_source=data_source,
-            fields=[field],
-            regex=regex,
+            search=search,
             permissions=permissions,
             limit=limit,
             offset=offset,

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -277,7 +277,7 @@ class MongoConnector(ToucanConnector):
     def get_df_with_regex(
         self,
         data_source: MongoDataSource,
-        search: dict[List[dict[str, Pattern]]],
+        search: dict[str, List[dict[str, Pattern]]],
         permissions: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -245,7 +245,7 @@ class MongoConnector(ToucanConnector):
     def get_slice_with_regex(
         self,
         data_source: MongoDataSource,
-        search: dict[List[dict[str, Pattern]]],
+        search: dict[str, List[dict[str, Pattern]]],
         permissions: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,


### PR DESCRIPTION
## Change Summary

Toucan connectors now support by-column regex filtering

## Related issue number

https://toucantoco.atlassian.net/browse/TCTC-3332
https://github.com/ToucanToco/laputa/pull/5280

## Checklist

* [x] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
