### PR TITLE
fix(deps): tune dependabot updates 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
         dependency-type: "production"
       dev-deps:
         dependency-type: "development"
+    ignore:
+      - dependency-name: "elasticsearch"
+        versions: ["8.x", "9.x"]
   # poetry LTS
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,11 +21,6 @@ updates:
     target-branch: "release/v3.23"
     allow:
       - dependency-type: "production"
-    groups:
-      prod-deps:
-        dependency-type: "production"
-      dev-deps:
-        dependency-type: "development"
   # GH actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
* Exclude `elasticsearch` from updates, as it is bound to a specific Elasticsearch version
* Do not group LTS dependency updates, as they should be done case by case (we only want security updates)