### PR TITLE
fix/alphanumeric percentage only

### DIFF
--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -216,6 +216,22 @@ def test_get_df(mocker: MockerFixture):
         "select * from Country where test LIKE '%%test%%'", con=snock(), params={}
     )
 
+    # With query having % and variables %(var)s
+    reasq.reset_mock()
+    data_source = MySQLDataSource(
+        **{
+            'domain': 'MySQL test',
+            'type': 'external_database',
+            'name': 'Some MySQL provider',
+            'database': 'mysql_db',
+            'query': "select * from Country where test LIKE '%test%' and %(var)s",
+        }
+    )
+    mysql_connector.get_df(data_source)
+    reasq.assert_called_once_with(
+        "select * from Country where test LIKE '%%test%%' and %(var)s", con=snock(), params={}
+    )
+
 
 def test_get_df_db(mysql_connector):
     """ " It should extract the table City without merges"""

--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -201,6 +201,16 @@ def test_get_df(mocker: MockerFixture):
     reasq.assert_called_once_with('select * from Country', con=snock(), params={})
 
     # With query having % and variables %(var)s
+    query_str = (
+        "select * from Country where test LIKE '%test example%' "
+        "AND test 'ok22%' AND test LIKE '%(var)s' OR test LIKE '%test' "
+        "OR test LIKE '(this is % a test'"
+    )
+    expected_query_str = (
+        "select * from Country where test LIKE '%%test example%%' "
+        "AND test 'ok22%%' AND test LIKE '%(var)s' OR test LIKE '%%test' "
+        "OR test LIKE '(this is %% a test'"
+    )
     reasq.reset_mock()
     data_source = MySQLDataSource(
         **{
@@ -208,12 +218,12 @@ def test_get_df(mocker: MockerFixture):
             'type': 'external_database',
             'name': 'Some MySQL provider',
             'database': 'mysql_db',
-            'query': "select * from Country where test LIKE '%test example%' AND test '%ok22%' AND test LIKE '%(var)s'",
+            'query': query_str,
         }
     )
     mysql_connector.get_df(data_source)
     reasq.assert_called_once_with(
-        "select * from Country where test LIKE '%%test example%%' AND test '%%ok22%%' AND test LIKE '%(var)s'",
+        expected_query_str,
         con=snock(),
         params={},
     )

--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -200,22 +200,6 @@ def test_get_df(mocker: MockerFixture):
     mysql_connector.get_df(data_source)
     reasq.assert_called_once_with('select * from Country', con=snock(), params={})
 
-    # With query having %
-    reasq.reset_mock()
-    data_source = MySQLDataSource(
-        **{
-            'domain': 'MySQL test',
-            'type': 'external_database',
-            'name': 'Some MySQL provider',
-            'database': 'mysql_db',
-            'query': "select * from Country where test LIKE '%test%'",
-        }
-    )
-    mysql_connector.get_df(data_source)
-    reasq.assert_called_once_with(
-        "select * from Country where test LIKE '%%test%%'", con=snock(), params={}
-    )
-
     # With query having % and variables %(var)s
     reasq.reset_mock()
     data_source = MySQLDataSource(
@@ -224,12 +208,14 @@ def test_get_df(mocker: MockerFixture):
             'type': 'external_database',
             'name': 'Some MySQL provider',
             'database': 'mysql_db',
-            'query': "select * from Country where test LIKE '%test%' and %(var)s",
+            'query': "select * from Country where test LIKE '%test example%' AND test '%ok22%' AND test LIKE '%(var)s'",
         }
     )
     mysql_connector.get_df(data_source)
     reasq.assert_called_once_with(
-        "select * from Country where test LIKE '%%test%%' and %(var)s", con=snock(), params={}
+        "select * from Country where test LIKE '%%test example%%' AND test '%%ok22%%' AND test LIKE '%(var)s'",
+        con=snock(),
+        params={},
     )
 
 

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -404,7 +404,7 @@ def pandas_read_sql(
         # FIXME: We should use here the sqlalchemy.text module to
         # escape characters like % but as a quick fix, we left replace
         query = query.replace('%%', '%')
-        query = re.sub(r'%[A-Za-z0-9]+%', r'%\g<0>%', query)
+        query = re.sub(r'%[^%()]+%', r'%\g<0>%', query)
         df = pd.read_sql(query, con=con, params=params, **kwargs)
     except pd.io.sql.DatabaseError:
         if is_interpolating_table_name(query):

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -401,10 +401,11 @@ def pandas_read_sql(
         params = adapt_param_type(params)
 
     try:
-        # FIXME: We should use here the sqlalchemy.text module to
-        # escape characters like % but as a quick fix, we left replace
+        # FIXME: We should use here the sqlalchemy.text() module to
+        # escape characters like % but as a quick fix,
+        # we added regex replace that will exclude %(.*) compositions
         query = query.replace('%%', '%')
-        query = re.sub(r'%[^%()]+%', r'%\g<0>%', query)
+        query = re.sub(r'%[^(%]', r'%\g<0>', query)
         df = pd.read_sql(query, con=con, params=params, **kwargs)
     except pd.io.sql.DatabaseError:
         if is_interpolating_table_name(query):

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -404,7 +404,7 @@ def pandas_read_sql(
         # FIXME: We should use here the sqlalchemy.text module to
         # escape characters like % but as a quick fix, we left replace
         query = query.replace('%%', '%')
-        query = re.sub(r'%[^%]+%', r'%\g<0>%', query)
+        query = re.sub(r'%[A-Za-z0-9]+%', r'%\g<0>%', query)
         df = pd.read_sql(query, con=con, params=params, **kwargs)
     except pd.io.sql.DatabaseError:
         if is_interpolating_table_name(query):


### PR DESCRIPTION
## Change Summary

We should replace % to %% only for alphanumeric characters to prevent breaking variables

- feat: we should handle only alpha numerics elements
- test: added a test accordingly
