### PR TITLE
feat: setUp dependabot automerge on patches

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,29 @@
+name: "Dependabot Automerge - Action"
+
+on:
+  pull_request:
+
+jobs:
+  worker:
+    runs-on: ubuntu-latest
+
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: automerge
+        uses: actions/github-script@0.2.0
+        # if it's a patch, merge it directly
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        with:
+          script: |
+            github.pullRequests.createReview({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              pull_number: context.payload.pull_request.number,
+              event: 'APPROVE'
+            })
+            github.pullRequests.merge({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              pull_number: context.payload.pull_request.number
+            })
+          github-token: ${{github.token}}


### PR DESCRIPTION
## WHAT

SetUp dependabot automerge on patches, since it's mostly fixes and small updates, 
we don't really want to have to check those everytime

## HOW

I added a new simple workflow that doesn't need a github app to process with an if condition on the semver bump.
