### PR TITLE
feat(mysql): Add support for REQUIRED ssl_mode TCTC-4228

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### [3.23.0] 2022-10-04
+
+### Changed
+
+- MySQL: Added support for REQUIRED ssl_mode
+
 ### [3.22.3] 2022-10-04
 
 ### Changed

--- a/doc/connectors/mysql.md
+++ b/doc/connectors/mysql.md
@@ -23,7 +23,7 @@ Import data from MySQL database.
 * `ssl_key`: SecretStr. The X509 certificate key content in PEM format to use to connect to the MySQL server. Equivalent of the --ssl-key option of the MySQL client
 * `ssl_mode`: SSLMode. SSL Mode to use to connect to the MySQL server. Equivalent of
   the --ssl-mode option of the MySQL client. **Must be set in order to use SSL**. If
-  set, must be one of `VERIFY_CA` or `VERIFY_IDENTITY`.
+  set, must be one of `REQUIRED`, `VERIFY_CA` or `VERIFY_IDENTITY`.
 
 ```coffee
 DATA_PROVIDERS: [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ multi_line_output = 3
 
 [tool.poetry]
 name = "toucan-connectors"
-version = "3.22.3"
+version = "3.23.0"
 description = "Toucan Toco Connectors"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 license = "BSD"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=3.22.3
+sonar.projectVersion=3.23.0
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=./toucan_connectors

--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -488,3 +488,22 @@ def test_sanitize_ssl_params_invalid_pem(mysql_connector_with_ssl: MySQLConnecto
     )
     with pytest.raises(ValueError):
         mysql_connector_with_ssl._sanitize_ssl_params()
+
+
+def test_ssl_parameters_required_mode(mocker: MockerFixture):
+    connect_mock = mocker.patch('pymysql.connect')
+    conn = MySQLConnector(
+        name='mycon',
+        host='localhost',
+        port=3306,
+        user='ubuntu',
+        password='ilovetoucan',
+        ssl_mode='REQUIRED',
+    )
+    conn._connect()
+    assert connect_mock.call_count == 1
+    kwargs = connect_mock.call_args.kwargs
+    assert kwargs['ssl_disabled'] is False
+    assert kwargs['ssl_verify_cert'] is True
+    for arg in ('ssl_ca', 'ssl_cert', 'ssl_key'):
+        assert arg not in kwargs


### PR DESCRIPTION
## Change Summary

Adds support for REQUIRED ssl mode in MySQL connector

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
