### PR TITLE
fix(gbq): do not ignore partitioning columns when listing table structure [TCTC-7946]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Google Big Query: do not exclude partitioning columns when listing table structure
+
 ## [5.3.0] 2024-02-14
 
 ### Changed

--- a/tests/google_big_query/test_google_big_query.py
+++ b/tests/google_big_query/test_google_big_query.py
@@ -404,7 +404,6 @@ FROM
         ON C.table_name = T.table_name
 WHERE
     IS_SYSTEM_DEFINED = 'NO'
-    AND IS_PARTITIONING_COLUMN = 'NO'
     AND IS_HIDDEN = 'NO'
 
 UNION ALL
@@ -422,7 +421,6 @@ FROM
         ON C.table_name = T.table_name
 WHERE
     IS_SYSTEM_DEFINED = 'NO'
-    AND IS_PARTITIONING_COLUMN = 'NO'
     AND IS_HIDDEN = 'NO'
 
 UNION ALL
@@ -440,7 +438,6 @@ FROM
         ON C.table_name = T.table_name
 WHERE
     IS_SYSTEM_DEFINED = 'NO'
-    AND IS_PARTITIONING_COLUMN = 'NO'
     AND IS_HIDDEN = 'NO'
 """
     )
@@ -468,7 +465,6 @@ FROM
         ON C.table_name = T.table_name
 WHERE
     IS_SYSTEM_DEFINED = 'NO'
-    AND IS_PARTITIONING_COLUMN = 'NO'
     AND IS_HIDDEN = 'NO'
 AND T.table_catalog = 'some-db'
 
@@ -487,7 +483,6 @@ FROM
         ON C.table_name = T.table_name
 WHERE
     IS_SYSTEM_DEFINED = 'NO'
-    AND IS_PARTITIONING_COLUMN = 'NO'
     AND IS_HIDDEN = 'NO'
 AND T.table_catalog = 'some-db'
 
@@ -506,7 +501,6 @@ FROM
         ON C.table_name = T.table_name
 WHERE
     IS_SYSTEM_DEFINED = 'NO'
-    AND IS_PARTITIONING_COLUMN = 'NO'
     AND IS_HIDDEN = 'NO'
 AND T.table_catalog = 'some-db'
 """
@@ -539,7 +533,6 @@ FROM
         ON C.table_name = T.table_name
 WHERE
     IS_SYSTEM_DEFINED = 'NO'
-    AND IS_PARTITIONING_COLUMN = 'NO'
     AND IS_HIDDEN = 'NO'
 AND T.table_catalog = 'some-db'
 """
@@ -654,7 +647,6 @@ FROM
         ON C.table_name = T.table_name
 WHERE
     IS_SYSTEM_DEFINED = 'NO'
-    AND IS_PARTITIONING_COLUMN = 'NO'
     AND IS_HIDDEN = 'NO'
 
 UNION ALL
@@ -672,7 +664,6 @@ FROM
         ON C.table_name = T.table_name
 WHERE
     IS_SYSTEM_DEFINED = 'NO'
-    AND IS_PARTITIONING_COLUMN = 'NO'
     AND IS_HIDDEN = 'NO'
 """
     )
@@ -694,7 +685,6 @@ FROM
         ON C.table_name = T.table_name
 WHERE
     IS_SYSTEM_DEFINED = 'NO'
-    AND IS_PARTITIONING_COLUMN = 'NO'
     AND IS_HIDDEN = 'NO'
 """
     )
@@ -716,7 +706,6 @@ FROM
         ON C.table_name = T.table_name
 WHERE
     IS_SYSTEM_DEFINED = 'NO'
-    AND IS_PARTITIONING_COLUMN = 'NO'
     AND IS_HIDDEN = 'NO'
 """
     )

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -381,7 +381,6 @@ FROM
         ON C.table_name = T.table_name
 WHERE
     IS_SYSTEM_DEFINED = 'NO'
-    AND IS_PARTITIONING_COLUMN = 'NO'
     AND IS_HIDDEN = 'NO'
 """
 


### PR DESCRIPTION
I think they were excluded by mistake in https://github.com/ToucanToco/toucan-connectors/pull/620/commits/1cc03f9e237537576afc3c7386e67c3370a9a009