### PR TITLE
fix: http tests failed on CI

### DIFF
--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -59,9 +59,19 @@ def test_transform_with_jq():
     ]
 
 
-def test_get_df(connector, data_source):
+@responses.activate
+def test_get_df(connector: HttpAPIConnector, data_source: HttpAPIDataSource) -> None:
+    responses.add(
+        responses.GET,
+        'https://jsonplaceholder.typicode.com/comments',
+        json=[
+            {'comment': 'Hello there', 'id': 1},
+            {'comment': 'Hello there', 'id': 2},
+            {'comment': 'Hello there', 'id': 3},
+        ],
+    )
     df = connector.get_df(data_source)
-    assert df.shape == (500, 5)
+    assert df.shape == (3, 2)
 
 
 @responses.activate

--- a/tests/one_drive/test_one_drive.py
+++ b/tests/one_drive/test_one_drive.py
@@ -2,10 +2,10 @@ import copy
 
 import pandas as pd
 import pytest
-from pytest_mock import MockerFixture
 import requests.exceptions
 import responses
 from pytest import fixture
+from pytest_mock import MockerFixture
 
 from tests.one_drive.fixtures import FAKE_LIBRARIES, FAKE_SHEET
 from toucan_connectors.common import HttpError
@@ -519,10 +519,7 @@ def test_run_fetch(con: OneDriveConnector, mocker: MockerFixture):
     mock_oauth2_connector.client_secret = 'secret'
     con._oauth2_connector = mock_oauth2_connector
 
-    responses.add(
-        responses.GET,
-        'https://jsonplaceholder.typicode.com/posts', json=[]
-    )
+    responses.add(responses.GET, 'https://jsonplaceholder.typicode.com/posts', json=[])
     con._run_fetch('https://jsonplaceholder.typicode.com/posts')
 
     mock_oauth2_connector.get_access_token.assert_called()

--- a/tests/one_drive/test_one_drive.py
+++ b/tests/one_drive/test_one_drive.py
@@ -2,6 +2,7 @@ import copy
 
 import pandas as pd
 import pytest
+from pytest_mock import MockerFixture
 import requests.exceptions
 import responses
 from pytest import fixture
@@ -510,13 +511,18 @@ def test_get_access_token(con, mocker):
     mock_oauth2_connector.get_access_token.assert_called()
 
 
-def test_run_fetch(con, mocker):
+@responses.activate
+def test_run_fetch(con: OneDriveConnector, mocker: MockerFixture):
     """It should run fetch"""
     mock_oauth2_connector = mocker.Mock(spec=OAuth2Connector)
     mock_oauth2_connector.client_id = 'client_id'
     mock_oauth2_connector.client_secret = 'secret'
     con._oauth2_connector = mock_oauth2_connector
 
+    responses.add(
+        responses.GET,
+        'https://jsonplaceholder.typicode.com/posts', json=[]
+    )
     con._run_fetch('https://jsonplaceholder.typicode.com/posts')
 
     mock_oauth2_connector.get_access_token.assert_called()


### PR DESCRIPTION
## WHAT

fix the CI by mocking http calls to jsonplaceholder free API.
looks like github action ip addresses are blacklisted.
