### PR TITLE
feat: get target version per engine [TCTC-3498]

### DIFF
--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -584,16 +584,18 @@ def test_status_unreachable(mongo_connector, mocker):
 
 
 def test_get_engine_version(mocker, mongo_connector):
+    # Should be a valide semver version converted to tuple
     mocker.patch('pymongo.MongoClient.server_info', return_value={'version': '3.4.5'})
-
     assert mongo_connector.get_engine_version() == (3, 4, 5)
 
+    # Should raise a MalformattedVersion error
     mocker.patch(
         'pymongo.MongoClient.server_info', return_value={'version': '--bad-version-format-'}
     )
     with pytest.raises(MalformattedVersion):
         assert mongo_connector.get_engine_version()
 
+    # Should raise an UnavailableVersion error
     mocker.patch('pymongo.MongoClient.server_info', return_value=None)
     with pytest.raises(UnavailableVersion):
         assert mongo_connector.get_engine_version()

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -18,6 +18,7 @@ from toucan_connectors.mongo.mongo_connector import (
     _format_explain_result,
     normalize_query,
 )
+from toucan_connectors.toucan_connector import MalformattedVersion, UnavailableVersion
 
 
 @pytest.fixture(scope='module')
@@ -580,6 +581,22 @@ def test_status_unreachable(mongo_connector, mocker):
         ],
         error='qwe',
     )
+
+
+def test_get_engine_version(mocker, mongo_connector):
+    mocker.patch('pymongo.MongoClient.server_info', return_value={'version': '3.4.5'})
+
+    assert mongo_connector.get_engine_version() == (3, 4, 5)
+
+    mocker.patch(
+        'pymongo.MongoClient.server_info', return_value={'version': '--bad-version-format-'}
+    )
+    with pytest.raises(MalformattedVersion):
+        assert mongo_connector.get_engine_version()
+
+    mocker.patch('pymongo.MongoClient.server_info', return_value=None)
+    with pytest.raises(UnavailableVersion):
+        assert mongo_connector.get_engine_version()
 
 
 def test_status_bad_username(mongo_connector):

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -18,7 +18,7 @@ from toucan_connectors.mongo.mongo_connector import (
     _format_explain_result,
     normalize_query,
 )
-from toucan_connectors.toucan_connector import MalformattedVersion, UnavailableVersion
+from toucan_connectors.toucan_connector import MalformedVersion, UnavailableVersion
 
 
 @pytest.fixture(scope='module')
@@ -588,11 +588,11 @@ def test_get_engine_version(mocker, mongo_connector):
     mocker.patch('pymongo.MongoClient.server_info', return_value={'version': '3.4.5'})
     assert mongo_connector.get_engine_version() == (3, 4, 5)
 
-    # Should raise a MalformattedVersion error
+    # Should raise a MalformedVersion error
     mocker.patch(
         'pymongo.MongoClient.server_info', return_value={'version': '--bad-version-format-'}
     )
-    with pytest.raises(MalformattedVersion):
+    with pytest.raises(MalformedVersion):
         assert mongo_connector.get_engine_version()
 
     # Should raise an UnavailableVersion error

--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -13,7 +13,7 @@ from toucan_connectors.mysql.mysql_connector import (
     NoQuerySpecified,
     handle_date_0,
 )
-from toucan_connectors.toucan_connector import MalformattedVersion, UnavailableVersion
+from toucan_connectors.toucan_connector import MalformedVersion, UnavailableVersion
 
 
 @pytest.fixture(scope='module')
@@ -103,13 +103,13 @@ def test_get_engine_version(mocker, mysql_connector):
     )
     assert mysql_connector.get_engine_version() == (3, 4, 5)
 
-    # Should raise a MalformattedVersion error
+    # Should raise a MalformedVersion error
     mocked_cursor.__enter__().fetchone.return_value = {'VERSION()': '--bad-version-format-'}
     mocked_connect.cursor.return_value = mocked_cursor
     mocker.patch(
         'toucan_connectors.mysql.mysql_connector.pymysql.connect', return_value=mocked_connect
     )
-    with pytest.raises(MalformattedVersion):
+    with pytest.raises(MalformedVersion):
         assert mysql_connector.get_engine_version()
 
     # Should raise an UnavailableVersion error

--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -92,26 +92,27 @@ def test_get_status_all_good(mysql_connector):
 
 
 def test_get_engine_version(mocker, mysql_connector):
-    # "in" and not "==", because sometimes, we can have "14.5.-Debiaan xxx" as version
     mocked_connect = mocker.MagicMock()
     mocked_cursor = mocker.MagicMock()
+
+    # Should be a valide semver version converted to tuple
     mocked_cursor.__enter__().fetchone.return_value = {'VERSION()': '3.4.5'}
     mocked_connect.cursor.return_value = mocked_cursor
     mocker.patch(
         'toucan_connectors.mysql.mysql_connector.pymysql.connect', return_value=mocked_connect
     )
