### PR TITLE
feat(mongo_connector): Make pool size configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Mongo: maximal connection pool size is now configurable via the `max_pool_size` parameter. It defaults to 1
+
 ## [5.2.0] 2024-02-08
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,5 +192,6 @@ files = [
       "toucan_connectors/toucan_connector.py",
       "toucan_connectors/hubspot_private_app/hubspot_connector.py",
       "toucan_connectors/snowflake/snowflake_connector.py",
-      "toucan_connectors/peakina/peakina_connector.py"
+      "toucan_connectors/peakina/peakina_connector.py",
+      "toucan_connectors/mongo/mongo_connector.py"
 ]

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -1,7 +1,7 @@
 import os
 import re
 from datetime import datetime
-from typing import Callable
+from typing import Callable, Self
 
 import pandas as pd
 import pymongo
@@ -63,16 +63,15 @@ def mongo_datasource():
 def test_username_password():
     # password not set
     mongo_connector = MongoConnector(name="mycon", host="localhost", port=22)
-    assert mongo_connector._get_mongo_client_kwargs() == {"host": "localhost", "port": 22}
+    assert mongo_connector._get_mongo_client_kwargs() == {"host": "localhost", "port": 22, "maxPoolSize": 1}
 
     # password set to None
     mongo_connector = MongoConnector(name="mycon", host="localhost", port=22, password=None)
-    assert mongo_connector._get_mongo_client_kwargs() == {"host": "localhost", "port": 22}
+    assert mongo_connector._get_mongo_client_kwargs() == {"host": "localhost", "port": 22, "maxPoolSize": 1}
 
     # password set without username
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="username must be set"):
         MongoConnector(name="mycon", host="localhost", port=22, password="bibou")
-    assert "username must be set" in str(e.value)
 
     # password and user set
     mongo_connector = MongoConnector(name="mycon", host="localhost", port=22, username="pika", password="bibou")
@@ -81,36 +80,39 @@ def test_username_password():
         "port": 22,
         "username": "pika",
         "password": "bibou",
+        "maxPoolSize": 1,
     }
 
 
 def test_client_with_detailed_params():
     connector = MongoConnector(name="my_mongo_con", host="myhost", port="123")
-    assert isinstance(connector.client, pymongo.MongoClient)
+    with connector.client() as client:
+        assert isinstance(client, pymongo.MongoClient)
 
 
 def test_client_with_mongo_uri():
     connector = MongoConnector(name="my_mongo_con", host="mongodb://myuser:mypassword@myhost:123")
-    assert isinstance(connector.client, pymongo.MongoClient)
+    with connector.client() as client:
+        assert isinstance(client, pymongo.MongoClient)
 
 
 def test_client_args_with_mongo_uri(mocker):
     """It should not pass any other parameter than the host to MongoClient"""
     mongo_client_mock = mocker.patch("toucan_connectors.mongo.mongo_connector.pymongo.MongoClient")
     connector = MongoConnector(name="my_mongo_con", host="mongodb://myuser:mypassword@myhost:123")
-    connector.client  # noqa: B018
-    mongo_client_mock.assert_called_with(host="mongodb://myuser:mypassword@myhost:123")
+    with connector.client():
+        mongo_client_mock.assert_called_with(host="mongodb://myuser:mypassword@myhost:123", maxPoolSize=1)
 
 
 def test_client_args_with_ssl(mocker):
     """It should forward parameters to mongo client"""
     mongo_client_mock = mocker.patch("toucan_connectors.mongo.mongo_connector.pymongo.MongoClient")
     connector = MongoConnector(name="my_mongo_con", host="myhost", password="blah", username="jean", ssl=True)
-    connector.client  # noqa: B018
-    mongo_client_mock.assert_called_with(host="myhost", ssl=True, password="blah", username="jean")
+    with connector.client():
+        mongo_client_mock.assert_called_with(host="myhost", ssl=True, password="blah", username="jean", maxPoolSize=1)
 
 
-def test_get_df_no_query(mongo_connector, mongo_datasource):
+def test_get_df_no_query(mongo_connector: MongoConnector, mongo_datasource: Callable[..., MongoDataSource]):
     """It should return the whole collection by default"""
     ds = mongo_datasource(collection="test_col")
     df = mongo_connector.get_df(ds)
