### PR TITLE
feat: allow empty field mysql ssl [TCTC-5306]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog (Pypi package)
 
 ## Unreleased
+ 
+### Changed
+
+- MySQL: Allow Optional parameters on ssl_mode
 
 ### [3.23.9] 2023-02-13
 

--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -461,8 +461,6 @@ def test_ssl_parameters_verify_ca(mysql_connector_with_ssl: MySQLConnector, mock
     kwargs = connect_mock.call_args.kwargs
     assert kwargs['ssl_disabled'] is False
     assert kwargs['ssl_ca'] is not None
-    assert kwargs['ssl_cert'] is not None
-    assert kwargs['ssl_key'] is not None
     assert kwargs['ssl_verify_cert'] is True
     assert kwargs['ssl_verify_identity'] is False
 
@@ -477,13 +475,11 @@ def test_ssl_parameters_verify_identity(
     kwargs = connect_mock.call_args.kwargs
     assert kwargs['ssl_disabled'] is False
     assert kwargs['ssl_ca'] is not None
-    assert kwargs['ssl_cert'] is not None
-    assert kwargs['ssl_key'] is not None
     assert kwargs['ssl_verify_cert'] is True
     assert kwargs['ssl_verify_identity'] is True
 
 
-@pytest.mark.parametrize('missing_param', ('ssl_ca', 'ssl_cert', 'ssl_key'))
+@pytest.mark.parametrize('missing_param', ('ssl_cert', 'ssl_key'))
 def test_ssl_parameters_missing_param(
     mysql_connector_with_ssl: MySQLConnector, mocker: MockerFixture, missing_param: str
 ):

--- a/tests/mysql/test_mysql.py
+++ b/tests/mysql/test_mysql.py
@@ -461,6 +461,8 @@ def test_ssl_parameters_verify_ca(mysql_connector_with_ssl: MySQLConnector, mock
     kwargs = connect_mock.call_args.kwargs
     assert kwargs['ssl_disabled'] is False
     assert kwargs['ssl_ca'] is not None
+    assert kwargs['ssl_cert'] is not None
+    assert kwargs['ssl_key'] is not None
     assert kwargs['ssl_verify_cert'] is True
     assert kwargs['ssl_verify_identity'] is False
 
@@ -475,6 +477,8 @@ def test_ssl_parameters_verify_identity(
     kwargs = connect_mock.call_args.kwargs
     assert kwargs['ssl_disabled'] is False
     assert kwargs['ssl_ca'] is not None
+    assert kwargs['ssl_cert'] is not None
+    assert kwargs['ssl_key'] is not None
     assert kwargs['ssl_verify_cert'] is True
     assert kwargs['ssl_verify_identity'] is True
 

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -242,12 +242,9 @@ class MySQLConnector(ToucanConnector, DiscoverableConnector, VersionableEngineCo
 
                     connection_params[ssl_opt] = ssl_opt_file.name
 
-                connection_params |= {
-                    **connection_params,
-                    # Verify that the server's hostname matches the CA
-                    **{'ssl_verify_identity': self.ssl_mode == SSLMode.VERIFY_IDENTITY},
-                }
-                return pymysql.connect(**connection_params)
+            connection_params['ssl_verify_identity'] = self.ssl_mode == SSLMode.VERIFY_IDENTITY
+
+            return pymysql.connect(**connection_params)
         return pymysql.connect(**connection_params)
 
     @staticmethod


### PR DESCRIPTION
## WHAT

we want to have ssl_ca, ssl_cert and ssl_key as optional params for an ssl connexion
