### PR TITLE
fix(elasticsearch): disable verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 
 - Google Big Query: A simple status check that validates the private key's format has been implemented
+- Elasticsearch: Host verification has been disabled to tolerate strict network configurations
 
 ## [3.23.25] 2024-01-17
 

--- a/tests/elasticsearch/test_elasticsearch.py
+++ b/tests/elasticsearch/test_elasticsearch.py
@@ -39,13 +39,10 @@ def pytest_generate_tests(metafunc):
 
 
 def test_connector(mocker):
-    class ElasticsearchMock:
-        def search(self, index, body):
-            return {'hits': {'hits': [{'_source': {'yo': 'la'}}]}}
 
     module = 'toucan_connectors.elasticsearch.elasticsearch_connector'
     mock_es = mocker.patch(f'{module}.Elasticsearch')
-    mock_es.return_value = ElasticsearchMock()
+    mock_es.return_value.search.return_value = {'hits': {'hits': [{'_source': {'yo': 'la'}}]}}
 
     con = ElasticsearchConnector(
         name='test',

--- a/toucan_connectors/elasticsearch/elasticsearch_connector.py
+++ b/toucan_connectors/elasticsearch/elasticsearch_connector.py
@@ -145,6 +145,7 @@ class ElasticsearchConnector(ToucanConnector):
             connection_params.append(h)
 
         esclient = Elasticsearch(connection_params)
+        esclient.transport._verified_elasticsearch = True
         response = getattr(esclient, data_source.search_method)(
             index=data_source.index, body=data_source.body
         )


### PR DESCRIPTION
## Change Summary
Disable the internal verification of the elasticsearch client that checks if the root `/` of the provided URL returns a a compatible payload.

This internal verification, for some reason, does not use the basic auth provided by http_auth. So this check fails when the client configuration ask for authentication for the `/` route.

https://github.com/elastic/elasticsearch-py/blob/v7.17.6/elasticsearch/transport.py#L532
https://github.com/elastic/elasticsearch-py/blob/v7.17.6/elasticsearch/transport.py#L216

https://toucantoco.slack.com/archives/C823R095H/p1705597838374409