### PR TITLE
fix(gbq): Validation error on mandatory GoogleCreds missing + add descriptive Exception message on missing datas [TCTC-6756]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## Fixed
+
+- Goole Big Query:
+    - fix Validation error when all GoogleCredentials are not set (only the `project_id` is required).
+    - Explicit error information when no data to return.
+    - fallback on normal GoogleCredentials connexion mode when jwt-token is not valid aymore.
+
 ### [4.9.0] 2023-09-20
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ## Fixed
 
 - Goole Big Query:
-    - Explicit errors information when no data to return.
-    - Fallback on normal GoogleCredentials connection when JWTCredentials fails (jwt-token is not valid aymore).
+    - Better UX (Switch between GoogleCreds auth or GoogleJWT  auth).
+    - Explicit errors information when no data is returned.
+    - Fallback on GoogleCredentials auth when JWTCredentials fails (or when jwt-token is not valid aymore).
 
 ### [4.9.0] 2023-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Goole Big Query:
     - fix Validation error when all GoogleCredentials are not set (only the `project_id` is required).
     - Explicit error information when no data to return.
-    - fallback on normal GoogleCredentials connexion mode when jwt-token is not valid aymore.
+    - fallback on normal GoogleCredentials connection mode when jwt-token is not valid aymore.
 
 ### [4.9.0] 2023-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,8 @@
 ## Fixed
 
 - Goole Big Query:
-    - fix Validation error when all GoogleCredentials are not set (only the `project_id` is required).
-    - Explicit error information when no data to return.
-    - fallback on normal GoogleCredentials connection mode when jwt-token is not valid aymore.
+    - Explicit errors information when no data to return.
+    - Fallback on normal GoogleCredentials connection when JWTCredentials fails (jwt-token is not valid aymore).
 
 ### [4.9.0] 2023-09-20
 

--- a/doc/connectors/google_big_query.md
+++ b/doc/connectors/google_big_query.md
@@ -15,8 +15,8 @@ For authentication, download an authentication file from console.developper.com
 and use the values here. This is an oauth2 credential file. For more information
 see this: http://gspread.readthedocs.io/en/latest/oauth2.html
 
-* `type`: str
-* `project_id`: str
+* `type`: str, required
+* `project_id`: str, required
 * `private_key_id`: str
 * `private_key`: str
 * `client_email`: str

--- a/doc/connectors/google_big_query.md
+++ b/doc/connectors/google_big_query.md
@@ -4,8 +4,8 @@
 
 * `type`: `"GoogleBigQuery"`
 * `name`: str, required
-* `credentials`: GoogleCredentials, required
-* `jwt_token`: str
+* `credentials`: GoogleCredentials
+* `jwt_credentials`: JWTCredentials
 * `dialect`: Dialect, default to legacy
 * `scopes`: list(str), default to ["https://www.googleapis.com/auth/bigquery"]
 
@@ -26,7 +26,7 @@ see this: http://gspread.readthedocs.io/en/latest/oauth2.html
 * `auth_provider_x509_cert_url`: str
 * `client_x509_cert_url`: str
 
-### Auth with JWT signed
+### Auth with JWT Credentials
 
 You can also authenticate with a signed `jwt_token` you've created yourself,
 in that case, you will only need here two fields:

--- a/doc/connectors/google_big_query.md
+++ b/doc/connectors/google_big_query.md
@@ -15,8 +15,8 @@ For authentication, download an authentication file from console.developper.com
 and use the values here. This is an oauth2 credential file. For more information
 see this: http://gspread.readthedocs.io/en/latest/oauth2.html
 
-* `type`: str, required
-* `project_id`: str, required
+* `type`: str
+* `project_id`: str
 * `private_key_id`: str
 * `private_key`: str
 * `client_email`: str

--- a/tests/google_big_query/test_google_big_query.py
+++ b/tests/google_big_query/test_google_big_query.py
@@ -44,6 +44,11 @@ def _fixture_credentials() -> GoogleCredentials:
 
 @pytest.fixture
 def gbq_connector_with_jwt(_fixture_credentials: GoogleCredentials) -> GoogleBigQueryConnector:
