### PR TITLE
fix(oracle_sql): pass parameters to pandas read_sql as numeric parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- OracleSQL: Add variables templating support
+
 ### Fix
 
 - MySQL: An unknown exception during the status check now makes the check fail

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ or [MacOS](https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/install-m
 On macOS, to test the `postgres` connector, you need to install `postgresql` by running for instance `brew install postgres`.
 You can then install the library with `env LDFLAGS='-L/usr/local/lib -L/usr/local/opt/openssl/lib -L/usr/local/opt/readline/lib' pip install psycopg2`
 
+#### Other
+
+You can find all connectors specific documentation [here](doc/connectors)
+
 ## Testing
 
 We are using `pytest` and various packages of its ecosystem.

--- a/tests/oracle_sql/test_oracle_sql.py
+++ b/tests/oracle_sql/test_oracle_sql.py
@@ -40,7 +40,6 @@ def oracle_connector(oracle_server):
 def test_oracle_get_df(mocker: MockerFixture):
     snock = mocker.patch("cx_Oracle.connect")
     reasq = mocker.patch("pandas.read_sql")
-
     oracle_connector = OracleSQLConnector(
         name="my_oracle_sql_con", user="system", password="oracle", dsn="localhost:22/xe"
     )
@@ -51,13 +50,13 @@ def test_oracle_get_df(mocker: MockerFixture):
 
     snock.assert_called_once_with(user="system", password="oracle", dsn="localhost:22/xe")
 
-    reasq.assert_called_once_with("SELECT * FROM City", con=snock(), params=None)
+    reasq.assert_called_once_with("SELECT * FROM City", con=snock(), params=[])
 
     # With table
     reasq.reset_mock()
     oracle_connector.get_df(OracleSQLDataSource(domain="Oracle test", name="my_oracle_sql_con", table="Nation"))
 
-    reasq.assert_called_once_with("SELECT * FROM Nation", con=snock(), params=None)
+    reasq.assert_called_once_with("SELECT * FROM Nation", con=snock(), params=[])
 
     # With both: query must prevail
     reasq.reset_mock()
@@ -70,7 +69,65 @@ def test_oracle_get_df(mocker: MockerFixture):
         )
     )
 
-    reasq.assert_called_once_with("SELECT * FROM Food", con=snock(), params=None)
+    reasq.assert_called_once_with("SELECT * FROM Food", con=snock(), params=[])
+
+
+def test_oracle_get_df_with_variables(mocker):
+    """It should connect to the database and retrieve the response to the query"""
+    snock = mocker.patch("cx_Oracle.connect")
+    reasq = mocker.patch("pandas.read_sql")
+    oracle_connector = OracleSQLConnector(
+        name="my_oracle_sql_con", user="system", password="oracle", dsn="localhost:22/xe"
+    )
+    ds = OracleSQLDataSource(
+        query="SELECT * FROM City WHERE id > %(id_nb)s AND population < %(population)s;",
+        domain="Oracle test",
+        name="my_oracle_sql_con",
+        table="Cities",
+        parameters={"population": 40_000, "id_nb": 1},
+    )
+    oracle_connector.get_df(ds)
+    snock.assert_called_once_with(user="system", password="oracle", dsn="localhost:22/xe")
+    reasq.assert_called_once_with(
+        "SELECT * FROM City WHERE id > :1 AND population < :2", con=snock(), params=[1, 40_000]
+    )
+    reasq.reset_mock()
+    snock.reset_mock()
+
+    # test with array value
+    ds = OracleSQLDataSource(
+        query="SELECT * FROM City WHERE name in %(names)s AND population < %(population)s;",
+        domain="Oracle test",
+        name="my_oracle_sql_con",
+        table="Cities",
+        parameters={"population": 40_000, "names": ["Manhattan", "Kabul", "TaTaTin"]},
+    )
+    oracle_connector.get_df(ds)
+    snock.assert_called_once_with(user="system", password="oracle", dsn="localhost:22/xe")
+    reasq.assert_called_once_with(
+        "SELECT * FROM City WHERE name in (:1,:2,:3) AND population < :4",
+        con=snock(),
+        params=["Manhattan", "Kabul", "TaTaTin", 40_000],
+    )
+
+
+def test_oracle_get_df_with_variables_jinja_syntax(mocker):
+    """It should connect to the database and retrieve the response to the query"""
+    snock = mocker.patch("cx_Oracle.connect")
+    reasq = mocker.patch("pandas.read_sql")
+    oracle_connector = OracleSQLConnector(
+        name="my_oracle_sql_con", user="system", password="oracle", dsn="localhost:22/xe"
+    )
+    ds = OracleSQLDataSource(
+        query="SELECT * FROM City WHERE name = {{ user.attributes.address.city }};",
+        domain="Oracle test",
+        name="my_oracle_sql_con",
+        table="Cities",
+        parameters={"user": {"attributes": {"address": {"city": "Toulouse", "country": "FR"}}}},
+    )
+    oracle_connector.get_df(ds)
+    snock.assert_called_once_with(user="system", password="oracle", dsn="localhost:22/xe")
+    reasq.assert_called_once_with("SELECT * FROM City WHERE name = Toulouse", con=snock(), params=[])
 
 
 def test_get_df_db(oracle_connector):
