### PR TITLE
chore: release toucan-connectors from 4.5.1 to 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 
 ## Changed
 
-- On missing params inside queries with `handle_errors` on **True**, we now
-  raise : `UndefinedVariableError` and not `NonValidVariable`.
+- On missing params inside queries with `handle_errors` on **True**, we now raise : `UndefinedVariableError` and not `NonValidVariable`.
 - `__VOID__` values are no longer removed from queries.
 
 ### [4.5.1] 2023-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 
 ## Changed
 
-- For a query, if there is missing params, we now either remove it, or raise an Exception in case `handle_errors` is True.
-- For a given query, we no longer update a pipeline if we found `__VOID__` values in it.
+- `__VOID__` values are no longer removed from queries.
 
 ### [4.5.1] 2023-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Changed
 
+- On missing params inside queries with `handle_errors` on **True**, we now
+  raise : `UndefinedVariableError` and not `NonValidVariable`.
 - `__VOID__` values are no longer removed from queries.
 
 ### [4.5.1] 2023-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Changed
 
-- On missing params inside queries with `handle_errors` on **True**, we now raise : `UndefinedVariableError` and not `NonValidVariable`.
+- The exception raised by `nosql_apply_parameters_to_query` when `handle_errors` is true and an undefined variable is encountered has changed from  `NonValidVariable`  to `UndefinedVariableError`.
 - `__VOID__` values are no longer removed from queries.
 
 ### [4.5.1] 2023-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### [4.6.0] 2023-06-02
+
+## Changed
+
+- For a query, if there is missing params, we now either remove it, or raise an Exception in case `handle_errors` is True.
+- For a given query, we no longer update a pipeline if we found `__VOID__` values in it.
+
 ### [4.5.1] 2023-04-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ multi_line_output = 3
 
 [tool.poetry]
 name = "toucan-connectors"
-version = "4.5.1"
+version = "4.6.0"
 description = "Toucan Toco Connectors"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 license = "BSD"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=4.5.1
+sonar.projectVersion=4.6.0
 sonar.python.version=3.11
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.


### PR DESCRIPTION
## WHAT

This is just a bump from 4.5.1 to 4.6.0 for toucan-connectors.