-
     assert mysql_connector.get_engine_version() == (3, 4, 5)
 
+    # Should raise a MalformattedVersion error
     mocked_cursor.__enter__().fetchone.return_value = {'VERSION()': '--bad-version-format-'}
     mocked_connect.cursor.return_value = mocked_cursor
     mocker.patch(
         'toucan_connectors.mysql.mysql_connector.pymysql.connect', return_value=mocked_connect
     )
-
     with pytest.raises(MalformattedVersion):
         assert mysql_connector.get_engine_version()
 
+    # Should raise an UnavailableVersion error
     mocked_cursor.__enter__().fetchone.return_value = None
     mocked_connect.cursor.return_value = mocked_cursor
     mocker.patch(

--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -13,6 +13,7 @@ from toucan_connectors.mysql.mysql_connector import (
     NoQuerySpecified,
     handle_date_0,
 )
+from toucan_connectors.toucan_connector import MalformattedVersion, UnavailableVersion
 
 
 @pytest.fixture(scope='module')
@@ -88,6 +89,36 @@ def test_get_status_all_good(mysql_connector):
             ('Authenticated', True),
         ],
     )
+
+
+def test_get_engine_version(mocker, mysql_connector):
+    # "in" and not "==", because sometimes, we can have "14.5.-Debiaan xxx" as version
+    mocked_connect = mocker.MagicMock()
+    mocked_cursor = mocker.MagicMock()
+    mocked_cursor.__enter__().fetchone.return_value = {'VERSION()': '3.4.5'}
+    mocked_connect.cursor.return_value = mocked_cursor
+    mocker.patch(
+        'toucan_connectors.mysql.mysql_connector.pymysql.connect', return_value=mocked_connect
+    )
+
+    assert mysql_connector.get_engine_version() == (3, 4, 5)
+
+    mocked_cursor.__enter__().fetchone.return_value = {'VERSION()': '--bad-version-format-'}
+    mocked_connect.cursor.return_value = mocked_cursor
+    mocker.patch(
+        'toucan_connectors.mysql.mysql_connector.pymysql.connect', return_value=mocked_connect
+    )
+
+    with pytest.raises(MalformattedVersion):
+        assert mysql_connector.get_engine_version()
+
+    mocked_cursor.__enter__().fetchone.return_value = None
+    mocked_connect.cursor.return_value = mocked_cursor
+    mocker.patch(
+        'toucan_connectors.mysql.mysql_connector.pymysql.connect', return_value=mocked_connect
+    )
+    with pytest.raises(UnavailableVersion):
+        assert mysql_connector.get_engine_version()
 
 
 def test_get_status_bad_host(mysql_connector):

--- a/tests/postgres/test_postgres.py
+++ b/tests/postgres/test_postgres.py
@@ -9,7 +9,7 @@ from toucan_connectors.postgres.postgresql_connector import (
     PostgresDataSource,
     pgsql,
 )
-from toucan_connectors.toucan_connector import MalformattedVersion, UnavailableVersion
+from toucan_connectors.toucan_connector import MalformedVersion, UnavailableVersion
 
 
 @pytest.fixture(scope='module')
@@ -67,13 +67,13 @@ def test_get_engine_version(mocker, postgres_connector):
     )
     assert postgres_connector.get_engine_version() == (3, 4, 5)
 
-    # Should raise a MalformattedVersion error
+    # Should raise a MalformedVersion error
     mocked_cursor.__enter__().fetchone.return_value = ['--bad-version-format-']
     mocked_connect.cursor.return_value = mocked_cursor
     mocker.patch(
         'toucan_connectors.postgres.postgresql_connector.pgsql.connect', return_value=mocked_connect
     )
