### PR TITLE
fix: get good project_id from jwt or google-creds when they are set or not [TCTC-6942]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixed
+
+- Google Big Query: get project_id from connector config whatever auth mode (JWT/GoogleCreds).
+
 ### [4.9.1] 2023-09-22
 
 ## Fixed


### PR DESCRIPTION
## WHAT

get the "good" and "valid" project-id from the connector configuration

## WHY
When both JWT and GoogleCreds were sets, on the "configuration for listing tables and schemas", we were using the wrong project-id to make requests, now, we make sure the jwt-credentials is checkec but also contains all informations needed.

## HOW

- fix: fallback when the project-id is not well get from either the jwt_credentials or the google-credentials
- add some Unit tests to illustrate that 
- doc: update the CHANGELOG.md

## ADDITIONAL INFOS

this branch is deployed on the ange guru and can be tested on the app TCTC-6942