### PR TITLE
fix(mysql): Do not specify the database for schema-related functions TCTC-3768

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### [3.18.4] 2022-08-26
+
+### Changed
+
+- MySQL: Do not specify a database on discoverability-related functions (listing databases and describing table schemas).
+
 ### [3.18.3] 2022-08-24
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ multi_line_output = 3
 
 [tool.poetry]
 name = "toucan-connectors"
-version = "3.18.3"
+version = "3.18.4"
 description = "Toucan Toco Connectors"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 license = "BSD"

--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -341,3 +341,21 @@ def test_get_df_no_query(query: str, mocker: MockerFixture):
                 }
             )
         )
+
+
+def test_list_db_names_ensure_no_db_specified(
+    mysql_connector: MySQLConnector, mocker: MockerFixture
+):
+    connect_mock = mocker.patch('pymysql.connect')
+    mysql_connector._list_db_names()
+    assert connect_mock.call_count == 1
+    assert 'database' not in connect_mock.call_args.kwargs
+
+
+def test_get_project_structure_ensure_no_db_specified(
+    mysql_connector: MySQLConnector, mocker: MockerFixture
+):
+    connect_mock = mocker.patch('pymysql.connect')
+    mysql_connector._get_project_structure()
+    assert connect_mock.call_count == 1
+    assert 'database' not in connect_mock.call_args.kwargs

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -99,9 +99,7 @@ class MySQLConnector(ToucanConnector, DiscoverableConnector):
         keep_untouched = (cached_property_with_ttl,)
 
     def _list_db_names(self) -> list[str]:
-        connection = pymysql.connect(
-            **self.get_connection_params(cursorclass=None, database='mysql')
-        )
+        connection = pymysql.connect(**self.get_connection_params(cursorclass=None, database=None))
         # Always add the suggestions for the available databases
         with connection.cursor() as cursor:
             cursor.execute('SHOW DATABASES;')
@@ -113,9 +111,7 @@ class MySQLConnector(ToucanConnector, DiscoverableConnector):
             ]
 
     def _get_project_structure(self) -> list[TableInfo]:
-        connection = pymysql.connect(
-            **self.get_connection_params(cursorclass=None, database='mysql')
-        )
+        connection = pymysql.connect(**self.get_connection_params(cursorclass=None, database=None))
         # Always add the suggestions for the available databases
         with connection.cursor() as cursor:
             cursor.execute(build_database_model_extraction_query())


### PR DESCRIPTION
## Change Summary

Both queries (SHOW DATABASES and the more complex one in build_database_model_extraction_query),
do not require a database to function.

Currently, the database was forced to "mysql", which caused the connection to fail in case the database
did not exist or if the SQL user used by the connector did not have sufficient permissions.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
