### PR TITLE
fix: lts mssql install script [TCTC-6583]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Install scripts: fix mssql install scripts by forcing debian/11 deb repo
+
 ### [3.23.16] 2023-08-01
 
 ### Changed

--- a/toucan_connectors/install_scripts/mssql.sh
+++ b/toucan_connectors/install_scripts/mssql.sh
@@ -9,9 +9,16 @@ fi
 apt-get update
 apt-get install -fyq gnupg curl
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-source /etc/os-release &&\
+
+source /etc/os-release
+if [ "$ID" == "debian" ]; then
+    # debian/12 fails - fixing to debian/11 works:
+    curl "https://packages.microsoft.com/config/debian/11/prod.list" \
+        | tee /etc/apt/sources.list.d/mssql-release.list
+else
     curl "https://packages.microsoft.com/config/${ID}/${VERSION_ID}/prod.list" \
-    | tee /etc/apt/sources.list.d/mssql-release.list
+        | tee /etc/apt/sources.list.d/mssql-release.list
+fi
 apt-get update
 ACCEPT_EULA=Y apt-get -y install msodbcsql17 unixodbc-dev
 

--- a/toucan_connectors/install_scripts/mssql_TLSv1_0.sh
+++ b/toucan_connectors/install_scripts/mssql_TLSv1_0.sh
@@ -21,9 +21,15 @@ fi
 apt-get update
 apt-get install -fyq gnupg curl
 curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-source /etc/os-release &&\
+source /etc/os-release
+if [ "$ID" == "debian" ]; then
+    # debian/12 fails - fixing to debian/11 works:
+    curl "https://packages.microsoft.com/config/debian/11/prod.list" \
+        | tee /etc/apt/sources.list.d/mssql-release.list
+else
     curl "https://packages.microsoft.com/config/${ID}/${VERSION_ID}/prod.list" \
-    | tee /etc/apt/sources.list.d/mssql-release.list
+        | tee /etc/apt/sources.list.d/mssql-release.list
+fi
 apt-get update
 ACCEPT_EULA=Y apt-get -y install msodbcsql17 unixodbc-dev
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

By using default repo (debian/12) we encountered this error: https://learn.microsoft.com/en-us/answers/questions/1328834/debian-12-public-key-is-not-available

Solution is to force the usage of debian/11 (this is what is done in the "build-image" stage of laputa's Dockerfile)