@@ -92,6 +149,28 @@ def test_get_df_db(oracle_connector):
     assert set(df.columns) == {"ID", "NAME", "COUNTRYCODE", "DISTRICT", "POPULATION"}
 
     assert len(df[df["POPULATION"] > 500000]) == 5
+
+
+def test_get_df_db_with_variable(oracle_connector):
+    """It should extract the table City and make some merge with some foreign key"""
+    data_sources_spec = [
+        {
+            "domain": "Oracle test",
+            "type": "external_database",
+            "name": "my_oracle_sql_con",
+            "query": "SELECT * FROM City WHERE population < %(population)s;",
+            "parameters": {"population": 2346},
+        }
+    ]
+
+    data_source = OracleSQLDataSource(**data_sources_spec[0])
+    df = oracle_connector.get_df(data_source)
+
+    assert not df.empty
+    assert df.shape == (1, 5)
+    assert set(df.columns) == {"ID", "NAME", "COUNTRYCODE", "DISTRICT", "POPULATION"}
+    assert len(df) == 1
+    assert df["POPULATION"][0] == 2345
 
 
 def test_get_form_empty_query(oracle_connector):

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -341,7 +341,7 @@ def convert_to_qmark_paramstyle(query_string: str, params_values: dict) -> tuple
 
 
 def convert_to_numeric_paramstyle(query_string: str, params_values: dict) -> tuple[str, tuple[Any]]:
-    """Takes a query in pyformat paramstyle and transforms it in numbered paramstyle
+    """Takes a query in pyformat paramstyle and transforms it in numeric paramstyle
        by replacing placeholders by :n and returning values in right order
     ex :
         ('select * from test where id > %(id_nb)s and price > %(price)s;', {"id_nb":1, "price":10}

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -340,7 +340,7 @@ def convert_to_qmark_paramstyle(query_string: str, params_values: dict) -> tuple
     return re.sub(RE_NAMED_PARAM, "?", query_string), flattened_values
 
 
-def convert_to_numbered_vars_paramstyle(query_string: str, params_values: dict) -> tuple[str, tuple[Any]]:
+def convert_to_numeric_paramstyle(query_string: str, params_values: dict) -> tuple[str, tuple[Any]]:
     """Takes a query in pyformat paramstyle and transforms it in numbered paramstyle
        by replacing placeholders by :n and returning values in right order
     ex :
@@ -446,7 +446,7 @@ def pandas_read_sql(
     adapt_params: bool = False,
     convert_to_qmark: bool = False,
     convert_to_printf: bool = True,
-    convert_to_numbered: bool = False,
+    convert_to_numeric: bool = False,
     render_user: bool = False,
     **kwargs,
 ) -> pd.DataFrame:
@@ -456,8 +456,8 @@ def pandas_read_sql(
         query = Template(query).render({"user": params.get("user", {})})
     if convert_to_qmark:
         query, params = convert_to_qmark_paramstyle(query, params)
-    if convert_to_numbered:
-        query, params = convert_to_numbered_vars_paramstyle(query, params)
+    if convert_to_numeric:
+        query, params = convert_to_numeric_paramstyle(query, params)
     if adapt_params:
         params = adapt_param_type(params)
 

--- a/toucan_connectors/oracle_sql/oracle_sql_connector.py
+++ b/toucan_connectors/oracle_sql/oracle_sql_connector.py
@@ -86,7 +86,8 @@ class OracleSQLConnector(ToucanConnector, data_source_model=OracleSQLDataSource)
             con=connection,
             params=query_params,
             render_user=True,
-            convert_to_numbered=True,
+            convert_to_numeric=True,
+            convert_to_printf=False,
         )
 
         connection.close()

--- a/toucan_connectors/oracle_sql/oracle_sql_connector.py
+++ b/toucan_connectors/oracle_sql/oracle_sql_connector.py
@@ -80,7 +80,14 @@ class OracleSQLConnector(ToucanConnector, data_source_model=OracleSQLDataSource)
         connection = cx_Oracle.connect(**self.get_connection_params())
 
         query = data_source.query[:-1] if data_source.query.endswith(";") else data_source.query
-        df = pandas_read_sql(query, con=connection)
+        query_params = data_source.parameters or {}
+        df = pandas_read_sql(
+            query,
+            con=connection,
+            params=query_params,
+            render_user=True,
+            convert_to_numbered=True,
+        )
 
         connection.close()
 


### PR DESCRIPTION
## Change Summary

 - OracleSQL: pass parameters as numeric to `read_sql`
