### PR TITLE
chore: bump toucan-connectors from 4.7.2 to 4.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- GoogleSheets: Replace empty string values in columns by numpy `null` values when parsing cells.
+- GoogleSheets: Replace empty values by numpy `NaN`.
 
 ### [4.7.2] 2023-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- GoogleSheets: Replace empty string by numpy `null` values when parsing cells values.
+- GoogleSheets: Replace empty string values in columns by numpy `null` values when parsing cells.
 
 ### [4.7.2] 2023-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### [4.7.3] 2023-08-22
+
+### Fixed
+
+- GoogleSheets: Replace empty string by numpy `null` values when parsing cells values.
+
 ### [4.7.2] 2023-07-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ multi_line_output = 3
 
 [tool.poetry]
 name = "toucan-connectors"
-version = "4.7.2"
+version = "4.7.3"
 description = "Toucan Toco Connectors"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 license = "BSD"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=4.7.2
+sonar.projectVersion=4.7.3
 sonar.python.version=3.11
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.


### PR DESCRIPTION
This brings https://github.com/ToucanToco/toucan-connectors/pull/1228