+    # those should and can be None
+    _fixture_credentials.private_key = None
+    _fixture_credentials.private_key_id = None
+    _fixture_credentials.client_id = None
+    _fixture_credentials.client_email = None
     return GoogleBigQueryConnector(
         name='woups',
         scopes=['https://www.googleapis.com/auth/bigquery'],

--- a/tests/google_big_query/test_google_big_query.py
+++ b/tests/google_big_query/test_google_big_query.py
@@ -732,9 +732,7 @@ WHERE
 
 
 def test_get_form(
-    mocker: MockFixture,
-    _fixture_credentials: MockFixture,
-    _jwt_fixture_credentials: MockFixture
+    mocker: MockFixture, _fixture_credentials: MockFixture, _jwt_fixture_credentials: MockFixture
 ) -> None:
     def mock_available_schs():
         return ['ok', 'test']
@@ -772,7 +770,6 @@ def test_get_form(
         )['properties']['database']['default']
         == 'THE_JWT_project_id'
     )
-
 
 
 @pytest.mark.parametrize(

--- a/tests/google_big_query/test_google_big_query.py
+++ b/tests/google_big_query/test_google_big_query.py
@@ -798,9 +798,30 @@ def test_optional_fields_validator_for_google_creds():
     }
 
     # Can create the connector without all fields on GoogleCredentials
-    _ = GoogleBigQueryConnector(
+    connector1 = GoogleBigQueryConnector(
         name='something', credentials=incomplete_credentials_with_project_id
     )
+    # default values setted when not valids
+    assert connector1.credentials.private_key == '__not_set__'
+    assert connector1.credentials.private_key_id == '__not_set__'
+
+    # with valid values set
+    valid_credentials = {
+        'type': 'service_account',
+        'project_id': 'your-project-id',
+        'private_key_id': 'my_private_key_id',
+        'private_key': 'my_private_key',
+        'client_email': 'my_client_email@email.com',
+        'client_id': 'my_client_id',
+        'auth_uri': 'https://accounts.google.com/o/oauth2/auth',
+        'token_uri': 'https://oauth2.googleapis.com/token',
+        'auth_provider_x509_cert_url': 'https://www.googleapis.com/oauth2/v1/certs',
+        'client_x509_cert_url': 'https://www.googleapis.com/robot/v1/metadata/x509/pika.com',
+    }
+    connector2 = GoogleBigQueryConnector(name='something', credentials=valid_credentials)
+    assert connector2.credentials.private_key == 'my_private_key'
+    assert connector2.credentials.private_key_id == 'my_private_key_id'
+    assert connector2.credentials.auth_uri == 'https://accounts.google.com/o/oauth2/auth'
 
     incomplete_credentials_with_no_project_id = {
         'type': 'service_account',

--- a/tests/google_big_query/test_google_big_query.py
+++ b/tests/google_big_query/test_google_big_query.py
@@ -48,7 +48,7 @@ def _fixture_credentials() -> GoogleCredentials:
 @pytest.fixture
 def _jwt_fixture_credentials() -> JWTCredentials:
     my_credentials = JWTCredentials(
-        project_id='my_project_id',
+        project_id='THE_JWT_project_id',
         jwt_token='valid-jwt',
     )
     return my_credentials
@@ -731,7 +731,11 @@ WHERE
     assert mocked_query.call_args_list[2][1] == {'location': 'Toulouse'}
 
 
-def test_get_form(mocker: MockFixture, _fixture_credentials: MockFixture) -> None:
+def test_get_form(
+    mocker: MockFixture,
+    _fixture_credentials: MockFixture,
+    _jwt_fixture_credentials: MockFixture
+) -> None:
     def mock_available_schs():
         return ['ok', 'test']
 
@@ -754,6 +758,21 @@ def test_get_form(mocker: MockFixture, _fixture_credentials: MockFixture) -> Non
         )['properties']['database']['default']
         == 'my_project_id'
     )
