### PR TITLE
fix(mysql,athena) hidden table attr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog (Pypi package)
 
+## [3.17.1] 2022-07-27
+
+### Changed
+
+- Fix: Mysql, Athena add hidden table attribute to avoid old datasources configs to break
 
 ## [3.17.1] 2022-07-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ multi_line_output = 3
 
 [tool.poetry]
 name = "toucan-connectors"
-version = "3.17.1"
+version = "3.17.2"
 description = "Toucan Toco Connectors"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 license = "BSD"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=3.15.2
+sonar.projectVersion=3.17.2
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors

--- a/toucan_connectors/awsathena/awsathena_connector.py
+++ b/toucan_connectors/awsathena/awsathena_connector.py
@@ -24,6 +24,9 @@ class AwsathenaDataSource(ToucanDataSource):
     database: constr(min_length=1) = Field(
         ..., description='The name of the database you want to query.'
     )
+    table: str = Field(
+        None, **{'ui.hidden': True}
+    )  # To avoid previous config migrations, won't be used
     language: str = Field('sql', **{'ui.hidden': True})
     query: constr(min_length=1) = Field(
         None,

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -30,6 +30,9 @@ class MySQLDataSource(ToucanDataSource):
     """
 
     database: str = Field(..., description='The name of the database you want to query')
+    table: str = Field(
+        None, **{'ui.hidden': True}
+    )  # To avoid previous config migrations, won't be used
     query: constr(min_length=1) = Field(
         None,
         description='You can write a custom query against your '


### PR DESCRIPTION
Old Athena & Mysql datasources config might have a Table attribute. 
We add them back but hidden from the UI to avoid breaking old configs. 