### PR TITLE
fix/convert date to text not working for some date format when there are null values [TCTC-4622]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+- Fix: On MongoConnector, we make sure the `$switch` aggregation should always have a `default` key
+  field set from the mongo query to prevent "PlanExecutor error".
+
 ### [3.23.6] 2022-12-02
 
 ### Changed


### PR DESCRIPTION
## WHAT

We make sure the `$switch` aggregation should always have a `default` key
field set from the mongo query to prevent "PlanExecutor error" by recursively browse the query keys and updating what need to be updated.

## BEFORE
![Screenshot from 2022-12-06 03-42-00](https://user-images.githubusercontent.com/22576758/205805156-e2610214-47be-4240-9605-2d8ebc2b5483.png)

## NOW
![Screenshot from 2022-12-06 03-45-55](https://user-images.githubusercontent.com/22576758/205805172-0cae4a0b-45f4-422d-b266-b80e9027fbac.png)

TODO next if this proposal is approved ? bumpings + pick stuffs to target master. 

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [x] Documentation reflects the changes where applicable
