### PR TITLE
feat: remove "_id" column from DataFrame on mongo_connector [TC-3788]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
-### [3.20.0] 2022-09-02
+### [3.20.2] 2022-09-05
+
+### Changed
+
+- Mongo: removed `_id` column in response DataFrame.
+
+### [3.20.1] 2022-09-02
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ multi_line_output = 3
 
 [tool.poetry]
 name = "toucan-connectors"
-version = "3.20.1"
+version = "3.20.2"
 description = "Toucan Toco Connectors"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 license = "BSD"

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -242,7 +242,7 @@ def test_get_slice(mongo_connector, mongo_datasource):
     res = mongo_connector.get_slice(datasource)
     assert res.stats.total_returned_rows == 5
     assert res.stats.total_rows == 5
-    assert res.df.shape == (5, 6)
+    assert res.df.shape == (5, 5)
     assert res.df['country'].tolist() == ['France', 'France', 'England', 'Germany', 'USA']
 
     # With a limit
@@ -250,21 +250,21 @@ def test_get_slice(mongo_connector, mongo_datasource):
     expected = pd.DataFrame({'country': ['France'], 'language': ['French'], 'value': [20]})
     assert res.stats.total_returned_rows == 5
     assert res.stats.total_rows == 5
-    assert res.df.shape == (1, 6)
+    assert res.df.shape == (1, 5)
     assert res.df[['country', 'language', 'value']].equals(expected)
 
     # With a offset
     res = mongo_connector.get_slice(datasource, offset=1)
     assert res.stats.total_returned_rows == 5
     assert res.stats.total_rows == 5
-    assert res.df.shape == (4, 6)
+    assert res.df.shape == (4, 5)
     assert res.df['country'].tolist() == ['France', 'England', 'Germany', 'USA']
 
     # With both
     res = mongo_connector.get_slice(datasource, offset=1, limit=1)
     assert res.stats.total_returned_rows == 5
     assert res.stats.total_rows == 5
-    assert res.df.shape == (1, 6)
+    assert res.df.shape == (1, 5)
     assert res.df.loc[0, 'country'] == 'France'
 
 
@@ -297,7 +297,7 @@ def test_get_slice_no_limit(mongo_connector, mongo_datasource):
             'name': ['François', 'Marie', 'Evelyn', 'Hans', 'Scarlett'],
         }
     )
-    assert ds.df.shape == (5, 6)
+    assert ds.df.shape == (5, 5)
     assert ds.df[['country', 'language', 'value', 'name']].equals(expected)
 
 
@@ -370,7 +370,7 @@ def test_get_df_with_regex_with_integers(mongo_connector, mongo_datasource):
         query=[{'$match': {'domain': 'domain1'}}],
     )
     df = mongo_connector.get_df_with_regex(datasource, {'and': [{'value': re.compile('^20$')}]})
-    assert df.drop(columns='_id').to_dict(orient='records') == [
+    assert df.to_dict(orient='records') == [
         {
             'domain': 'domain1',
             'country': 'France',
@@ -396,7 +396,7 @@ def test_get_df_with_regex_case_sensitiveness(mongo_connector, mongo_datasource)
     df = mongo_connector.get_df_with_regex(
         datasource, {'and': [{'country': re.compile('^FrAn.*')}]}
     )
-    assert df.drop(columns='_id').to_dict(orient='records') == [
+    assert df.to_dict(orient='records') == [
         {
             'domain': 'domain1',
             'country': 'France',
@@ -437,7 +437,7 @@ def test_get_df_with_regex_and(mongo_connector, mongo_datasource):
     )
     assert mongo_connector.get_df_with_regex(
         datasource, {'and': [{'country': re.compile('France'), 'name': re.compile('Marie')}]}
-    ).drop(columns='_id').to_dict(orient='records') == [
+    ).to_dict(orient='records') == [
         {
             'domain': 'domain1',
             'country': 'France',
@@ -455,7 +455,7 @@ def test_get_df_with_regex_or(mongo_connector, mongo_datasource):
     )
     assert mongo_connector.get_df_with_regex(
         datasource, {'or': [{'country': re.compile('France'), 'name': re.compile('Marie')}]}
-    ).drop(columns='_id').to_dict(orient='records') == [
+    ).to_dict(orient='records') == [
         {
             'domain': 'domain1',
             'country': 'France',
@@ -466,7 +466,7 @@ def test_get_df_with_regex_or(mongo_connector, mongo_datasource):
     ]
     assert mongo_connector.get_df_with_regex(
         datasource, {'or': [{'country': re.compile('France')}, {'name': re.compile('Marie')}]}
-    ).drop(columns='_id').to_dict(orient='records') == [
+    ).to_dict(orient='records') == [
         {
             'domain': 'domain1',
             'country': 'France',


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

- feat: removed te column from mongo translator
- test: add tests related to that change
- chore: bump toucan-connectors from 3.20.1 to 3.20.2

<!-- Please give a short summary of the changes. -->

## ADDITIONAL INFOS
### BEFORE
![Screenshot from 2022-09-06 09-32-28](https://user-images.githubusercontent.com/22576758/188574269-7d0a7067-58d9-4515-a1c4-033ccd1aed04.png)

### AFTER
![Screenshot from 2022-09-06 09-32-08](https://user-images.githubusercontent.com/22576758/188574312-291a5dd9-75ff-4938-bd3a-8693f28ee9d5.png)

## Checklist

* [ ] Unit tests for the changes exist
* [ ] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
