### PR TITLE
fix(mysql): Do not use too modern aggregation functions when retrieving project structure TCTC-3768

### DIFF
--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -362,7 +362,8 @@ def test_get_project_structure_no_parameter_ensure_no_db_name_specified(
     mysql_connector: MySQLConnector, mocker: MockerFixture
 ):
     connect_mock = mocker.patch('pymysql.connect')
-    mysql_connector._get_project_structure()
+    # Calling list to actually execute the function body
+    list(mysql_connector._get_project_structure())
     assert connect_mock.call_count == 1
     assert 'database' not in connect_mock.call_args.kwargs
 
@@ -371,6 +372,7 @@ def test_get_project_structure_no_parameter_with_db_name(
     mysql_connector: MySQLConnector, mocker: MockerFixture
 ):
     connect_mock = mocker.patch('pymysql.connect')
-    mysql_connector._get_project_structure(db_name='something')
+    # Calling list to actually execute the function body
+    list(mysql_connector._get_project_structure(db_name='something'))
     assert connect_mock.call_count == 1
     assert connect_mock.call_args.kwargs['database'] == 'something'


### PR DESCRIPTION
We were previously using json_arrayagg, which was introduced in MySQL 5.7.22. In order to be compatible with older MySQL
versions, do the column information aggregation on the client side.

relates to TCTC-3768

Signed-off-by: Luka Peschke <luka.peschke@toucantoco.com>

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
