### PR TITLE
fix(mysql): Always specify db_name in get_model TCTC-3769

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -331,7 +331,7 @@ def test_default_implementation_of_discoverable_connector():
         def _retrieve_data(self, datasource):
             return pd.DataFrame()
 
-        def get_model(self) -> List[TableInfo]:
+        def get_model(self, db_name: str | None = None) -> List[TableInfo]:
             model = [('database', 'schema', 'type', 'name', [{'name': 'column', 'type': 'type'}])]
             return DiscoverableConnector.format_db_model(model)
 

--- a/toucan_connectors/awsathena/awsathena_connector.py
+++ b/toucan_connectors/awsathena/awsathena_connector.py
@@ -212,6 +212,6 @@ class AwsathenaConnector(ToucanConnector, DiscoverableConnector):
                     error=f'Cannot verify connection to Athena: {exc}, {sts_exc}',
                 )
 
-    def get_model(self) -> list[TableInfo]:
+    def get_model(self, db_name: str | None = None) -> list[TableInfo]:
         """Retrieves the database tree structure using current session"""
         return self.project_tree

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -225,6 +225,6 @@ class GoogleBigQueryConnector(ToucanConnector, DiscoverableConnector):
         )
         return self._format_db_model(client.query(query).to_dataframe())
 
-    def get_model(self) -> list[TableInfo]:
+    def get_model(self, db_name: str | None = None) -> list[TableInfo]:
         """Retrieves the database tree structure using current connection"""
         return self.project_tree

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -183,7 +183,7 @@ class MySQLConnector(ToucanConnector, DiscoverableConnector):
 
         return ConnectorStatus(status=True, details=self._get_details(3, True), error=None)
 
-    def get_model(self) -> list[Any]:
+    def get_model(self, db_name: str | None = None) -> list[Any]:
         """Retrieves the database tree structure using current connection"""
         return DiscoverableConnector.format_db_model(self.project_tree)
 

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -110,8 +110,10 @@ class MySQLConnector(ToucanConnector, DiscoverableConnector):
                 if db_name not in ('information_schema', 'mysql', 'performance_schema')
             ]
 
-    def _get_project_structure(self) -> list[TableInfo]:
-        connection = pymysql.connect(**self.get_connection_params(cursorclass=None, database=None))
+    def _get_project_structure(self, db_name: str | None = None) -> list[TableInfo]:
+        connection = pymysql.connect(
+            **self.get_connection_params(cursorclass=None, database=db_name)
+        )
         # Always add the suggestions for the available databases
         with connection.cursor() as cursor:
             cursor.execute(build_database_model_extraction_query())
@@ -121,9 +123,8 @@ class MySQLConnector(ToucanConnector, DiscoverableConnector):
     def available_dbs(self) -> list[str]:
         return self._list_db_names()
 
-    @cached_property_with_ttl(ttl=60)
-    def project_tree(self) -> list[TableInfo]:
-        return self._get_project_structure()
+    def project_tree(self, db_name: str | None = None) -> list[TableInfo]:
+        return self._get_project_structure(db_name=db_name)
 
     def get_connection_params(self, *, database=None, cursorclass=pymysql.cursors.DictCursor):
         conv = pymysql.converters.conversions.copy()
@@ -185,7 +186,7 @@ class MySQLConnector(ToucanConnector, DiscoverableConnector):
 
     def get_model(self, db_name: str | None = None) -> list[Any]:
         """Retrieves the database tree structure using current connection"""
-        return DiscoverableConnector.format_db_model(self.project_tree)
+        return DiscoverableConnector.format_db_model(self.project_tree(db_name=db_name))
 
     @staticmethod
     def decode_df(df):

--- a/toucan_connectors/postgres/postgresql_connector.py
+++ b/toucan_connectors/postgres/postgresql_connector.py
@@ -1,5 +1,5 @@
 from contextlib import suppress
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import psycopg2 as pgsql
 from pydantic import Field, SecretStr, constr, create_model
