### PR TITLE
feat(athena): Add an option allowing to toggle CTAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog (Pypi package)
 
+## Unreleased
+
+### Changed
+
+- Athena: Add an option allowing to toggle CTAS (disabled by default)
+
 ## [3.17.1] 2022-07-27
 
 ### Changed

--- a/doc/connectors.md
+++ b/doc/connectors.md
@@ -12,6 +12,8 @@
 
 * [ClickhouseConnector](connectors/clickhouse.md)
 
+* [DatabricksConnector](connectors/databricks.md)
+
 * [DataikuConnector](connectors/dataiku.md)
 
 * [ElasticsearchConnector](connectors/elasticsearch.md)

--- a/doc/connectors/awsathena.md
+++ b/doc/connectors/awsathena.md
@@ -4,12 +4,13 @@
 
 * `type`: `"Awsathena"`
 * `name`: str, required
+* `type`: str
 * `cache_ttl`: int
 * `identifier`: str
 * `secrets_storage_version`: str, defaults to 1
-* `s3_output_bucket`: str, required. Your S3 Output bucket (where query results are stored.)
-* `aws_access_key_id`: str, required. Your AWS access key ID.
-* `aws_secret_access_key`: str, required. Your AWS secret key.
+* `s3_output_bucket`: str, required
+* `aws_access_key_id`: str, required
+* `aws_secret_access_key`: SecretStr
 * `region_name`: str, required
 
 ```coffee
@@ -35,7 +36,11 @@ DATA_PROVIDERS: [
 * `name`: str, required
 * `cache_ttl`: int
 * `database`: str (not empty), required
-* `query`: str (not empty), required
+* `table`: str
+* `language`: str, defaults to sql
+* `query`: str (not empty)
+* `query_object`: dict
+* `use_ctas`: bool, defaults to False
 
 ```coffee
 DATA_SOURCES: [
@@ -43,7 +48,11 @@ DATA_SOURCES: [
   name:    '<name>'
   cache_ttl:    '<cache_ttl>'
   database:    '<database>'
+  table:    '<table>'
+  language:    '<language>'
   query:    '<query>'
+  query_object:    '<query_object>'
+  use_ctas:    '<use_ctas>'
 ,
   ...
 ]

--- a/tests/awsathena/test_awsathena.py
+++ b/tests/awsathena/test_awsathena.py
@@ -59,9 +59,16 @@ def status_checks() -> List[str]:
     ]
 
 
+@pytest.mark.parametrize('use_ctas', (True, False))
 def test_get_df(
-    mocker, athena_connector, data_source, sample_data, mocked_read_sql_query, mocked_boto_session
+    athena_connector,
+    data_source,
+    sample_data,
+    mocked_read_sql_query,
+    mocked_boto_session,
+    use_ctas: bool,
 ):
+    data_source.use_ctas = use_ctas
     # The actual data request
     df = athena_connector.get_df(data_source=data_source)
 
@@ -72,6 +79,7 @@ def test_get_df(
         database='mydatabase',
         boto3_session={'a': 'b'},
         s3_output='s3://test/results/',
+        ctas_approach=use_ctas,
     )
 
     mocked_boto_session.assert_called_once()
@@ -97,6 +105,7 @@ def test_get_slice(
         database='mydatabase',
         boto3_session={'a': 'b'},
         s3_output='s3://test/results/',
+        ctas_approach=False,
     )
 
 

--- a/toucan_connectors/awsathena/awsathena_connector.py
+++ b/toucan_connectors/awsathena/awsathena_connector.py
@@ -38,6 +38,10 @@ class AwsathenaDataSource(ToucanDataSource):
         description='An object describing a simple select query This field is used internally',
         **{'ui.hidden': True},
     )
+    use_ctas: bool = Field(
+        False,
+        description='Set to true if you want to use CTAS (recommended for big queries only)',
+    )
 
     @classmethod
     def get_form(cls, connector: 'AwsathenaConnector', current_config: dict[str, Any]):
@@ -111,6 +115,7 @@ class AwsathenaConnector(ToucanConnector, DiscoverableConnector):
             database=data_source.database,
             boto3_session=self.get_session(),
             s3_output=self.s3_output_bucket,
+            ctas_approach=data_source.use_ctas,
         )
         return df
 


### PR DESCRIPTION
## Change Summary

Allow to toggle Create Table As (CTAS) in athena connector. For small result sets, disabling it is faster because it reduces latency

## Related issue number

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
