### PR TITLE
fix(athena): correct interpolation for parameters [TCTC-9024]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,12 @@ jobs:
       env:
         BEARER_API_KEY: ${{ secrets.BEARER_API_KEY }}
         BEARER_AIRCALL_AUTH_ID: ${{ secrets.BEARER_AIRCALL_AUTH_ID }}
+        # Athena
+        ATHENA_OUTPUT: '${{ secrets.ATHENA_OUTPUT }}'
+        ATHENA_DATABASE: '${{ secrets.ATHENA_DATABASE }}'
+        ATHENA_ACCESS_KEY_ID: '${{ secrets.ATHENA_ACCESS_KEY_ID }}'
+        ATHENA_SECRET_ACCESS_KEY: '${{ secrets.ATHENA_SECRET_ACCESS_KEY }}'
+        ATHENA_REGION: '${{ secrets.ATHENA_REGION }}'
 
     - name: SonarCloud Scan
       # Only executed for one of the tested python version and pandas version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fix
+
+- Athena: params are now correctly interpolated
+
 ## [6.3.2] 2024-07-17
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,7 @@ warn_unused_ignores = true
 ignore_missing_imports = true
 files = [
       "toucan_connectors/auth.py",
+      "toucan_connectors/awsathena/awsathena_connector.py",
       "toucan_connectors/google_big_query/google_big_query_connector.py",
       "toucan_connectors/hubspot_private_app/hubspot_connector.py",
       "toucan_connectors/mongo/mongo_connector.py",

--- a/tests/awsathena/test_athena_integration.py
+++ b/tests/awsathena/test_athena_integration.py
@@ -1,0 +1,164 @@
+import os
+from typing import Any
+
+import pandas as pd
+import pytest
+from pandas.core.dtypes.common import is_float_dtype, is_object_dtype
+from pandas.testing import assert_frame_equal
+
+from toucan_connectors.awsathena.awsathena_connector import AwsathenaConnector, AwsathenaDataSource
+
+
+@pytest.fixture
+def athena_connector() -> AwsathenaConnector:
+    return AwsathenaConnector(
+        name="test-athena",
+        s3_output_bucket=os.environ.get("ATHENA_OUTPUT"),
+        aws_access_key_id=os.environ.get("ATHENA_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.environ.get("ATHENA_SECRET_ACCESS_KEY"),
+        region_name=os.environ.get("ATHENA_REGION"),
+    )
+
+
+def _athena_datasource(query: str, parameters: dict[str, Any] | None = None) -> AwsathenaDataSource:
+    return AwsathenaDataSource(
+        name="test-athena-datasource",
+        domain="test-domain",
+        database=os.environ.get("ATHENA_DATABASE"),
+        use_ctas=False,
+        query=query,
+        parameters=parameters,
+    )
+
+
+@pytest.fixture
+def expected_beers() -> pd.DataFrame:
+    df = pd.DataFrame(
+        {
+            "price_per_l": [
+                0.1599999964237213,
+                0.05400000140070915,
+                0.004999999888241291,
+                0.0560000017285347,
+                0.07000000029802322,
+                0.004999999888241291,
+                0.04500000178813934,
+                0.08399999886751175,
+                0.06499999761581421,
+                0.05999999865889549,
+            ],
+            "alcohol_degree": [
+                13.5,
+                4.877377033233643,
+                0.5699344873428345,
+                6.994105339050293,
+                8.930644989013672,
+                1.2437106370925903,
+                4.717409610748291,
+                12.974271774291992,
+                7.74746561050415,
+                8.749608993530273,
+            ],
+            "name": [
+                "Superstrong beer",
+                "Ninkasi Ploploplop",
+                "Brewdog Nanny State Alcoholvrij",
+                "Ardwen Blonde",
+                "Cuvée des Trolls",
+                "Weihenstephan Hefe Weizen Alcoholarm",
+                "Bellfield Lawless Village IPA",
+                "Pauwel Kwak",
+                "Brasserie De Sutter Brin de Folie",
+                "Brugse Zot blonde",
+            ],
+            "cost": [
+                2.890000104904175,
+                2.890000104904175,
+                2.2899999618530273,
+                2.0899999141693115,
+                1.5499999523162842,
+                1.590000033378601,
+                2.490000009536743,
+                1.690000057220459,
+                2.190000057220459,
+                1.7899999618530273,
+            ],
+            "beer_kind": [
+                "Triple",
+                "India Pale Ale",
+                "Sans alcool",
+                "Best-sellers",
+                "Blonde",
+                "Blanche & Weizen",
+                "India Pale Ale",
+                "Belge blonde forte & Golden Ale",
+                "Blonde",
+                "Blonde",
+            ],
+            "volume_ml": [330.0, 330.0, 330.0, 330.0, 250.0, 500.0, 330.0, 330.0, 330.0, 330.0],
+            "brewing_date": [
+                pd.Timestamp("2022-01-01 00:00:00"),
+                pd.Timestamp("2022-01-02 00:00:00"),
+                pd.Timestamp("2022-01-03 00:00:00"),
+                pd.Timestamp("2022-01-04 00:00:00"),
+                pd.Timestamp("2022-01-05 00:00:00"),
+                pd.Timestamp("2022-01-06 00:00:00"),
+                pd.Timestamp("2022-01-07 00:00:00"),
+                pd.Timestamp("2022-01-08 00:00:00"),
+                pd.Timestamp("2022-01-09 00:00:00"),
+                pd.Timestamp("2022-01-10 00:00:00"),
+            ],
+            "nullable_name": [
+                None,
+                "Ninkasi Ploploplop",
+                "Brewdog Nanny State Alcoholvrij",
+                "Ardwen Blonde",
+                None,
+                "Weihenstephan Hefe Weizen Alcoholarm",
+                "Bellfield Lawless Village IPA",
+                "Pauwel Kwak",
+                None,
+                "Brugse Zot blonde",
+            ],
+        }
+    )
+    for col_name, dtype in df.dtypes.items():
+        if is_float_dtype(dtype):
+            df[col_name] = df[col_name].astype("float32")
+        elif is_object_dtype(dtype):
+            df[col_name] = df[col_name].astype("string")
+
+    return df
+
+
+def test_simple_query(athena_connector: AwsathenaConnector, expected_beers: pd.DataFrame) -> None:
+    result = athena_connector.get_df(data_source=_athena_datasource("SELECT * FROM beers_tiny"))
+    assert_frame_equal(expected_beers, result)
+
+
+def test_simple_query_with_parameters(athena_connector: AwsathenaConnector, expected_beers: pd.DataFrame) -> None:
+    result = athena_connector.get_df(
+        data_source=_athena_datasource(
+            "SELECT * FROM beers_tiny WHERE beer_kind = {{ beer_kind }} AND COST > {{ cost }}",
+            {"beer_kind": "Blonde", "cost": 2},
+        )
+    )
+    expected = expected_beers[(expected_beers["beer_kind"] == "Blonde") & (expected_beers["cost"] > 2)].reset_index(
+        drop=True
+    )
+    assert_frame_equal(expected, result)
+
+
+def test_simple_query_with_missing_parameters(
+    athena_connector: AwsathenaConnector, expected_beers: pd.DataFrame
+) -> None:
+    result = athena_connector.get_df(
+        data_source=_athena_datasource(
+            "SELECT * FROM beers_tiny WHERE beer_kind = {{ beer_kind }} AND (COST > {{ cost }} OR name = {{ nope }})",
+            {"beer_kind": "Blonde", "cost": 2},
+        )
+    )
+    expected = expected_beers[(expected_beers["beer_kind"] == "Blonde") & (expected_beers["cost"] > 2)].reset_index(
+        drop=True
+    )
+    assert_frame_equal(expected, result)

--- a/tests/awsathena/test_awsathena.py
+++ b/tests/awsathena/test_awsathena.py
@@ -80,6 +80,7 @@ def test_get_df(
         boto3_session={"a": "b"},
         s3_output="s3://test/results/",
         ctas_approach=use_ctas,
+        paramstyle="named",
     )
 
     mocked_boto_session.assert_called_once()
@@ -107,6 +108,7 @@ def test_get_slice(mocker, athena_connector, data_source, mocked_read_sql_query,
         boto3_session={"a": "b"},
         s3_output="s3://test/results/",
         ctas_approach=False,
+        paramstyle="named",
     )
 
 
@@ -270,15 +272,16 @@ def test_no_sql_injection(athena_connector, mocker):
         query="SELECT * FROM Users WHERE UserId = {{ user_id }}",
         parameters={"user_id": "105 OR 1=1"},
     )
-    assert ds.query == "SELECT * FROM Users WHERE UserId = :__QUERY_PARAM_0__;"
+    assert ds.query == "SELECT * FROM Users WHERE UserId = :__QUERY_PARAM_0__"
     assert ds.parameters == {"user_id": "105 OR 1=1", "__QUERY_PARAM_0__": "105 OR 1=1"}
 
     athena_connector.get_df(ds)
     read_sql_mock.assert_called_once_with(
-        "SELECT * FROM Users WHERE UserId = :__QUERY_PARAM_0__;",
+        "SELECT * FROM Users WHERE UserId = :__QUERY_PARAM_0__",
         params={"user_id": "105 OR 1=1", "__QUERY_PARAM_0__": "105 OR 1=1"},
         database="db",
         boto3_session=mocker.ANY,
         s3_output=mocker.ANY,
         ctas_approach=mocker.ANY,
+        paramstyle="named",
     )

--- a/toucan_connectors/awsathena/awsathena_connector.py
+++ b/toucan_connectors/awsathena/awsathena_connector.py
@@ -62,7 +62,7 @@ class AwsathenaDataSource(ToucanDataSource):
 
 def athena_variable_transformer(variable: str):
     """Add surrounding for parameters injection"""
-    return f":{variable};"
+    return f":{variable}"
 
 
 class AwsathenaConnector(ToucanConnector, DiscoverableConnector, data_source_model=AwsathenaDataSource):
@@ -119,6 +119,7 @@ class AwsathenaConnector(ToucanConnector, DiscoverableConnector, data_source_mod
             boto3_session=self.get_session(),
             s3_output=self.s3_output_bucket,
             ctas_approach=data_source.use_ctas,
+            paramstyle="named",
         )
         return df
 


### PR DESCRIPTION
This fixes the parameter intepolation in the athena connector, which changed with awswrangler 3.0.0.

It also adds integration tests to the athena connector to avoid having hitting this kind of bug again