@@ -197,7 +197,7 @@ class PostgresConnector(ToucanConnector, DiscoverableConnector):
             res = cursor.description
         return {r.name: types.get(r.type_code) for r in res}
 
-    def get_model(self) -> List[TableInfo]:
+    def get_model(self, db_name: str | None = None) -> List[TableInfo]:
         """Retrieves the database tree structure using current connection"""
         available_dbs = self._list_db_names()
         databases_tree = []
@@ -206,7 +206,7 @@ class PostgresConnector(ToucanConnector, DiscoverableConnector):
                 databases_tree += self._list_tables_info(db)
         return DiscoverableConnector.format_db_model(databases_tree)
 
-    def get_model_with_info(self) -> Tuple[List[TableInfo], Dict]:
+    def get_model_with_info(self, db_name: str | None = None) -> tuple[list[TableInfo], dict]:
         """Retrieves the database tree structure using current connection"""
         available_dbs = self._list_db_names()
         databases_tree = []

--- a/toucan_connectors/redshift/redshift_database_connector.py
+++ b/toucan_connectors/redshift/redshift_database_connector.py
@@ -349,7 +349,7 @@ class RedshiftConnector(ToucanConnector, DiscoverableConnector):
                 )
         return table_infos
 
-    def get_model(self) -> list[TableInfo]:
+    def get_model(self, db_name: str | None = None) -> list[TableInfo]:
         """Retrieves the database tree structure using current connection"""
         tables_info = []
         for db in self.available_dbs:
@@ -358,7 +358,7 @@ class RedshiftConnector(ToucanConnector, DiscoverableConnector):
 
         return tables_info
 
-    def get_model_with_info(self) -> tuple[list[TableInfo], dict]:
+    def get_model_with_info(self, db_name: str | None = None) -> tuple[list[TableInfo], dict]:
         """Retrieves the database tree structure using current connection"""
         databases_tree = []
         failed_databases = []

--- a/toucan_connectors/snowflake/snowflake_connector.py
+++ b/toucan_connectors/snowflake/snowflake_connector.py
@@ -435,7 +435,7 @@ class SnowflakeConnector(ToucanConnector):
         ) as connection:
             db_contents += SnowflakeCommon().get_db_content(connection).to_dict('records')
 
-    def get_model(self):
+    def get_model(self, db_name: str | None = None):
         with self._get_connection() as connection:
             databases = SnowflakeCommon().get_databases(connection=connection)
         content_queries = []

--- a/toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py
+++ b/toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py
@@ -296,7 +296,7 @@ class SnowflakeoAuth2Connector(ToucanConnector):
         ) as connection:
             db_contents += SnowflakeCommon().get_db_content(connection).to_dict('records')
 
-    def get_model(self):
+    def get_model(self, db_name: str | None = None):
         with self._get_connection() as connection:
             databases = SnowflakeCommon().get_databases(connection=connection)
         content_queries = []

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -478,12 +478,13 @@ TableInfo = Dict[str, Union[str, List[Dict[str, str]]]]
 
 class DiscoverableConnector(ABC):
     @abstractmethod
-    def get_model(self) -> List[TableInfo]:
+    def get_model(self, db_name: str | None = None) -> List[TableInfo]:
         """Tries to get all tables that are available for the connector"""
 
-    def get_model_with_info(self) -> Tuple[List[TableInfo], Dict]:
-        """Tries to get all tables that are available for the connector and gives back some infos about what happenned"""
-        return (self.get_model(), {})
+    def get_model_with_info(self, db_name: str | None = None) -> Tuple[List[TableInfo], Dict]:
+        """Tries to get all tables that are available for the connector
+        and gives back some infos about what happened"""
+        return (self.get_model(db_name=db_name), {})
 
     @staticmethod
     def format_db_model(


### PR DESCRIPTION
## Change Summary

Always provide a db_name in mysql's `get_model` because depending on the SQL user's rights, now having a db can cause
SQL errors.

## Related issue number

TCTC-3768

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
