### PR TITLE
fix: Ensure STL dates are returned with the right dtype TCTC-3424

### DIFF
--- a/tests/utils/test_datetime.py
+++ b/tests/utils/test_datetime.py
@@ -1,0 +1,66 @@
+from datetime import date, datetime
+
+import pandas as pd
+import pytest
+from numpy import dtype
+
+from toucan_connectors.utils.datetime import is_datetime_col, sanitize_df_dates
+
+
+@pytest.mark.parametrize(
+    'col',
+    [
+        pd.date_range(start='2022-07-01', end='2022-08-01').to_series(),
+        pd.Series([date(2022, 7, x) for x in range(1, 31)]),
+        pd.Series([datetime(2022, 7, x) for x in range(1, 31)]),
+    ],
+)
+def test_is_datetime_col_valid(col: pd.Series):
+    assert is_datetime_col(col)
+
+
+@pytest.mark.parametrize(
+    'col',
+    [
+        pd.Series([*(date(2022, 7, x) for x in range(1, 31)), 42]),
+        pd.Series([*(date(2022, 7, x) for x in range(1, 31)), 42]),
+        pd.Series(['2022-03-05T00:02:03']),
+        pd.Series(['2022-03-05']),
+    ],
+)
+def test_is_datetime_col_invalid(col: pd.Series):
+    assert not is_datetime_col(col)
+
+
+def test_sanitize_df_dates_with_dates():
+    df = pd.DataFrame(
+        {
+            'a': [1, 2, 3],
+            'b': ['a', 'b', 'c'],
+            'c': [date(2022, 7, 21), date(2022, 7, 22), date(2022, 7, 23)],
+        }
+    )
+    # First, ensure the dtypes are invalid
+    assert df.dtypes.to_list() == [dtype('int64'), dtype('object'), dtype('object')]
+
+    assert sanitize_df_dates(df).dtypes.to_list() == [
+        dtype('int64'),
+        dtype('object'),
+        dtype('datetime64[ns]'),
+    ]
+
+
+def test_sanitize_df_dates_with_datetimes():
+    df = pd.DataFrame(
+        {
+            'a': [1, 2, 3],
+            'b': ['a', 'b', 'c'],
+            'c': [datetime(2022, 7, 21), datetime(2022, 7, 22), datetime(2022, 7, 23)],
+        }
+    )
+    assert df.dtypes.to_list() == [dtype('int64'), dtype('object'), dtype('datetime64[ns]')]
+    assert sanitize_df_dates(df).dtypes.to_list() == [
+        dtype('int64'),
+        dtype('object'),
+        dtype('datetime64[ns]'),
+    ]

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -20,6 +20,7 @@ from toucan_connectors.common import (
 )
 from toucan_connectors.json_wrapper import JsonWrapper
 from toucan_connectors.pandas_translator import PandasConditionTranslator
+from toucan_connectors.utils.datetime import sanitize_df_dates
 
 try:
     from bearer import Bearer
@@ -342,6 +343,7 @@ class ToucanConnector(BaseModel, metaclass=ABCMeta):
         """
         res = self._retrieve_data(data_source)
         res.columns = res.columns.astype(str)
+        res = sanitize_df_dates(res)
 
         if permissions is not None:
             permissions_query = PandasConditionTranslator.translate(permissions)

--- a/toucan_connectors/utils/datetime.py
+++ b/toucan_connectors/utils/datetime.py
@@ -1,0 +1,17 @@
+from datetime import date
+
+import pandas as pd
+from pandas.api.types import is_datetime64_any_dtype as pd_is_datetime
+
+
+def is_datetime_col(col: pd.Series) -> bool:
+    return pd_is_datetime(col) or all(isinstance(val, date) for val in col)
+
+
+def sanitize_df_dates(df: pd.DataFrame) -> pd.DataFrame:
+    """Converts all datetime columns to pd.datetime64"""
+    for col in df.columns:
+        if is_datetime_col(df[col]):
+            df[col] = pd.to_datetime(df[col])
+
+    return df


### PR DESCRIPTION
BigQuery and Athena translators store objects in the SQL DATE type as datetime.date objects.
That is correct, but pandas does not consider datetime.date objects as datetimes. As a result, when
serializing and deserializing a dataframe containing datetime.date objects, these get dumped/loaded
as strings.

This change ensures the right type is used.

TCTC-3424

Signed-off-by: Luka Peschke <luka.peschke@toucantoco.com>

## Checklist

* [x ] Unit tests for the changes exist
* [ x] Tests pass on CI and coverage remains at 100%
* [ x] Documentation reflects the changes where applicable
