### PR TITLE
fix(utils): Pass utc=True in sanitize_df_dates util

### DIFF
--- a/tests/google_sheets/test_google_sheets.py
+++ b/tests/google_sheets/test_google_sheets.py
@@ -10,6 +10,7 @@ from googleapiclient.http import HttpMock
 from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 from pytest_mock import MockFixture
+from pytz import utc
 
 from toucan_connectors.google_sheets.google_sheets_connector import (
     GoogleSheetsConnector,
@@ -66,9 +67,10 @@ def test_retrieve_data_with_dates(mocker: MockFixture):
         pd.DataFrame(
             columns=['label', 'value', 'date'],
             data=[
-                ['A', 1, datetime.fromisoformat('2022-01-04')],
-                ['B', 2, datetime.fromisoformat('2022-01-26')],
-                ['C', 3, datetime.fromisoformat('2021-11-30')],
+                # NOTE: Using pytz.utc instead of STL here because that's what pandas uses
+                ['A', 1, datetime(2022, 1, 4, tzinfo=utc)],
+                ['B', 2, datetime(2022, 1, 26, tzinfo=utc)],
+                ['C', 3, datetime(2021, 11, 30, tzinfo=utc)],
             ],
         ),
     )

--- a/tests/google_sheets_2/test_google_sheets_2.py
+++ b/tests/google_sheets_2/test_google_sheets_2.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 from pytest import fixture
+from pytz import utc
 
 from toucan_connectors.common import HttpError
 from toucan_connectors.google_sheets_2.google_sheets_2_connector import (
@@ -302,4 +303,5 @@ def test_parse_datetime(mocker, con):
     }
     mocker.patch(f'{import_path}.fetch', return_value=fake_result)
     ds = con.get_slice(ds, limit=2)
-    assert ds.df['a_date'].iloc[0] == datetime.datetime(year=2001, month=2, day=2)
+    # Using pytz.utc rather than STL here because that's what pandas does
+    assert ds.df['a_date'].iloc[0] == datetime.datetime(year=2001, month=2, day=2, tzinfo=utc)

--- a/tests/one_drive/test_one_drive.py
+++ b/tests/one_drive/test_one_drive.py
@@ -388,8 +388,8 @@ def test_sheets_with_dates(mocker, con, ds_with_dates):
         1.1,
         1,
         44197,
-        pd.Timestamp('2021-01-02 00:00:00'),
-        pd.Timestamp('2021-01-02 12:02:31'),
+        pd.Timestamp('2021-01-02 00:00:00', tz='UTC'),
+        pd.Timestamp('2021-01-02 12:02:31', tz='UTC'),
         'toto',
     ]
 

--- a/toucan_connectors/utils/datetime.py
+++ b/toucan_connectors/utils/datetime.py
@@ -12,6 +12,6 @@ def sanitize_df_dates(df: pd.DataFrame) -> pd.DataFrame:
     """Converts all datetime columns to pd.datetime64"""
     for col in df.columns:
         if is_datetime_col(df[col]):
-            df[col] = pd.to_datetime(df[col])
+            df[col] = pd.to_datetime(df[col], utc=True)
 
     return df


### PR DESCRIPTION
pd.to_datetime() creates np.datetime64 objects, which are naive. Thus, in order to be converted to UTC, we must pass utc=True.

relates to TCTC-4151

Signed-off-by: Luka Peschke <luka.peschke@toucantoco.com>

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