@@ -134,6 +136,12 @@ def test_get_df(mocker):
 
         def __getitem__(self, row):
             return self.data[row]
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_) -> None:
+            pass
 
         def close(self):
             pass
@@ -165,8 +173,8 @@ def test_get_df(mocker):
     )
     mongo_connector.get_df(datasource)
 
-    snock.assert_called_with(host="localhost", username="ubuntu", password="ilovetoucan", port=22)
-    assert snock.call_count == 1  # client is cached
+    snock.assert_called_with(host="localhost", username="ubuntu", password="ilovetoucan", port=22, maxPoolSize=1)
+    assert snock.call_count == 2  # Only one client should have been instanciated per call
 
     aggregate.assert_called_with([{"$match": {"domain": "domain1"}}])
     assert aggregate.call_count == 2
@@ -463,7 +471,7 @@ def test_get_df_with_regex_or(mongo_connector, mongo_datasource):
     ]
 
 
-def test_explain(mongo_connector, mongo_datasource):
+def test_explain(mongo_connector: MongoConnector, mongo_datasource: Callable[..., MongoDataSource]):
     datasource = mongo_datasource(collection="test_col", query={"domain": "domain1"})
     res = mongo_connector.explain(datasource)
     assert list(res.keys()) == ["details", "summary"]
@@ -696,23 +704,25 @@ def test_get_multiple_dfs(mocker, mongo_connector, mongo_datasource):
         for query in queries:
             datasource = mongo_datasource(collection="test_col", query=query)
             con.get_df(datasource)
-    mongo_client.assert_called_once()
     assert aggregate.call_count == 4
+    assert mongo_client.call_count == 4
+    assert mongo_client_close.call_count == 4
     validate_database.assert_called_once()
-    mongo_client_close.assert_called_once()
 
 
-def test_validate_cache(mongo_connector):
+def test_validate_cache(mongo_connector: MongoConnector):
     """It should cache the validation of a database for the same instance only"""
     con1 = mongo_connector
-    assert con1.validate_database("toucan") is None
-    con1.client.drop_database("toucan")
-    assert con1.validate_database("toucan") is None, "the cache should validate the dropped db"
+    with con1.client() as client:
+        assert con1._validate_database(client, "toucan") is None
+        client.drop_database("toucan")
+        assert con1._validate_database(client, "toucan") is None, "the cache should validate the dropped db"
 
     # A new connector should have a fresh cache
-    con2 = con1.copy()
+    con2 = con1.model_copy()
     with pytest.raises(UnkwownMongoDatabase):
-        con2.validate_database("toucan")
+        with con2.client() as client:
+            con2._validate_database(client, "toucan")
 
 
 def test_format_no_explain_result():

--- a/tests/mongo/test_mongo.py
+++ b/tests/mongo/test_mongo.py
@@ -1,7 +1,7 @@
 import os
 import re
 from datetime import datetime
-from typing import Callable, Self
+from typing import TYPE_CHECKING, Callable
 
 import pandas as pd
 import pymongo
@@ -21,6 +21,9 @@ from toucan_connectors.mongo.mongo_connector import (
 )
 from toucan_connectors.pagination import OffsetLimitInfo
 from toucan_connectors.toucan_connector import MalformedVersion, UnavailableVersion
+
+if TYPE_CHECKING:
+    from typing import Self
 
 
 @pytest.fixture(scope="module")
@@ -137,7 +140,7 @@ def test_get_df(mocker):
         def __getitem__(self, row):
             return self.data[row]
 
-        def __enter__(self) -> Self:
+        def __enter__(self) -> "Self":
             return self
 
         def __exit__(self, *_) -> None:

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -1,10 +1,12 @@
-from functools import _lru_cache_wrapper, lru_cache
+from collections.abc import Generator
+from contextlib import contextmanager
+from functools import _lru_cache_wrapper, cached_property, lru_cache
 from typing import Any, List, Optional, Pattern, Union
