### PR TITLE
feat(redshift): Add an option to toggle TCP keep-alive (enabled by default) TCTC-3769

### DIFF
--- a/tests/redshift/test_redshift.py
+++ b/tests/redshift/test_redshift.py
@@ -92,6 +92,7 @@ def test_config_schema_extra():
             'session_token': 'session_token_test',
             'profile': 'profile_test',
             'region': 'region_test',
+            'enable_tcp_keepalive': True,
         }
     }
     RedshiftConnector.Config().schema_extra(schema)
@@ -164,6 +165,7 @@ def test_redshiftconnector_get_connection_params_db_cred_mode(redshift_connector
         timeout=10,
         user='user',
         password='sample',
+        tcp_keepalive=True,
     )
 
 
@@ -223,6 +225,7 @@ def test_redshiftconnector_get_connection_params_aws_creds_mode(redshift_connect
         secret_access_key='secret_access_key',
         session_token='token',
         region='eu-west-1',
+        tcp_keepalive=True,
     )
 
 
@@ -263,6 +266,23 @@ def test_redshiftconnector_get_connection_params_aws_profile_mode(redshift_conne
         cluster_identifier='toucan_test',
         region='eu-west-1',
         profile='sample',
+        tcp_keepalive=True,
+    )
+
+
+@pytest.mark.parametrize('opt', (True, False))
+def test_redshiftconnector_get_connection_tcp_keepalive(redshift_connector, opt: bool):
+    redshift_connector.enable_tcp_keepalive = opt
+    result = redshift_connector._get_connection_params(database='test')
+    assert result == dict(
+        host='localhost',
+        database='test',
+        cluster_identifier='toucan_test',
+        port=0,
+        timeout=10,
+        user='user',
+        password='sample',
+        tcp_keepalive=opt,
     )
 
 

--- a/toucan_connectors/redshift/redshift_database_connector.py
+++ b/toucan_connectors/redshift/redshift_database_connector.py
@@ -46,6 +46,7 @@ ORDERED_KEYS = [
     'session_token',
     'profile',
     'region',
+    'enable_tcp_keepalive',
 ]
 
 logger = logging.getLogger(__name__)
@@ -127,6 +128,13 @@ class RedshiftConnector(ToucanConnector, DiscoverableConnector):
         description='You can set a connection timeout in seconds here, i.e. the maximum length of '
         'time you want to wait for the server to respond. None by default',
     )
+    # True by default to match redshift_connector kwargs syntax
+    enable_tcp_keepalive: bool = Field(
+        True,
+        title='Enable TCP keep-alive',
+        description='You may disable TCP keep-alive by unticking this option. Disabling might be '
+        'required for long-running queries or if you are behind a firewall',
+    )
 
     access_key_id: str | None = Field(None, description='The access key id of your aws account.')
     secret_access_key: SecretStr | None = Field(
@@ -183,6 +191,7 @@ class RedshiftConnector(ToucanConnector, DiscoverableConnector):
             port=self.port,
             timeout=self.connect_timeout,
             cluster_identifier=self.cluster_identifier,
+            tcp_keepalive=self.enable_tcp_keepalive,
         )
         if self.authentication_method == AuthenticationMethod.DB_CREDENTIALS.value:
             con_params['user'] = self.user


### PR DESCRIPTION
## Change Summary

Add an option to disable TCP keep-alive in the redshift cnnectro

## Related issue number

relates to TCTC-3769

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
