### PR TITLE
feat: google big query database selection much faster [TCTC-6113]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## Changed
+
+- Feat[Goole Big Query] : We can now get the database model(list of tables) based on a given schema name to speed up the project tree structure.
 - Fix: on mysql, avoid duplicated columns when retrieving table informations
 
 ### [4.6.0] 2023-06-02

--- a/tests/google_big_query/test_google_big_query.py
+++ b/tests/google_big_query/test_google_big_query.py
@@ -1,3 +1,4 @@
+from typing import Any, Generator
 from unittest.mock import patch
 
 import pandas
@@ -180,8 +181,8 @@ def test_get_model(mocker: MockFixture, _fixture_credentials) -> None:
         def __init__(self) -> None:
             ...
 
-        def to_dataframe(self) -> pd.DataFrame:
-            return pd.DataFrame(
+        def to_dataframe(self) -> Generator[Any, Any, Any]:
+            yield pd.DataFrame(
                 [
                     {
                         'name': 'coucou',
@@ -272,6 +273,11 @@ def test_get_model(mocker: MockFixture, _fixture_credentials) -> None:
     )
 
     mocker.patch(
+        'toucan_connectors.google_big_query.google_big_query_connector.GoogleBigQueryConnector._fetch_query_results',
+        return_value=FakeResponse().to_dataframe(),
+    )
+
+    mocker.patch(
         'toucan_connectors.google_big_query.google_big_query_connector.GoogleBigQueryConnector._get_google_credentials',
         return_value=Credentials,
     )
@@ -321,55 +327,159 @@ def test_get_model(mocker: MockFixture, _fixture_credentials) -> None:
     assert (
         mocked_query.call_args_list[0][0][0]
         == """
-SELECT C.table_name AS name, C.table_schema AS schema, T.table_catalog AS database,
-T.table_type AS type, C.column_name, C.data_type FROM foooo.INFORMATION_SCHEMA.COLUMNS C
-JOIN foooo.INFORMATION_SCHEMA.TABLES T ON C.table_name = T.table_name
-WHERE IS_SYSTEM_DEFINED='NO' AND IS_PARTITIONING_COLUMN='NO' AND IS_HIDDEN='NO'
+SELECT
+    C.table_name AS name,
+    C.table_schema AS schema,
+    T.table_catalog AS database,
+    T.table_type AS type,
+    C.column_name,
+    C.data_type
+FROM
+    foooo.INFORMATION_SCHEMA.COLUMNS C
+    JOIN foooo.INFORMATION_SCHEMA.TABLES T
+        ON C.table_name = T.table_name
+WHERE
+    IS_SYSTEM_DEFINED = 'NO'
+    AND IS_PARTITIONING_COLUMN = 'NO'
+    AND IS_HIDDEN = 'NO'
 
 UNION ALL
 
-SELECT C.table_name AS name, C.table_schema AS schema, T.table_catalog AS database,
-T.table_type AS type, C.column_name, C.data_type FROM baarrrr.INFORMATION_SCHEMA.COLUMNS C
-JOIN baarrrr.INFORMATION_SCHEMA.TABLES T ON C.table_name = T.table_name
-WHERE IS_SYSTEM_DEFINED='NO' AND IS_PARTITIONING_COLUMN='NO' AND IS_HIDDEN='NO'
+SELECT
+    C.table_name AS name,
+    C.table_schema AS schema,
+    T.table_catalog AS database,
+    T.table_type AS type,
+    C.column_name,
+    C.data_type
+FROM
+    baarrrr.INFORMATION_SCHEMA.COLUMNS C
+    JOIN baarrrr.INFORMATION_SCHEMA.TABLES T
+        ON C.table_name = T.table_name
+WHERE
+    IS_SYSTEM_DEFINED = 'NO'
+    AND IS_PARTITIONING_COLUMN = 'NO'
+    AND IS_HIDDEN = 'NO'
 
 UNION ALL
 
-SELECT C.table_name AS name, C.table_schema AS schema, T.table_catalog AS database,
-T.table_type AS type, C.column_name, C.data_type FROM taar.INFORMATION_SCHEMA.COLUMNS C
-JOIN taar.INFORMATION_SCHEMA.TABLES T ON C.table_name = T.table_name
-WHERE IS_SYSTEM_DEFINED='NO' AND IS_PARTITIONING_COLUMN='NO' AND IS_HIDDEN='NO'
+SELECT
+    C.table_name AS name,
+    C.table_schema AS schema,
+    T.table_catalog AS database,
+    T.table_type AS type,
+    C.column_name,
+    C.data_type
+FROM
+    taar.INFORMATION_SCHEMA.COLUMNS C
+    JOIN taar.INFORMATION_SCHEMA.TABLES T
+        ON C.table_name = T.table_name
+WHERE
+    IS_SYSTEM_DEFINED = 'NO'
+    AND IS_PARTITIONING_COLUMN = 'NO'
+    AND IS_HIDDEN = 'NO'
 """
     )
     mocked_query.reset_mock()
+
+    mocker.patch(
+        'toucan_connectors.google_big_query.google_big_query_connector.GoogleBigQueryConnector._fetch_query_results',
+        return_value=FakeResponse().to_dataframe(),
+    )
+
     connector.get_model('some-db')
     assert (
         mocked_query.call_args_list[0][0][0]
         == """
-SELECT C.table_name AS name, C.table_schema AS schema, T.table_catalog AS database,
-T.table_type AS type, C.column_name, C.data_type FROM foooo.INFORMATION_SCHEMA.COLUMNS C
-JOIN foooo.INFORMATION_SCHEMA.TABLES T ON C.table_name = T.table_name
-WHERE IS_SYSTEM_DEFINED='NO' AND IS_PARTITIONING_COLUMN='NO' AND IS_HIDDEN='NO'
+SELECT
+    C.table_name AS name,
+    C.table_schema AS schema,
+    T.table_catalog AS database,
+    T.table_type AS type,
+    C.column_name,
+    C.data_type
+FROM
+    foooo.INFORMATION_SCHEMA.COLUMNS C
+    JOIN foooo.INFORMATION_SCHEMA.TABLES T
+        ON C.table_name = T.table_name
+WHERE
+    IS_SYSTEM_DEFINED = 'NO'
+    AND IS_PARTITIONING_COLUMN = 'NO'
+    AND IS_HIDDEN = 'NO'
 AND T.table_catalog = 'some-db'
 
 UNION ALL
 
-SELECT C.table_name AS name, C.table_schema AS schema, T.table_catalog AS database,
-T.table_type AS type, C.column_name, C.data_type FROM baarrrr.INFORMATION_SCHEMA.COLUMNS C
-JOIN baarrrr.INFORMATION_SCHEMA.TABLES T ON C.table_name = T.table_name
-WHERE IS_SYSTEM_DEFINED='NO' AND IS_PARTITIONING_COLUMN='NO' AND IS_HIDDEN='NO'
+SELECT
+    C.table_name AS name,
+    C.table_schema AS schema,
+    T.table_catalog AS database,
+    T.table_type AS type,
+    C.column_name,
+    C.data_type
+FROM
+    baarrrr.INFORMATION_SCHEMA.COLUMNS C
+    JOIN baarrrr.INFORMATION_SCHEMA.TABLES T
+        ON C.table_name = T.table_name
+WHERE
+    IS_SYSTEM_DEFINED = 'NO'
+    AND IS_PARTITIONING_COLUMN = 'NO'
+    AND IS_HIDDEN = 'NO'
 AND T.table_catalog = 'some-db'
 
 UNION ALL
 
-SELECT C.table_name AS name, C.table_schema AS schema, T.table_catalog AS database,
-T.table_type AS type, C.column_name, C.data_type FROM taar.INFORMATION_SCHEMA.COLUMNS C
-JOIN taar.INFORMATION_SCHEMA.TABLES T ON C.table_name = T.table_name
-WHERE IS_SYSTEM_DEFINED='NO' AND IS_PARTITIONING_COLUMN='NO' AND IS_HIDDEN='NO'
+SELECT
+    C.table_name AS name,
+    C.table_schema AS schema,
+    T.table_catalog AS database,
+    T.table_type AS type,
+    C.column_name,
+    C.data_type
+FROM
+    taar.INFORMATION_SCHEMA.COLUMNS C
+    JOIN taar.INFORMATION_SCHEMA.TABLES T
+        ON C.table_name = T.table_name
+WHERE
+    IS_SYSTEM_DEFINED = 'NO'
+    AND IS_PARTITIONING_COLUMN = 'NO'
+    AND IS_HIDDEN = 'NO'
 AND T.table_catalog = 'some-db'
 """
     )
 
+    mocked_query.reset_mock()
+
+    mocker.patch(
+        'toucan_connectors.google_big_query.google_big_query_connector.GoogleBigQueryConnector._fetch_query_results',
+        return_value=FakeResponse().to_dataframe(),
+    )
+
+    connector.get_model('some-db', 'foooo')
+
+    # since we specified only the foooo schema we should only get the query for
+    # it
+    assert (
+        mocked_query.call_args_list[0][0][0]
+        == """
+SELECT
+    C.table_name AS name,
+    C.table_schema AS schema,
+    T.table_catalog AS database,
+    T.table_type AS type,
+    C.column_name,
+    C.data_type
+FROM
+    foooo.INFORMATION_SCHEMA.COLUMNS C
+    JOIN foooo.INFORMATION_SCHEMA.TABLES T
+        ON C.table_name = T.table_name
+WHERE
+    IS_SYSTEM_DEFINED = 'NO'
+    AND IS_PARTITIONING_COLUMN = 'NO'
+    AND IS_HIDDEN = 'NO'
+AND T.table_catalog = 'some-db'
+"""
+    )
 
 def test_get_model_multi_location(mocker: MockFixture, _fixture_credentials) -> None:
     fake_resp_1 = mocker.MagicMock()

--- a/tests/google_big_query/test_google_big_query.py
+++ b/tests/google_big_query/test_google_big_query.py
@@ -667,7 +667,7 @@ def test_get_form(mocker: MockFixture, _fixture_credentials: MockFixture) -> Non
         return ['ok', 'test']
 
     mocker.patch(
-        'toucan_connectors.google_big_query.google_big_query_connector.GoogleBigQueryConnector.available_schs',
+        'toucan_connectors.google_big_query.google_big_query_connector.GoogleBigQueryConnector._available_schs',
         return_value=mock_available_schs,
     )
 

--- a/tests/google_big_query/test_google_big_query.py
+++ b/tests/google_big_query/test_google_big_query.py
@@ -481,6 +481,7 @@ AND T.table_catalog = 'some-db'
 """
     )
 
+
 def test_get_model_multi_location(mocker: MockFixture, _fixture_credentials) -> None:
     fake_resp_1 = mocker.MagicMock()
     fake_resp_1.to_dataframe.return_value = pd.DataFrame(
@@ -578,17 +579,39 @@ def test_get_model_multi_location(mocker: MockFixture, _fixture_credentials) -> 
     assert (
         mocked_query.call_args_list[0][0][0]
         == """
-SELECT C.table_name AS name, C.table_schema AS schema, T.table_catalog AS database,
-T.table_type AS type, C.column_name, C.data_type FROM foooo.INFORMATION_SCHEMA.COLUMNS C
-JOIN foooo.INFORMATION_SCHEMA.TABLES T ON C.table_name = T.table_name
-WHERE IS_SYSTEM_DEFINED='NO' AND IS_PARTITIONING_COLUMN='NO' AND IS_HIDDEN='NO'
+SELECT
+    C.table_name AS name,
+    C.table_schema AS schema,
+    T.table_catalog AS database,
+    T.table_type AS type,
+    C.column_name,
+    C.data_type
+FROM
+    foooo.INFORMATION_SCHEMA.COLUMNS C
+    JOIN foooo.INFORMATION_SCHEMA.TABLES T
+        ON C.table_name = T.table_name
+WHERE
+    IS_SYSTEM_DEFINED = 'NO'
+    AND IS_PARTITIONING_COLUMN = 'NO'
+    AND IS_HIDDEN = 'NO'
 
 UNION ALL
 
-SELECT C.table_name AS name, C.table_schema AS schema, T.table_catalog AS database,
-T.table_type AS type, C.column_name, C.data_type FROM baarrrr.INFORMATION_SCHEMA.COLUMNS C
-JOIN baarrrr.INFORMATION_SCHEMA.TABLES T ON C.table_name = T.table_name
-WHERE IS_SYSTEM_DEFINED='NO' AND IS_PARTITIONING_COLUMN='NO' AND IS_HIDDEN='NO'
+SELECT
+    C.table_name AS name,
+    C.table_schema AS schema,
+    T.table_catalog AS database,
+    T.table_type AS type,
+    C.column_name,
+    C.data_type
+FROM
+    baarrrr.INFORMATION_SCHEMA.COLUMNS C
+    JOIN baarrrr.INFORMATION_SCHEMA.TABLES T
+        ON C.table_name = T.table_name
+WHERE
+    IS_SYSTEM_DEFINED = 'NO'
+    AND IS_PARTITIONING_COLUMN = 'NO'
+    AND IS_HIDDEN = 'NO'
 """
     )
     # No location should be specified in the happy path
@@ -596,10 +619,21 @@ WHERE IS_SYSTEM_DEFINED='NO' AND IS_PARTITIONING_COLUMN='NO' AND IS_HIDDEN='NO'
     assert (
         mocked_query.call_args_list[1][0][0]
         == """
-SELECT C.table_name AS name, C.table_schema AS schema, T.table_catalog AS database,
-T.table_type AS type, C.column_name, C.data_type FROM foooo.INFORMATION_SCHEMA.COLUMNS C
-JOIN foooo.INFORMATION_SCHEMA.TABLES T ON C.table_name = T.table_name
-WHERE IS_SYSTEM_DEFINED='NO' AND IS_PARTITIONING_COLUMN='NO' AND IS_HIDDEN='NO'
+SELECT
+    C.table_name AS name,
+    C.table_schema AS schema,
+    T.table_catalog AS database,
+    T.table_type AS type,
+    C.column_name,
+    C.data_type
+FROM
+    foooo.INFORMATION_SCHEMA.COLUMNS C
+    JOIN foooo.INFORMATION_SCHEMA.TABLES T
+        ON C.table_name = T.table_name
+WHERE
+    IS_SYSTEM_DEFINED = 'NO'
+    AND IS_PARTITIONING_COLUMN = 'NO'
+    AND IS_HIDDEN = 'NO'
 """
     )
     # Next calls should specify the location
@@ -607,17 +641,36 @@ WHERE IS_SYSTEM_DEFINED='NO' AND IS_PARTITIONING_COLUMN='NO' AND IS_HIDDEN='NO'
     assert (
         mocked_query.call_args_list[2][0][0]
         == """
-SELECT C.table_name AS name, C.table_schema AS schema, T.table_catalog AS database,
-T.table_type AS type, C.column_name, C.data_type FROM baarrrr.INFORMATION_SCHEMA.COLUMNS C
-JOIN baarrrr.INFORMATION_SCHEMA.TABLES T ON C.table_name = T.table_name
-WHERE IS_SYSTEM_DEFINED='NO' AND IS_PARTITIONING_COLUMN='NO' AND IS_HIDDEN='NO'
+SELECT
+    C.table_name AS name,
+    C.table_schema AS schema,
+    T.table_catalog AS database,
+    T.table_type AS type,
+    C.column_name,
+    C.data_type
+FROM
+    baarrrr.INFORMATION_SCHEMA.COLUMNS C
+    JOIN baarrrr.INFORMATION_SCHEMA.TABLES T
+        ON C.table_name = T.table_name
+WHERE
+    IS_SYSTEM_DEFINED = 'NO'
+    AND IS_PARTITIONING_COLUMN = 'NO'
+    AND IS_HIDDEN = 'NO'
 """
     )
     # Next calls should specify the location
     assert mocked_query.call_args_list[2][1] == {'location': 'Toulouse'}
 
 
-def test_get_form(_fixture_credentials: MockFixture) -> None:
+def test_get_form(mocker: MockFixture, _fixture_credentials: MockFixture) -> None:
+    def mock_available_schs():
+        return ['ok', 'test']
+
+    mocker.patch(
+        'toucan_connectors.google_big_query.google_big_query_connector.GoogleBigQueryConnector.available_schs',
+        return_value=mock_available_schs,
+    )
+
     assert (
         GoogleBigQueryDataSource(query=',', name='MyGBQ', domain='foo').get_form(
             GoogleBigQueryConnector(

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -48,13 +48,13 @@ class GoogleBigQueryDataSource(ToucanDataSource):
         **{'ui.hidden': True},
     )
     language: str = Field('sql', **{'ui.hidden': True})
-    database: str = Field(None, description='The name of the database you want to query.')
+    db_schema: str = Field(None, description='The name of the db_schema you want to query.')
 
     @classmethod
     def get_form(cls, connector: 'GoogleBigQueryConnector', current_config: dict[str, Any]):
         return create_model(
             'FormSchema',
-            database=strlist_to_enum('database', connector.available_dbs),
+            db_schema=strlist_to_enum('db_schema', connector.available_dbs),
             __base__=cls,
         ).schema()
 

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -319,12 +319,7 @@ WHERE
         client = bigquery.Client(location=None, credentials=credentials)
         db_list = [ds.dataset_id for ds in client.list_datasets()]
 
-        print('\n' * 10)
-        print('-' * 100)
-        print(f'>> {db_list=}')
         db_as_series = pd.Series(db_list).values
-        print('-' * 100)
-        print(f'>> {db_as_series=}')
 
         return db_as_series
 

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -52,11 +52,14 @@ class GoogleBigQueryDataSource(ToucanDataSource):
 
     @classmethod
     def get_form(cls, connector: 'GoogleBigQueryConnector', current_config: dict[str, Any]):
-        return create_model(
+        schema = create_model(
             'FormSchema',
             db_schema=strlist_to_enum('db_schema', connector.available_dbs),
             __base__=cls,
         ).schema()
+        schema['properties']['database']['default'] = connector.credentials.project_id
+
+        return schema
 
 
 BigQueryParam = Union[bigquery.ScalarQueryParameter, bigquery.ArrayQueryParameter]

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -54,7 +54,7 @@ class GoogleBigQueryDataSource(ToucanDataSource):
     def get_form(cls, connector: 'GoogleBigQueryConnector', current_config: dict[str, Any]):
         schema = create_model(
             'FormSchema',
-            db_schema=strlist_to_enum('db_schema', connector.available_schs),
+            db_schema=strlist_to_enum('db_schema', connector._available_schs),
             __base__=cls,
         ).schema()
         schema['properties']['database']['default'] = connector.credentials.project_id
@@ -258,7 +258,9 @@ WHERE
             self._build_dataset_info_query_for_ds(dataset_id, db_name) for dataset_id in dataset_ids
         )
 
-    def _fetch_query_results(self, query_job: QueryJob) -> Generator[Any, Any, Any]:
+    def _fetch_query_results(
+        self, query_job: QueryJob
+    ) -> Generator[Any, Any, Any]:  # pragma: no cover
         """Fetches query results in a paginated manner using a generator."""
         row_iterator = query_job.result(page_size=_PAGE_SIZE, max_results=_MAXIMUM_RESULTS_FETCHED)
 
@@ -308,13 +310,11 @@ WHERE
         return pd.concat(dfs)
 
     @cached_property
-    def available_schs(self) -> list[str]:
+    def _available_schs(self) -> list[str]:  # prama: no cover
         credentials = self._get_google_credentials(self.credentials, self.scopes)
         client = bigquery.Client(location=None, credentials=credentials)
 
-        dataset_list = (ds.dataset_id for ds in client.list_datasets())
-
-        return pd.Series(dataset_list).values
+        return pd.Series((ds.dataset_id for ds in client.list_datasets())).values
 
     def _get_project_structure(
         self, db_name: str | None = None, schema_name: str | None = None

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -130,9 +130,6 @@ class GoogleBigQueryConnector(ToucanConnector, DiscoverableConnector):
         )
         return client
 
-    def project_tree(self) -> list[TableInfo]:
-        return self._get_project_structure()
-
     @staticmethod
     def _execute_query(client: bigquery.Client, query: str, parameters: list) -> pd.DataFrame:
         try:

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -310,7 +310,7 @@ WHERE
         return pd.concat(dfs)
 
     @cached_property
-    def _available_schs(self) -> list[str]:  # prama: no cover
+    def _available_schs(self) -> list[str]:  # pragma: no cover
         credentials = self._get_google_credentials(self.credentials, self.scopes)
         client = bigquery.Client(location=None, credentials=credentials)
 

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -48,14 +48,13 @@ class GoogleBigQueryDataSource(ToucanDataSource):
         **{'ui.hidden': True},
     )
     language: str = Field('sql', **{'ui.hidden': True})
-    database: str = Field(None)
+    database: str = Field(None, description='The name of the database you want to query.')
 
     @classmethod
     def get_form(cls, connector: 'GoogleBigQueryConnector', current_config: dict[str, Any]):
-        default_db = current_config.get('database', connector.credentials.project_id)
         return create_model(
             'FormSchema',
-            database=strlist_to_enum('database', connector.available_dbs, default_db),
+            database=strlist_to_enum('database', connector.available_dbs),
             __base__=cls,
         ).schema()
 

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -5,7 +5,6 @@ from itertools import groupby
 from timeit import default_timer as timer
 from typing import Any, Dict, Generator, Iterable, List, Union
 
-import pandas
 import pandas as pd
 from google.api_core.exceptions import GoogleAPIError
 from google.cloud import bigquery
@@ -48,7 +47,7 @@ class GoogleBigQueryDataSource(ToucanDataSource):
         **{'ui.hidden': True},
     )
     language: str = Field('sql', **{'ui.hidden': True})
-    database: str = Field(None)
+    database: str = Field(None, **{'ui.hidden': True})
     db_schema: str = Field(None, description='The name of the db_schema you want to query.')
 
     @classmethod
@@ -132,7 +131,7 @@ class GoogleBigQueryConnector(ToucanConnector, DiscoverableConnector):
         return self._get_project_structure()
 
     @staticmethod
-    def _execute_query(client: bigquery.Client, query: str, parameters: list) -> pandas.DataFrame:
+    def _execute_query(client: bigquery.Client, query: str, parameters: list) -> pd.DataFrame:
         try:
             start = timer()
 

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -48,6 +48,7 @@ class GoogleBigQueryDataSource(ToucanDataSource):
         **{'ui.hidden': True},
     )
     language: str = Field('sql', **{'ui.hidden': True})
+    database: str = Field(None)
     db_schema: str = Field(None, description='The name of the db_schema you want to query.')
 
     @classmethod


### PR DESCRIPTION
## WHAT

In case of a big project structure, we were struggling to fetch datasets using the
`_get_project_structure_fast` method in some huge cases, even tho it was implemented
too to speed up that process.
So, to solve that problem of latency, We tested numerous solutions such as *paginator_iter* from gbq lib,
update the fetching page per page and finaly, this is how we optimized it in 2 steps :
- For the method `_get_project_structure_fast`, if the project structure is expected to be large, we might want to paginate the results instead of returning a single DataFrame to avoid memory issues. that's why we added a query_job with the new parameter in the config : `_PAGE_SIZE`, this will help us paginate results regarding that parameter and `_MAXIMUM_RESULTS_FETCHED`, to impose ourself a limit of max results we can get from a single query
- We built up a generator like method to yield those results in a seperate function `_fetch_query_results`
- Add threading when fetching result by updating the `startIndex` parameter for each iteration.

## EDIT

- We return the schema from the list of databases to have the graphical interface(but this need a check on the frontend)


## EDIT 2

- We finally decided to retrieve the list of all schemas db first to let the user check what he/she wants when getting the model (project structure with the list of tables).