### PR TITLE
chore: bump snowflake-connector-python to 2.7.12

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2022,7 +2022,7 @@ toucan_toco = ["toucan-client"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10,<3.11"
-content-hash = "ac397ee88bcf2a0f5b31b508eee5c59db6ee1264d4e95003821d4b05c6fe771e"
+content-hash = "7de1dd9be6db7fa448f8ac4b28e58b9b3d3a5a2e1efde0f70edd9b7d1ecd1a9e"
 
 [metadata.files]
 adobe-analytics = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ PyJWT = {version = ">=1.5.3,<3", optional = true}
 simplejson = {version = "^3.17.6", optional = true}
 pyhdb = {version = ">=0.3.4,<1.0", optional = true}
 zeep = {version = "^4.1.0", optional = true}
-snowflake-connector-python = {version = "^2.7.8", optional = true}
+snowflake-connector-python = {version = "^2.7.12", optional = true}
 pyarrow = {version = "<7", optional = true}
 toucan-client = {version = "^1.0.1", optional = true}
 


### PR DESCRIPTION
This allows us to upgrade pyarrow to 8.0.0 -> #690 