+from warnings import warn
 
 import pandas as pd
 import pymongo
 from bson.son import SON
-from cached_property import cached_property
 from pydantic import ConfigDict, Field, create_model, field_validator, model_validator
 
 from toucan_connectors.common import ConnectorStatus, nosql_apply_parameters_to_query
@@ -95,7 +97,7 @@ def apply_condition_filter(query, permissions_condition: dict):
     return query
 
 
-def validate_database(client, database: str):
+def validate_database(client: pymongo.MongoClient, database: str):
     if database not in client.list_database_names():
         raise UnkwownMongoDatabase(f"Database {database!r} doesn't exist")
 
@@ -130,17 +132,17 @@ class MongoDataSource(ToucanDataSource):
         """
         constraints = {}
 
-        client = pymongo.MongoClient(**connector._get_mongo_client_kwargs())
         # Always add the suggestions for the available databases
-        available_databases = client.list_database_names()
-        constraints["database"] = strlist_to_enum("database", available_databases)
+        with connector.client() as client:
+            available_databases = client.list_database_names()
+            constraints["database"] = strlist_to_enum("database", available_databases)
 
-        if "database" in current_config:
-            validate_database(client, current_config["database"])
-            available_cols = client[current_config["database"]].list_collection_names()
-            constraints["collection"] = strlist_to_enum("collection", available_cols)
+            if "database" in current_config:
+                validate_database(client, current_config["database"])
+                available_cols = client[current_config["database"]].list_collection_names()
+                constraints["collection"] = strlist_to_enum("collection", available_cols)
 
-        return create_model("FormSchema", **constraints, __base__=cls).schema()
+        return create_model("FormSchema", __base__=cls, **constraints).schema()  # type: ignore[call-overload]
 
 
 class MongoConnector(ToucanConnector, VersionableEngineConnector, data_source_model=MongoDataSource):
@@ -156,6 +158,7 @@ class MongoConnector(ToucanConnector, VersionableEngineConnector, data_source_mo
     password: Optional[PlainJsonSecretStr] = Field(None, description="Your login password")
     ssl: Optional[bool] = Field(None, description="Create the connection to the server using SSL")
     model_config = ConfigDict(ignored_types=(cached_property, _lru_cache_wrapper))
+    max_pool_size: int = Field(1, alias="maxPoolSize")
 
     @model_validator(mode="after")
     def password_must_have_a_user(self) -> "MongoConnector":
@@ -167,10 +170,11 @@ class MongoConnector(ToucanConnector, VersionableEngineConnector, data_source_mo
         return hash(id(self)) + hash(JsonWrapper.dumps(self._get_mongo_client_kwargs()))
 
     def __enter__(self):
+        warn("Using MongoConnector as a context manager is deprecated", stacklevel=2)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.client.close()
+        pass
 
     @staticmethod
     def _get_details(index: int, status: Optional[bool]):
@@ -180,14 +184,16 @@ class MongoConnector(ToucanConnector, VersionableEngineConnector, data_source_mo
         not_validated_checks = [(c, None) for i, c in enumerate(checks) if i > index]
         return ok_checks + [new_check] + not_validated_checks
 
-    def _get_mongo_client_kwargs(self):
+    def _get_mongo_client_kwargs(self) -> dict[str, Any]:
         # We don't want parent class attributes nor the `client` property
         # nor attributes with `None` value
-        to_exclude = set(ToucanConnector.__fields__) | {"client"}
-        mongo_client_kwargs = self.dict(exclude=to_exclude, exclude_none=True).copy()
+        to_exclude = set(ToucanConnector.model_fields.keys()) | {"client", "max_pool_size"}
+        mongo_client_kwargs = self.model_dump(exclude=to_exclude, exclude_none=True).copy()
 
         if "password" in mongo_client_kwargs:
             mongo_client_kwargs["password"] = mongo_client_kwargs["password"].get_secret_value()
+
+        mongo_client_kwargs["maxPoolSize"] = self.max_pool_size
 
         return mongo_client_kwargs
 
@@ -208,36 +214,43 @@ class MongoConnector(ToucanConnector, VersionableEngineConnector, data_source_mo
         # Check databases access
         mongo_client_kwargs = self._get_mongo_client_kwargs()
         mongo_client_kwargs["serverSelectionTimeoutMS"] = 500
-        client = pymongo.MongoClient(**mongo_client_kwargs)
-        try:
-            client.server_info()
-        except pymongo.errors.ServerSelectionTimeoutError as e:
-            return ConnectorStatus(status=False, details=self._get_details(2, False), error=str(e))
-        except pymongo.errors.OperationFailure as e:
-            return ConnectorStatus(status=False, details=self._get_details(3, False), error=str(e))
+        with self.client(mongo_client_kwargs) as client:
+            try:
+                client.server_info()
+            except pymongo.errors.ServerSelectionTimeoutError as e:
+                return ConnectorStatus(status=False, details=self._get_details(2, False), error=str(e))
+            except pymongo.errors.OperationFailure as e:
+                return ConnectorStatus(status=False, details=self._get_details(3, False), error=str(e))
 
         return ConnectorStatus(status=True, details=self._get_details(3, True), error=None)
 
-    @cached_property
-    def client(self):
-        return pymongo.MongoClient(**self._get_mongo_client_kwargs())
+    @contextmanager
+    def client(self, client_args: dict[str, Any] | None = None) -> Generator[pymongo.MongoClient, None, None]:
+        client: pymongo.MongoClient = pymongo.MongoClient(
+            **(self._get_mongo_client_kwargs() if client_args is None else client_args)
+        )
+        try:
+            yield client
+        finally:
+            client.close()
 
     @lru_cache(maxsize=32)  # noqa: B019
-    def validate_database(self, database: str):
-        return validate_database(self.client, database)
+    def _validate_database(self, client: pymongo.MongoClient, database: str):
+        return validate_database(client, database)
 
     @lru_cache(maxsize=32)  # noqa: B019
-    def validate_collection(self, database: str, collection: str):
-        return validate_collection(self.client, database, collection)
+    def _validate_collection(self, client: pymongo.MongoClient, database: str, collection: str):
+        return validate_collection(client, database, collection)
 
-    def validate_database_and_collection(self, database: str, collection: str):
-        self.validate_database(database)
-        self.validate_collection(database, collection)
+    def validate_database_and_collection(self, client: pymongo.MongoClient, database: str, collection: str):
+        self._validate_database(client, database)
+        self._validate_collection(client, database, collection)
 
     def _execute_query(self, data_source: MongoDataSource):
-        self.validate_database_and_collection(data_source.database, data_source.collection)
-        col = self.client[data_source.database][data_source.collection]
-        return col.aggregate(data_source.query)
+        with self.client() as client:
+            self.validate_database_and_collection(client, data_source.database, data_source.collection)
+            col = client[data_source.database][data_source.collection]
+            return col.aggregate(data_source.query)  # type: ignore[arg-type]
 
     def _retrieve_data(self, data_source):
         data_source.query = normalize_query(data_source.query, data_source.parameters)
@@ -253,18 +266,18 @@ class MongoConnector(ToucanConnector, VersionableEngineConnector, data_source_mo
     def get_slice(
         self,
         data_source: MongoDataSource,
-        permissions: Optional[str] = None,
+        permissions: dict[str, Any] | None = None,
         offset: int = 0,
-        limit: Optional[int] = None,
-        get_row_count: Optional[bool] = False,
+        limit: int | None = None,
+        get_row_count: bool | None = False,
     ) -> DataSlice:
         # Create a copy in order to keep the original (deepcopy-like)
         data_source = data_source.model_copy(deep=True)
         if offset or limit is not None:
-            data_source.query = apply_condition_filter(data_source.query, permissions)
+            data_source.query = apply_condition_filter(data_source.query, permissions or {})
             data_source.query = normalize_query(data_source.query, data_source.parameters)
 
-            df_facet = []
+            df_facet: list[dict[str, Any]] = []
             if offset:
                 df_facet.append({"$skip": offset})
             if limit is not None:
@@ -283,7 +296,7 @@ class MongoConnector(ToucanConnector, VersionableEngineConnector, data_source_mo
                     "df": df_facet,  # df_facet is never empty
                 }
             }
-            data_source.query.append(facet)
+            data_source.query.append(facet)  # type:ignore[union-attr]
 
             res = self._execute_query(data_source).next()
             total_count = res["count"][0]["value"] if len(res["count"]) > 0 else 0
@@ -319,7 +332,7 @@ class MongoConnector(ToucanConnector, VersionableEngineConnector, data_source_mo
         # Mongo will then optimize the pipeline to move the match regex to its most convenient position
         # (c.f https://docs.mongodb.com/manual/core/aggregation-pipeline-optimization/#pipeline-sequence-optimization)
         # Since Mongo '$regex' operator doesn't work with integer values, we need to check the stringified versions
-        search_steps = {}
+        search_steps: dict[str, Any] = {}
         for condition in search:
             search_steps[f"${condition}"] = []  # convert "and"/"or" to "$and"/"$or"
             for column in search[condition]:
@@ -334,8 +347,8 @@ class MongoConnector(ToucanConnector, VersionableEngineConnector, data_source_mo
                             }
                         }
                     )
-        data_source.query.append({"$match": {"$expr": search_steps}})
-        data_source.query.append({"$unset": ["_id"]})
+        data_source.query.append({"$match": {"$expr": search_steps}})  # type:ignore[union-attr]
+        data_source.query.append({"$unset": ["_id"]})  # type:ignore[union-attr]
 
         return self.get_slice(data_source, permissions, limit=limit, offset=offset or 0)
 
@@ -357,19 +370,19 @@ class MongoConnector(ToucanConnector, VersionableEngineConnector, data_source_mo
 
     @decorate_func_with_retry
     def explain(self, data_source, permissions=None):
-        client = pymongo.MongoClient(**self._get_mongo_client_kwargs())
-        self.validate_database_and_collection(data_source.database, data_source.collection)
-        data_source.query = apply_condition_filter(data_source.query, permissions)
-        data_source.query = normalize_query(data_source.query, data_source.parameters)
+        with self.client() as client:
+            self.validate_database_and_collection(client, data_source.database, data_source.collection)
+            data_source.query = apply_condition_filter(data_source.query, permissions)
+            data_source.query = normalize_query(data_source.query, data_source.parameters)
 
-        agg_cmd = SON(
-            [
-                ("aggregate", data_source.collection),
-                ("pipeline", data_source.query),
-                ("cursor", {}),
-            ]
-        )
-        result = client[data_source.database].command(command="explain", value=agg_cmd, verbosity="executionStats")
+            agg_cmd = SON(
+                [
+                    ("aggregate", data_source.collection),
+                    ("pipeline", data_source.query),
+                    ("cursor", {}),
+                ]
+            )
+            result = client[data_source.database].command(command="explain", value=agg_cmd, verbosity="executionStats")
         return _format_explain_result(result)
 
     def get_unique_identifier(self) -> str:
@@ -382,9 +395,9 @@ class MongoConnector(ToucanConnector, VersionableEngineConnector, data_source_mo
         return data_source_rendered.model_dump(exclude={"parameters"})
 
     def get_engine_version(self) -> tuple:
-        client = pymongo.MongoClient(**self._get_mongo_client_kwargs())
         try:
-            version = client.server_info()["version"]
+            with self.client() as client:
+                version = client.server_info()["version"]
             return super()._format_version(version)
         except (TypeError, KeyError) as exc:
             raise UnavailableVersion from exc


### PR DESCRIPTION
Work items:

- Added a new `max_pool_size` parameter to MongoConnector, which defaults to 1 (PyMongo's default pool size is 100).
- Ensure mongo clients are closed after usage. This may seem sub-optimal, but a typical connector usage is instanciation -> call a single method (retrieve data or get_status) -> close the client, so this seems reasonable
- Enable mypy checks on the Mongo connector, since it's by far the one we use the most

relates to TCTC-7814