-    with pytest.raises(MalformattedVersion):
+    with pytest.raises(MalformedVersion):
         assert postgres_connector.get_engine_version()
 
     # Should raise an UnavailableVersion error

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -347,5 +347,6 @@ class MySQLConnector(ToucanConnector, DiscoverableConnector, VersionableEngineCo
             except (TypeError, KeyError) as exc:
                 raise UnavailableVersion from exc
 
+
 class InvalidQuery(Exception):
     """raised when a query is invalid"""

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -16,6 +16,8 @@ from toucan_connectors.toucan_connector import (
     TableInfo,
     ToucanConnector,
     ToucanDataSource,
+    UnavailableVersion,
+    VersionableEngineConnector,
     strlist_to_enum,
 )
 from toucan_connectors.utils.pem import InvalidPEMFormat, sanitize_spaces_pem
@@ -91,7 +93,7 @@ class SSLMode(str, Enum):
     VERIFY_CA = 'VERIFY_CA'
 
 
-class MySQLConnector(ToucanConnector, DiscoverableConnector):
+class MySQLConnector(ToucanConnector, DiscoverableConnector, VersionableEngineConnector):
     """
     Import data from MySQL database.
     """
@@ -331,6 +333,19 @@ class MySQLConnector(ToucanConnector, DiscoverableConnector):
         connection.close()
         return df
 
+    def get_engine_version(self) -> tuple:
+        """
+        We try to get the MySQL version by running a query with our connection
+        """
+        connection = pymysql.connect(**self.get_connection_params())
+
+        with connection.cursor() as cursor:
+            cursor.execute('SELECT VERSION()')
+            version = cursor.fetchone()
+            try:
+                return super()._format_version(version['VERSION()'])
+            except (TypeError, KeyError) as exc:
+                raise UnavailableVersion from exc
 
 class InvalidQuery(Exception):
     """raised when a query is invalid"""

--- a/toucan_connectors/postgres/postgresql_connector.py
+++ b/toucan_connectors/postgres/postgresql_connector.py
@@ -248,7 +248,7 @@ class PostgresConnector(ToucanConnector, DiscoverableConnector, VersionableEngin
         connection = pgsql.connect(**self.get_connection_params(database=self.default_database))
 
         with connection.cursor() as cursor:
-            cursor.execute("select current_setting('server_version');")
+            cursor.execute("SELECT CURRENT_SETTING('server_version');")
             version = cursor.fetchone()
             try:
                 return super()._format_version(str(version[0]))

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -507,21 +507,20 @@ class DiscoverableConnector(ABC):
         )
 
 
-class MalformattedVersion(Exception):
-    """raise when the given version of the engine is not well formated"""
+class MalformedVersion(Exception):
+    """raised when the given version of the engine is not well formated"""
 
 
 class UnavailableVersion(Exception):
-    """raise when the version of the engine is not available"""
+    """raised when the version of the engine is not available"""
 
 
 class VersionableEngineConnector(ABC):
     """
-    This class is responsable for formating and rendering the version engine
+    This class is responsible for formating and rendering the version engine
     from which the connector is fetching data from !
 
-    We suppose all versions should fit the semver format and for that, we
-    build a regex match that can be describe in 6 points :
+    We built a regex match for all common version structure that can be describe in 6 points :
     - Major version is required, minor and patch version, and the meta version are supported but optional.
     - Major, minor, and/or patch can be 0 but cannot be a non-zero value with a leading 0.
     - The meta version can contain any Unicode letter (not restricted to Latin characters), _, ., and - characters.
@@ -539,7 +538,7 @@ class VersionableEngineConnector(ABC):
     """
 
     # The output of these rules :
-    semver_regex = (
+    semver_regex = re.compile(
         r'(0|(?:[1-9]\d*))(?:\.(0|(?:[1-9]\d*))(?:\.(0|(?:[1-9]\d*)))?(?:\-([\w][\w\.\-_]*))?)?'
     )
 
@@ -550,7 +549,7 @@ class VersionableEngineConnector(ABC):
         if engine_version is None:
             raise UnavailableVersion  # pragma: no cover
 
-        return re.match(self.semver_regex, str(engine_version)) is not None
+        return self.semver_regex.match(str(engine_version)) is not None
 
     @abstractmethod
     def get_engine_version(self) -> tuple:
@@ -566,7 +565,7 @@ class VersionableEngineConnector(ABC):
         """
         if self._validate(input_version):
             return tuple(
-                [int(x) for x in re.findall(self.semver_regex, str(input_version))[0] if len(x)]
+                [int(x) for x in self.semver_regex.findall(str(input_version))[0] if len(x)]
             )
 
-        raise MalformattedVersion(f'"{input_version}" is not a valid semver version')
+        raise MalformedVersion(f'"{input_version}" is not a valid version')

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -547,7 +547,7 @@ class VersionableEngineConnector(ABC):
         A small validation function for incoming version format
         """
         if engine_version is None:
-            return None
+            raise UnavailableVersion
 
         return self.semver_regex.match(str(engine_version))
 
@@ -565,6 +565,6 @@ class VersionableEngineConnector(ABC):
         """
         input_version_validated: re.Match | None = self._validate(input_version)
         if input_version_validated is not None:
-            return tuple(map(int, input_version_validated.string.split('.')))
+            return tuple(map(int, input_version_validated.group(0).split('.')))
 
         raise MalformedVersion(f'"{input_version}" is not understood')

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -548,7 +548,7 @@ class VersionableEngineConnector(ABC):
         A small validation function for incoming version format
         """
         if engine_version is None:
-            raise UnavailableVersion('This engine has an unavailable version')
+            raise UnavailableVersion  # pragma: no cover
 
         return re.match(self.semver_regex, str(engine_version)) is not None
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

We want to get the target source version for each engine, but on this Pull Request, we will be focusing on Mysql/PostgreSql and mongo.

- add an abstract method in a class called VersionableEngineConnector from toucan_connector
- set up target version handler for mysql + test
- set up target version handler for postgresql + test
- set up target version handler for mongo + test

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
