### PR TITLE
chore: bump connectors from 4.6.0 to 4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### [4.7.0] 2023-07-07
+
 ## Changed
 
 - Feat[Goole Big Query] : We can now get the database model(list of tables) based on a given schema name to speed up the project tree structure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ multi_line_output = 3
 
 [tool.poetry]
 name = "toucan-connectors"
-version = "4.6.0"
+version = "4.7.0"
 description = "Toucan Toco Connectors"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 license = "BSD"


### PR DESCRIPTION
## WHAT

Bump from 4.6.0 to 4.7.0
