### PR TITLE
fix(mongo-connector): search [TCTC-3545]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ multi_line_output = 3
 
 [tool.poetry]
 name = "toucan-connectors"
-version = "3.17.3"
+version = "3.17.4"
 description = "Toucan Toco Connectors"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 license = "BSD"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=3.17.3
+sonar.projectVersion=3.17.4
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors

--- a/tests/mongo/fixtures/docs.json
+++ b/tests/mongo/fixtures/docs.json
@@ -3,24 +3,35 @@
     "domain": "domain1",
     "country": "France",
     "language": "French",
-    "value": 20
+    "value": 20,
+    "name": "François"
+  },
+  {
+    "domain": "domain1",
+    "country": "France",
+    "language": "French",
+    "value": 20,
+    "name": "Marie"
   },
   {
     "domain": "domain1",
     "country": "England",
     "language": "English",
-    "value": 14
+    "value": 14,
+    "name": "Evelyn"
   },
   {
     "domain": "domain1",
     "country": "Germany",
     "language": "German",
-    "value": 17
-  }, 
+    "value": 17,
+    "name": "Hans"
+  },
   {
     "domain": "domain1",
     "country": "USA",
-    "language":"English",
-    "value": 28
+    "language": "English",
+    "value": 28,
+    "name": "Scarlett"
   }
 ]

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -439,11 +439,11 @@ def test_get_df_with_regex_and(mongo_connector, mongo_datasource):
         datasource, {'and': [{'country': re.compile('France'), 'name': re.compile('Marie')}]}
     ).drop(columns='_id').to_dict(orient='records') == [
         {
-            "domain": "domain1",
-            "country": "France",
-            "language": "French",
-            "value": 20,
-            "name": "Marie",
+            'domain': 'domain1',
+            'country': 'France',
+            'language': 'French',
+            'value': 20,
+            'name': 'Marie',
         }
     ]
 