+
+    assert (
+        GoogleBigQueryDataSource(query=',', name='MyGBQ-WITH-JWT', domain='foo').get_form(
+            GoogleBigQueryConnector(
+                name='MyGBQ',
+                jwt_credentials=_jwt_fixture_credentials,
+                scopes=[
+                    'https://www.googleapis.com/auth/bigquery',
+                ],
+            ),
+            {},
+        )['properties']['database']['default']
+        == 'THE_JWT_project_id'
+    )
+
 
 
 @pytest.mark.parametrize(

--- a/tests/google_big_query/test_google_big_query.py
+++ b/tests/google_big_query/test_google_big_query.py
@@ -826,7 +826,7 @@ def test_optional_fields_validator_for_google_creds():
     incomplete_credentials_with_no_project_id = {
         'type': 'service_account',
     }
-    # should raise an errro if the project_id is not set
+    # should raise an error if the project_id is not set
     with pytest.raises(ValidationError) as _:
         _ = GoogleBigQueryConnector(
             name='something', credentials=incomplete_credentials_with_no_project_id

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -101,7 +101,14 @@ class GoogleBigQueryDataSource(ToucanDataSource):
             db_schema=strlist_to_enum('db_schema', connector._available_schs),
             __base__=cls,
         ).schema()
-        schema['properties']['database']['default'] = connector.credentials.project_id
+
+        project_id = ''
+        if connector.jwt_credentials:
+            project_id = connector.jwt_credentials.project_id
+        elif connector.credentials:
+            project_id = connector.credentials.project_id
+
+        schema['properties']['database']['default'] = project_id
 
         return schema
 

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -321,7 +321,7 @@ class GoogleBigQueryConnector(ToucanConnector, DiscoverableConnector):
         """Add surrounding for parameters injection"""
         return f'@{variable}'
 
-    def _bigquery_client_with_google_creds(self):
+    def _bigquery_client_with_google_creds(self) -> bigquery.Client:
         try:
             credentials = GoogleBigQueryConnector._get_google_credentials(
                 self.credentials, self.scopes

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -135,7 +135,8 @@ class GoogleBigQueryConnector(ToucanConnector, DiscoverableConnector):
 
         # Iterate over optional fields and set them to None if missing
         for field_name in optional_fields:
-            if not hasattr(value, field_name):
+            if not hasattr(value, field_name) and not value.get(field_name):
+                # for all links
                 if field_name in [
                     'client_x509_cert_url',
                     'auth_provider_x509_cert_url',
@@ -143,6 +144,7 @@ class GoogleBigQueryConnector(ToucanConnector, DiscoverableConnector):
                 ]:
                     value[field_name] = 'https://valid-scheme.com'
                 else:
+                    # for other values
                     value[field_name] = '__not_set__'
 
         return value

--- a/toucan_connectors/google_credentials.py
+++ b/toucan_connectors/google_credentials.py
@@ -8,11 +8,25 @@ CREDENTIALS_INFO_MESSAGE = (
 )
 
 
+class JWTCredentials(BaseModel):
+    """
+    For Google Credentials inside the JWT
+
+    """
+
+    project_id: str = Field(..., title='Project ID', description=CREDENTIALS_INFO_MESSAGE)
+    jwt_token: str = Field(
+        ...,
+        title='JSON web token (JWT) signed',
+        description='JWT signed with your service_account credentials,'
+        'see the docs of the connector for that.',
+    )
+
+
 class GoogleCredentials(BaseModel):
     type: str = Field(
         'service_account', title='Service account', description=CREDENTIALS_INFO_MESSAGE
     )
-    # On service account MODE :
     project_id: str = Field(..., title='Project ID', description=CREDENTIALS_INFO_MESSAGE)
     private_key_id: str = Field(..., title='Private Key ID', description=CREDENTIALS_INFO_MESSAGE)
     private_key: str = Field(
@@ -39,7 +53,7 @@ class GoogleCredentials(BaseModel):
         description=f'{CREDENTIALS_INFO_MESSAGE}. You should not need to change the default value.',
     )
     client_x509_cert_url: HttpUrl = Field(
-        ...,
+        'https://www.client_cert.test',
         title='Client X509 certification URL',
         description=CREDENTIALS_INFO_MESSAGE,
     )


### PR DESCRIPTION
## WHAT

- Explicit Exception information when data are not available when an ValueError ( on empty data in the dataframe when concatenate)
- Fix a ValidationError introduced in the previous bump (All GoogleCredentials should no be "mandatory"/"required" for the GoogleBigQuery connector)
- Add a fallback on GoogleCredentials login, so that if the jwt-token is not valid anymore, we can still connect with GoogleCreds if they are available