### PR TITLE
fix(postgresql): Ensure we always use default_database if provided TCTC-4462 (#740) [backport]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changed
 
+- Fix: Ensure Postgres always uses the default database for connection, rather than 'postgres'.
+
+### [3.23.3] 2022-10-26
+
+### Changed
+
 - Fix regression introduced in the mongo connector in 3.23.2 where `$match` statements containing only matches on
   nulls were considered empty.
 

--- a/toucan_connectors/postgres/postgresql_connector.py
+++ b/toucan_connectors/postgres/postgresql_connector.py
@@ -110,12 +110,12 @@ class PostgresConnector(ToucanConnector, DiscoverableConnector, VersionableEngin
         'time you want to wait for the server to respond. None by default',
     )
 
-    def get_connection_params(self, *, database=DEFAULT_DATABASE):
+    def get_connection_params(self, *, database: str | None = None):
         con_params = dict(
             user=self.user,
             host=self.host,
             client_encoding=self.charset,
-            dbname=database,
+            dbname=database if database is not None else self.default_database,
             password=self.password.get_secret_value() if self.password else None,
             port=self.port,
             connect_timeout=self.connect_timeout,


### PR DESCRIPTION
* fix(postgresql): Ensure we always use default_database if provided

closes TCTC-4462

Signed-off-by: Luka Peschke <luka.peschke@toucantoco.com>