### PR TITLE
fix(filters): handle __VOID__ in $and match conditions

### DIFF
--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -543,6 +543,21 @@ def test_normalize_query():
     ]
     assert normalize_query(query_with_nulls_in_match, {}) == query_with_nulls_in_match
 
+    query_with_and_condition = [
+        {'$match': {'domain': 'fifa23_players'}},
+        {'$project': {'Name': 1, 'Height': 1, 'Nationality': 1}},
+        {'$match': {'$and': [{'Nationality': {'$eq': 'French'}}, {'Height': {}}]}},
+        {'$sort': {'Height': -1}},
+    ]
+    expected = [
+        {'$match': {'domain': 'fifa23_players'}},
+        {'$project': {'Name': 1, 'Height': 1, 'Nationality': 1}},
+        {'$match': {'$and': [{'Nationality': {'$eq': 'French'}}]}},
+        {'$sort': {'Height': -1}},
+    ]
+    assert normalize_query(query_with_and_condition, {}) == expected
+
+
 
 def test_status_all_good(mongo_connector):
     assert mongo_connector.get_status() == ConnectorStatus(

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -558,7 +558,6 @@ def test_normalize_query():
     assert normalize_query(query_with_and_condition, {}) == expected
 
 
-
 def test_status_all_good(mongo_connector):
     assert mongo_connector.get_status() == ConnectorStatus(
         status=True,

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -34,12 +34,14 @@ def _is_empty_match_column(elem: Any):
 
     return False
 
+
 def _is_match_empty(match_: dict) -> bool:
     return all(_is_empty_match_column(v) for v in match_.values())
 
 
 def _is_match_statement(d: Any) -> bool:
     return isinstance(d, dict) and list(d.keys()) == ['$match']
+
 
 def _sanitize_match(query: dict) -> dict:
     if _is_match_empty(query):
@@ -48,7 +50,8 @@ def _sanitize_match(query: dict) -> dict:
         and_condition = query['$and']
         if isinstance(and_condition, list):
             query['$and'] = [elem for elem in and_condition if not _is_empty_match_column(elem)]
-    return query; 
+    return query
+
 
 def _sanitize_query_matches(query: dict | list[dict]) -> Any:
     """Transforms match operations matching nothing into match-alls.
@@ -58,7 +61,7 @@ def _sanitize_query_matches(query: dict | list[dict]) -> Any:
     """
     if isinstance(query, list):
         return [
-            {'$match': _sanitize_match(q['$match']) } if _is_match_statement(q) else q for q in query
+            {'$match': _sanitize_match(q['$match'])} if _is_match_statement(q) else q for q in query
         ]
     return query
 

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -24,22 +24,31 @@ from toucan_connectors.toucan_connector import (
 MAX_COUNTED_ROWS = 1000001
 
 
-def _is_match_empty(match_: dict) -> bool:
-    def is_empty(elem: Any):
-        # Not matching None here, because we don't want to consider {'$match': {'col': None}} to be
-        # empty
-        if elem == {}:
-            return True
-        if isinstance(elem, dict):
-            return _is_match_empty(elem)
-        return False
+def _is_empty_match_column(elem: Any):
+    # Not matching None here, because we don't want to consider {'$match': {'col': None}} to be
+    # empty
+    if elem == {}:
+        return True
+    if isinstance(elem, dict):
+        return _is_match_empty(elem)
 
-    return all(is_empty(v) for v in match_.values())
+    return False
+
+def _is_match_empty(match_: dict) -> bool:
+    return all(_is_empty_match_column(v) for v in match_.values())
 
 
 def _is_match_statement(d: Any) -> bool:
     return isinstance(d, dict) and list(d.keys()) == ['$match']
 
+def _sanitize_match(query: dict) -> dict:
+    if _is_match_empty(query):
+        return {}
+    if '$and' in query:
+        and_condition = query['$and']
+        if isinstance(and_condition, list):
+            query['$and'] = [elem for elem in and_condition if not _is_empty_match_column(elem)]
+    return query; 
 
 def _sanitize_query_matches(query: dict | list[dict]) -> Any:
     """Transforms match operations matching nothing into match-alls.
@@ -49,7 +58,7 @@ def _sanitize_query_matches(query: dict | list[dict]) -> Any:
     """
     if isinstance(query, list):
         return [
-            {'$match': {}} if (_is_match_statement(q) and _is_match_empty(q)) else q for q in query
+            {'$match': _sanitize_match(q['$match']) } if _is_match_statement(q) else q for q in query
         ]
     return query
 


### PR DESCRIPTION
## Change Summary
When there is a void match of a column inside an "and" condition, it is not filtered from the query, resulting to empty results of data. 

## Related issue number
x

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] Documentation reflects the changes where applicable