@@ -457,29 +457,29 @@ def test_get_df_with_regex_or(mongo_connector, mongo_datasource):
         datasource, {'or': [{'country': re.compile('France'), 'name': re.compile('Marie')}]}
     ).drop(columns='_id').to_dict(orient='records') == [
         {
-            "domain": "domain1",
-            "country": "France",
-            "language": "French",
-            "value": 20,
-            "name": "Marie",
+            'domain': 'domain1',
+            'country': 'France',
+            'language': 'French',
+            'value': 20,
+            'name': 'Marie',
         }
     ]
     assert mongo_connector.get_df_with_regex(
         datasource, {'or': [{'country': re.compile('France')}, {'name': re.compile('Marie')}]}
     ).drop(columns='_id').to_dict(orient='records') == [
         {
-            "domain": "domain1",
-            "country": "France",
-            "language": "French",
-            "value": 20,
-            "name": "François",
+            'domain': 'domain1',
+            'country': 'France',
+            'language': 'French',
+            'value': 20,
+            'name': 'François',
         },
         {
-            "domain": "domain1",
-            "country": "France",
-            "language": "French",
-            "value": 20,
-            "name": "Marie",
+            'domain': 'domain1',
+            'country': 'France',
+            'language': 'French',
+            'value': 20,
+            'name': 'Marie',
         },
     ]
 

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -430,6 +430,60 @@ def test_get_df_with_regex_with_offset_and_limit(mongo_connector, mongo_datasour
     pd.testing.assert_series_equal(df['country'], pd.Series(['Germany'], name='country'))
 
 
+def test_get_df_with_regex_and(mongo_connector, mongo_datasource):
+    datasource = mongo_datasource(
+        collection='test_col',
+        query=[{'$match': {'domain': 'domain1'}}],
+    )
+    assert mongo_connector.get_df_with_regex(
+        datasource, {'and': [{'country': re.compile('France'), 'name': re.compile('Marie')}]}
+    ).drop(columns='_id').to_dict(orient='records') == [
+        {
+            "domain": "domain1",
+            "country": "France",
+            "language": "French",
+            "value": 20,
+            "name": "Marie",
+        }
+    ]
+
+
+def test_get_df_with_regex_or(mongo_connector, mongo_datasource):
+    datasource = mongo_datasource(
+        collection='test_col',
+        query=[{'$match': {'domain': 'domain1'}}],
+    )
+    assert mongo_connector.get_df_with_regex(
+        datasource, {'or': [{'country': re.compile('France'), 'name': re.compile('Marie')}]}
+    ).drop(columns='_id').to_dict(orient='records') == [
+        {
+            "domain": "domain1",
+            "country": "France",
+            "language": "French",
+            "value": 20,
+            "name": "Marie",
+        }
+    ]
+    assert mongo_connector.get_df_with_regex(
+        datasource, {'or': [{'country': re.compile('France')}, {'name': re.compile('Marie')}]}
+    ).drop(columns='_id').to_dict(orient='records') == [
+        {
+            "domain": "domain1",
+            "country": "France",
+            "language": "French",
+            "value": 20,
+            "name": "François",
+        },
+        {
+            "domain": "domain1",
+            "country": "France",
+            "language": "French",
+            "value": 20,
+            "name": "Marie",
+        },
+    ]
+
+
 def test_explain(mongo_connector, mongo_datasource):
     datasource = mongo_datasource(collection='test_col', query={'domain': 'domain1'})
     res = mongo_connector.explain(datasource)

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -258,10 +258,12 @@ class MongoConnector(ToucanConnector):
         # (c.f https://docs.mongodb.com/manual/core/aggregation-pipeline-optimization/#pipeline-sequence-optimization)
         # Since Mongo '$regex' operator doesn't work with integer values, we need to check the stringified versions
         search_steps = {}
-        for condition in search: 
-            search_steps[f'${condition}'] = [] # convert "and"/"or" to "$and"/"$or"
+        for condition in search:
+            search_steps[f'${condition}'] = []  # convert "and"/"or" to "$and"/"$or"
             for column in search[condition]:
-                search_steps[f'${condition}'].append({'$and': []}) # makes an "and" of all columns searches
+                search_steps[f'${condition}'].append(
+                    {'$and': []}
+                )  # makes an "and" of all columns searches
                 for col, regex in column.items():
                     search_steps[f'${condition}'][-1]['$and'].append(
                         {

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -258,11 +258,12 @@ class MongoConnector(ToucanConnector):
         # (c.f https://docs.mongodb.com/manual/core/aggregation-pipeline-optimization/#pipeline-sequence-optimization)
         # Since Mongo '$regex' operator doesn't work with integer values, we need to check the stringified versions
         search_steps = {}
-        for condition in search:
-            search_steps[f'${condition}'] = []  # convert "and"/"or" to "$and"/"$or"
+        for condition in search: 
+            search_steps[f'${condition}'] = [] # convert "and"/"or" to "$and"/"$or"
             for column in search[condition]:
+                search_steps[f'${condition}'].append({'$and': []}) # makes an "and" of all columns searches
                 for col, regex in column.items():
-                    search_steps[f'${condition}'].append(
+                    search_steps[f'${condition}'][-1]['$and'].append(
                         {
                             '$regexMatch': {
                                 'input': {'$toString': f'${col}'},


### PR DESCRIPTION
https://toucantoco.atlassian.net/browse/TCTC-3545

Searching for

```yml
or:
- foo: Foo
  bar: Bar
- baz: Baz
  qux: Qux
```

resulted in (pseudo mongo)

```yml
$or:
- foo: matches Foo
- bar: matches Bar
- baz: matches Baz
- qux: matches Qux
```

but it should result in (pseudo mongo)

```yml
$or:
- $and:
  - foo: matches Foo
  - bar: matches Bar
- $and:
  - baz: matches Baz
  - qux: matches Qux
```

It's more reasonable when reading the bug ticket: basically if I want to filter rows where name is John or Johnny and age is 20 I don't wanna be showned a John that is not 20 years old

