### PR TITLE
fix(lts): oracle install script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog (Pypi package)
 
+## [3.23.24] 2024-01-16
+
+### Fixed
+
+- Install scripts: fix oracle install script by replacing gdown.pl with wget
+
 ## [3.23.23] 2023-12-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ multi_line_output = 3
 
 [tool.poetry]
 name = "toucan-connectors"
-version = "3.23.23"
+version = "3.23.24"
 description = "Toucan Toco Connectors"
 authors = ["Toucan Toco <dev@toucantoco.com>"]
 license = "BSD"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization=toucantoco
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=Toucan Connectors
-sonar.projectVersion=3.23.23
+sonar.projectVersion=3.23.24
 sonar.python.version=3.10
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.

--- a/toucan_connectors/install_scripts/oracle.sh
+++ b/toucan_connectors/install_scripts/oracle.sh
@@ -9,12 +9,10 @@ fi
 apt-get update
 apt-get install -fyq libaio1 curl wget unzip
 mkdir -p /opt/oracle
-curl -s 'https://public-package.toucantoco.com/connectors_sources/gdown/gdown.pl' -o /tmp/gdown.pl
-chmod +x /tmp/gdown.pl
-/tmp/gdown.pl 'https://public-package.toucantoco.com/connectors_sources/oracle/oracle_client_lib/oracle_client_lib.zip' '/tmp/oracle_client_lib.zip'
+wget 'https://public-package.toucantoco.com/connectors_sources/oracle/oracle_client_lib/instantclient-basiclite-linux.x64-12.2.0.1.0.zip' -O '/tmp/oracle_client_lib.zip'
 unzip /tmp/oracle_client_lib.zip -d /opt/oracle
 sh -c "echo /opt/oracle/instantclient_12_2 > /etc/ld.so.conf.d/oracle-instantclient.conf"
 ldconfig
-rm -rf /tmp/gdown.pl /tmp/oracle_client_lib.zip
+rm -rf /tmp/oracle_client_lib.zip
 
 touch ~/oracle-installed

--- a/toucan_connectors/install_scripts/oracle.sh
+++ b/toucan_connectors/install_scripts/oracle.sh
@@ -13,6 +13,6 @@ wget 'https://public-package.toucantoco.com/connectors_sources/oracle/oracle_cli
 unzip /tmp/oracle_client_lib.zip -d /opt/oracle
 sh -c "echo /opt/oracle/instantclient_12_2 > /etc/ld.so.conf.d/oracle-instantclient.conf"
 ldconfig
-rm -rf /tmp/oracle_client_lib.zip
+rm -f /tmp/oracle_client_lib.zip
 
 touch ~/oracle-installed


### PR DESCRIPTION
Fix oracle install script by replacing gdown.pl with wget and fixing the archive hosted on our cloud