### PR TITLE
fix: google-sheet dates load double to string [TCTC-4148]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Feat: The connector `GoogleSheets` datasource now has an option called `Render DateTime`, to trigger date time rendering when reading a sheet dataset.
+
 ### [3.23.5] 2022-11-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Feat: The connector `GoogleSheets` datasource now has an option called `Render DateTime`, to trigger date time rendering when reading a sheet dataset.
+- Feat: The connector `GoogleSheets` datasource now has an option called `Dates as Floats`, to see date time columns as strings or float when reading the sheet.
 
 ### [3.23.5] 2022-11-07
 

--- a/toucan_connectors/google_sheets/google_sheets_connector.py
+++ b/toucan_connectors/google_sheets/google_sheets_connector.py
@@ -30,8 +30,8 @@ class GoogleSheetsDataSource(ToucanDataSource):
     header_row: int = Field(
         0, title='Header row', description='Row of the header of the spreadsheet'
     )
-    render_date_time: bool = Field(
-        False, title='Render DateTime', description='Render DateTime columns from the sheet'
+    dates_as_float: bool = Field(
+        False, title='Dates as floats', description='Render Date as Floats or String from the sheet'
     )
 
     class Config:
@@ -145,7 +145,7 @@ class GoogleSheetsConnector(ToucanConnector):
         https://developers.google.com/sheets/api/reference/rest/v4/DateTimeRenderOption
         We use FORMATTED_STRING to load as simple strings
         """
-        return 'SERIAL_NUMBER' if data_source.render_date_time else 'FORMATTED_STRING'
+        return 'SERIAL_NUMBER' if data_source.dates_as_float else 'FORMATTED_STRING'
 
     def _retrieve_data(self, data_source: GoogleSheetsDataSource) -> pd.DataFrame:
 

--- a/toucan_connectors/google_sheets/google_sheets_connector.py
+++ b/toucan_connectors/google_sheets/google_sheets_connector.py
@@ -150,7 +150,9 @@ class GoogleSheetsConnector(ToucanConnector):
                 .get(
                     spreadsheetId=data_source.spreadsheet_id,
                     range=f"'{data_source.sheet}'",  # FIXME what will happen is the sheet name contains a single quote?
-                    dateTimeRenderOption='SERIAL_NUMBER',
+                    # Following the documentation, to prevent loading dates as double :
+                    # https://developers.google.com/sheets/api/reference/rest/v4/DateTimeRenderOption
+                    dateTimeRenderOption='FORMATTED_STRING',
                     majorDimension='ROWS',
                     valueRenderOption='UNFORMATTED_VALUE',
                 )

--- a/toucan_connectors/google_sheets/google_sheets_connector.py
+++ b/toucan_connectors/google_sheets/google_sheets_connector.py
@@ -30,6 +30,9 @@ class GoogleSheetsDataSource(ToucanDataSource):
     header_row: int = Field(
         0, title='Header row', description='Row of the header of the spreadsheet'
     )
+    render_date_time: bool = Field(
+        False, title='Render DateTime', description='Render DateTime columns from the sheet'
+    )
 
     class Config:
         @staticmethod
@@ -136,6 +139,14 @@ class GoogleSheetsConnector(ToucanConnector):
         except GoogleApiClientError:
             return ConnectorStatus(status=False, error="Couldn't retrieve user infos")
 
+    def _render_date_time_option_from_sheet(self, data_source: GoogleSheetsDataSource) -> str:
+        """
+        Following the documentation, to prevent loading dates as double :
+        https://developers.google.com/sheets/api/reference/rest/v4/DateTimeRenderOption
+        We use FORMATTED_STRING to load as simple strings
+        """
+        return 'SERIAL_NUMBER' if data_source.render_date_time else 'FORMATTED_STRING'
+
     def _retrieve_data(self, data_source: GoogleSheetsDataSource) -> pd.DataFrame:
 
         if data_source.sheet is None:
@@ -150,9 +161,9 @@ class GoogleSheetsConnector(ToucanConnector):
                 .get(
                     spreadsheetId=data_source.spreadsheet_id,
                     range=f"'{data_source.sheet}'",  # FIXME what will happen is the sheet name contains a single quote?
-                    # Following the documentation, to prevent loading dates as double :
-                    # https://developers.google.com/sheets/api/reference/rest/v4/DateTimeRenderOption
-                    dateTimeRenderOption='FORMATTED_STRING',
+                    dateTimeRenderOption=self._render_date_time_option_from_sheet(
+                        data_source=data_source
+                    ),
                     majorDimension='ROWS',
                     valueRenderOption='UNFORMATTED_VALUE',
                 )


### PR DESCRIPTION
## Change Summary

Updated the `dateTimeRenderOption` parameter from *SERIAL_NUMBER* to *FORMATTED_STRING* to load dates as simple string, see : https://developers.google.com/sheets/api/reference/rest/v4/DateTimeRenderOption
*EDIT1*: Added a new param to let the user trigger that option as default, see : https://github.com/ToucanToco/toucan-connectors/pull/800#issuecomment-1334930144 and https://github.com/ToucanToco/toucan-connectors/pull/800#issuecomment-1334971509

## DATASET
![Screenshot from 2022-12-02 09-53-28](https://user-images.githubusercontent.com/22576758/205254099-97175669-bd0e-4fa0-a2db-bfd1b5e0a15d.png)


## ON TOUCAN
### BEFORE
![Screenshot from 2022-12-02 01-21-56](https://user-images.githubusercontent.com/22576758/205186774-41d7abfc-edcf-47c3-805e-50bc37407ed3.png)

### AFTER
![Screenshot from 2022-12-02 01-18-40](https://user-images.githubusercontent.com/22576758/205186795-48ae9e83-19a3-40dc-8d8a-7f58ffed11e3.png)


PS: to be honest... am wondering if we really have to do this change since the date infering will be "broken"... seems to be a product question tho... ?

## TODO ?

If the fix seems to be okay, it should be cherry-pick on V3 too.

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
