### PR TITLE
feat(hubspot): allow to list and select custom datasets [TCTC-9025]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog (Pypi package)
 
+## Unreleased
+
+### Changed
+
+- Hubspot: added support for listing and selection of custom objects
+
 ## [6.4.0] 2024-07-25
 
 ### Changed

--- a/tests/hubspot_private_app/test_hubspot.py
+++ b/tests/hubspot_private_app/test_hubspot.py
@@ -1,15 +1,15 @@
 from datetime import datetime
 from typing import Any
-from unittest.mock import MagicMock, call
+from unittest.mock import ANY, MagicMock, call
 
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal as pd_assert_frame_equal
 from pytest_mock import MockFixture
 
+from toucan_connectors.hubspot_private_app import hubspot_connector as connector_module
 from toucan_connectors.hubspot_private_app.hubspot_connector import (
     HubspotConnector,
-    HubspotDataset,
     HubspotDataSource,
 )
 
@@ -95,18 +95,13 @@ def hubspot_all_results(hubspot_full_page: _DictableDict) -> list[_DictableDict]
 
 
 @pytest.fixture
-def hubspot_client(mocker: MockFixture) -> MagicMock:
-    basic_api = MagicMock()
-    api = MagicMock()
-    api.basic_api = basic_api
+def get_all_mock(mocker: MockFixture) -> MagicMock:
+    return mocker.patch.object(connector_module, "_get_all")
 
-    mocker.patch.object(HubspotConnector, "_api_for_dataset", return_value=api)
-    mocker.patch(
-        "toucan_connectors.hubspot_private_app.hubspot_connector._page_api_for",
-        return_value=basic_api,
-    )
 
-    return api
+@pytest.fixture
+def get_page_mock(mocker: MockFixture) -> MagicMock:
+    return mocker.patch.object(connector_module, "_get_page")
 
 
 @pytest.fixture
@@ -144,119 +139,130 @@ def hubspot_connector() -> HubspotConnector:
 
 @pytest.fixture
 def hubspot_data_source() -> HubspotDataSource:
-    return HubspotDataSource(name="hubspot", domain="coucou", dataset=HubspotDataset.contacts)
+    return HubspotDataSource(name="hubspot", domain="coucou", dataset="contacts")
 
 
 def test_get_df(
+    mocker: MockFixture,
     hubspot_connector: HubspotConnector,
     hubspot_data_source: HubspotDataSource,
-    hubspot_client: MagicMock,
+    get_all_mock: MagicMock,
     hubspot_all_results: list[_DictableDict],
     expected_df: pd.DataFrame,
 ):
-    hubspot_client.get_all.return_value = hubspot_all_results
+    get_all_mock.return_value = hubspot_all_results
 
     assert_frame_equal(hubspot_connector.get_df(hubspot_data_source), expected_df)
-    hubspot_client.get_all.assert_called_once()
+    get_all_mock.assert_called_once()
 
 
 def test_get_slice_no_limit_or_offset(
     hubspot_connector: HubspotConnector,
     hubspot_data_source: HubspotDataSource,
-    hubspot_client: MagicMock,
+    get_all_mock: MagicMock,
+    get_page_mock: MagicMock,
     hubspot_all_results: list[_DictableDict],
     expected_df: pd.DataFrame,
 ):
-    hubspot_client.get_all.return_value = hubspot_all_results
+    get_all_mock.return_value = hubspot_all_results
 
     result = hubspot_connector.get_slice(hubspot_data_source)
     assert_frame_equal(result.df, expected_df)
 
     # Since no limit was specified, we should have called get_all
-    hubspot_client.basic_api.get_page.assert_not_called()
-    hubspot_client.get_all.assert_called_once()
+    get_page_mock.assert_not_called()
+    get_all_mock.assert_called_once()
 
 
 def test_get_slice_with_offset_and_limit_greater_than_results(
     hubspot_connector: HubspotConnector,
     hubspot_data_source: HubspotDataSource,
-    hubspot_client: MagicMock,
+    get_all_mock: MagicMock,
+    get_page_mock: MagicMock,
     hubspot_full_page: _DictableDict,
     expected_df: pd.DataFrame,
 ):
-    hubspot_client.basic_api.get_page.return_value = hubspot_full_page
+    get_page_mock.return_value = hubspot_full_page
 
     result = hubspot_connector.get_slice(hubspot_data_source, offset=1, limit=2)
     assert_frame_equal(result.df, expected_df[1:].reset_index(drop=True))
 
-    hubspot_client.basic_api.get_page.assert_called_once()
-    hubspot_client.get_all.assert_not_called()
+    get_page_mock.assert_called_once()
+    get_all_mock.assert_not_called()
 
 
 def test_get_slice_with_offset_only(
     hubspot_connector: HubspotConnector,
     hubspot_data_source: HubspotDataSource,
-    hubspot_client: MagicMock,
+    get_all_mock: MagicMock,
+    get_page_mock: MagicMock,
     hubspot_all_results: list[_DictableDict],
     expected_df: pd.DataFrame,
 ):
-    hubspot_client.get_all.return_value = hubspot_all_results
+    get_all_mock.return_value = hubspot_all_results
 
     result = hubspot_connector.get_slice(hubspot_data_source, offset=1)
     assert_frame_equal(result.df, expected_df[1:].reset_index(drop=True))
 
-    hubspot_client.basic_api.get_page.assert_not_called()
-    hubspot_client.get_all.assert_called_once()
+    get_page_mock.assert_not_called()
+    get_all_mock.assert_called_once()
 
 
 def test_get_slice_with_offset_and_limit_in_bounds(
     hubspot_connector: HubspotConnector,
     hubspot_data_source: HubspotDataSource,
-    hubspot_client: MagicMock,
+    get_all_mock: MagicMock,
+    get_page_mock: MagicMock,
     hubspot_first_page: _DictableDict,
     hubspot_second_page: _DictableDict,
     expected_df: pd.DataFrame,
 ):
-    hubspot_client.basic_api.get_page.side_effect = [hubspot_first_page, hubspot_second_page]
+    get_page_mock.side_effect = [hubspot_first_page, hubspot_second_page]
 
     result = hubspot_connector.get_slice(hubspot_data_source, offset=1, limit=1)
     assert_frame_equal(result.df, expected_df[1:].reset_index(drop=True))
 
-    assert hubspot_client.basic_api.get_page.call_args_list == [
-        call(after=None, limit=1, properties=[]),
-        call(after="1", limit=1, properties=[]),
+    assert get_page_mock.call_args_list == [
+        call(client=ANY, dataset=hubspot_data_source.dataset, after=None, limit=1, properties=[]),
+        call(client=ANY, dataset=hubspot_data_source.dataset, after="1", limit=1, properties=[]),
     ]
-    hubspot_client.get_all.assert_not_called()
+    get_all_mock.assert_not_called()
 
 
 def test_get_slice_with_offset_out_of_bounds(
     hubspot_connector: HubspotConnector,
     hubspot_data_source: HubspotDataSource,
-    hubspot_client: MagicMock,
+    get_all_mock: MagicMock,
+    get_page_mock: MagicMock,
     hubspot_second_page: _DictableDict,
 ):
-    hubspot_client.basic_api.get_page.side_effect = [hubspot_second_page]
+    get_page_mock.side_effect = [hubspot_second_page]
 
     result = hubspot_connector.get_slice(hubspot_data_source, offset=140, limit=1000)
     assert_frame_equal(result.df, pd.DataFrame())
 
-    hubspot_client.get_all.assert_not_called()
+    get_all_mock.assert_not_called()
     # Limit should have been truncated to 100 results
-    assert hubspot_client.basic_api.get_page.call_args_list == [call(after=None, limit=100, properties=[])]
+    assert get_page_mock.call_args_list == [
+        call(client=ANY, dataset=hubspot_data_source.dataset, after=None, limit=100, properties=[])
+    ]
 
 
 def test_get_slice_has_the_right_behaviour_even_when_too_many_results_are_returned(
     hubspot_connector: HubspotConnector,
     hubspot_data_source: HubspotDataSource,
-    hubspot_client: MagicMock,
+    get_all_mock: MagicMock,
+    get_page_mock: MagicMock,
     hubspot_full_page: _DictableDict,
     expected_df: pd.DataFrame,
 ):
-    hubspot_client.basic_api.get_page.return_value = hubspot_full_page
+    get_page_mock.return_value = hubspot_full_page
 
     result = hubspot_connector.get_slice(hubspot_data_source, offset=0, limit=1)
     assert_frame_equal(result.df, expected_df[:1])
 
-    hubspot_client.get_all.assert_not_called()
+    get_all_mock.assert_not_called()
     # Limit should have been truncated to 100 results
-    assert hubspot_client.basic_api.get_page.call_args_list == [call(after=None, limit=1, properties=[])]
+    assert get_page_mock.call_args_list == [
+        call(client=ANY, dataset=hubspot_data_source.dataset, after=None, limit=1, properties=[])
+    ]

--- a/tests/hubspot_private_app/test_hubspot.py
+++ b/tests/hubspot_private_app/test_hubspot.py
@@ -9,6 +9,7 @@ from pytest_mock import MockFixture
 
 from toucan_connectors.hubspot_private_app import hubspot_connector as connector_module
 from toucan_connectors.hubspot_private_app.hubspot_connector import (
+    HUBSPOT_DEFAULT_DATASETS,
     HubspotConnector,
     HubspotDataSource,
 )
@@ -266,3 +267,15 @@ def test_get_slice_has_the_right_behaviour_even_when_too_many_results_are_return
     assert get_page_mock.call_args_list == [
         call(client=ANY, dataset=hubspot_data_source.dataset, after=None, limit=1, properties=[])
     ]
+
+
+def test_get_form(
+    hubspot_connector: HubspotConnector,
+    hubspot_data_source: HubspotDataSource,
+    mocker: MockFixture,
+):
+    mocker.patch.object(HubspotConnector, "get_custom_objects", return_value=["myobject"])
+    form = hubspot_data_source.get_form(hubspot_connector, None)
+
+    assert "myobject" in str(form)
+    assert all(dataset in str(form) for dataset in HUBSPOT_DEFAULT_DATASETS)

--- a/toucan_connectors/hubspot_private_app/hubspot_connector.py
+++ b/toucan_connectors/hubspot_private_app/hubspot_connector.py
@@ -1,10 +1,10 @@
+from contextlib import suppress
 from datetime import datetime
-from enum import Enum
 from typing import Any, Generator, Protocol, TypeAlias
 
 import pandas as pd
 from hubspot import HubSpot
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, create_model
 
 from toucan_connectors.pagination import build_pagination_info
 from toucan_connectors.toucan_connector import (
@@ -12,20 +12,24 @@ from toucan_connectors.toucan_connector import (
     PlainJsonSecretStr,
     ToucanConnector,
     ToucanDataSource,
+    strlist_to_enum,
 )
 
-
-class HubspotDataset(str, Enum):
-    contacts = "contacts"
-    companies = "companies"
-    deals = "deals"
-    quotes = "quotes"
-    owners = "owners"
+HUBSPOT_DEFAULT_DATASETS = ["contacts", "companies", "deals", "quotes", "owners"]
 
 
 class HubspotDataSource(ToucanDataSource):
-    dataset: HubspotDataset
+    dataset: str = Field(..., title="Dataset", description="The dataset to extract the data from")
     properties: list[str] = Field(default_factory=list, description="List of all properties you want to retrieve")
+
+    @classmethod
+    def get_form(cls, connector: "HubspotConnector", current_config, **kwargs):
+        constraints: Any = {"dataset": strlist_to_enum("dataset", HUBSPOT_DEFAULT_DATASETS)}
+        with suppress(Exception):
+            # try to retrieve user's custom defined objects
+            available_custom_objects = connector.get_custom_objects()
+            constraints["dataset"] = strlist_to_enum("dataset", HUBSPOT_DEFAULT_DATASETS + available_custom_objects)
+        return create_model("FormSchema", **constraints, __base__=cls).schema()
 
 
 class _HubSpotPagingNext(BaseModel):
@@ -66,51 +70,38 @@ class _HubSpotObject(Protocol):  # pragma: no cover
     def to_dict(self) -> _RawHubSpotResult: ...
 
 
-class _PageApi(Protocol):  # pragma: no cover
-    def get_page(self, after: str | None, limit: int | None, properties: list[str]) -> _HubSpotObject: ...
+def _get_all(client: HubSpot, dataset: str) -> list[_HubSpotObject]:
+    return client.crm.objects.get_all(dataset)
 
 
-class _Api(Protocol):  # pragma: no cover
-    @property
-    def basic_api(self) -> _PageApi: ...
-
-    def get_all(self, properties: list[str]) -> list[_HubSpotObject]: ...
-
-
-def _page_api_for(api: _Api, dataset: HubspotDataset) -> _PageApi:  # pragma: no cover
-    """Some clients have a '{name}_api' attribute.
-
-    basic_api seems to be the default fallback
-    """
-    page_api_name = dataset.value + "_api"
-    if hasattr(api, page_api_name):
-        return getattr(api, page_api_name)
-    return api.basic_api
+def _get_page(
+    client: HubSpot, dataset: str, after: str | None, limit: int | None, properties: list[str]
+) -> _HubSpotObject:
+    return client.crm.objects.basic_api.get_page(dataset, after=after, limit=limit, properties=properties)
 
 
 class HubspotConnector(ToucanConnector, data_source_model=HubspotDataSource):
     access_token: PlainJsonSecretStr = Field(..., description="An API key for the target private app")
 
     def _fetch_page(
-        self, api: _PageApi, properties: list[str], after: str | None = None, limit: int | None = None
+        self, dataset: str, properties: list[str], after: str | None = None, limit: int | None = None
     ) -> _HubSpotResponse:
-        page = api.get_page(after=after, limit=limit, properties=properties)
+        client = HubSpot(access_token=self.access_token.get_secret_value())
+        page = _get_page(client=client, dataset=dataset, after=after, limit=limit, properties=properties)
         return _HubSpotResponse(**page.to_dict())
 
-    def _fetch_all(self, api: _Api, properties: list[str]) -> list[_HubSpotResult]:
-        results = api.get_all(properties=properties)
+    def _fetch_all(self, dataset: str, properties: list[str]) -> list[_HubSpotResult]:
+        client = HubSpot(access_token=self.access_token.get_secret_value())
+        results = _get_all(client=client, dataset=dataset)
         return [_HubSpotResult(**elem.to_dict()) for elem in results]
 
-    def _api_for_dataset(self, object_type: HubspotDataset) -> _Api:  # pragma: no cover
-        client = HubSpot(access_token=self.access_token.get_secret_value())
-        return getattr(client.crm, object_type.value)
-
     def _retrieve_data(self, data_source: HubspotDataSource) -> pd.DataFrame:
-        api = self._api_for_dataset(data_source.dataset)
-        return pd.DataFrame(r.to_dict() for r in self._fetch_all(api, properties=data_source.properties))
+        return pd.DataFrame(
+            r.to_dict() for r in self._fetch_all(data_source.dataset, properties=data_source.properties)
+        )
 
     def _result_iterator(
-        self, api: _PageApi, properties: list[str], max_results: int | None, limit: int | None
+        self, dataset: str, properties: list[str], max_results: int | None, limit: int | None
     ) -> Generator[_HubSpotResult, None, None]:
         after = None
         count = 0
@@ -118,7 +109,7 @@ class HubspotConnector(ToucanConnector, data_source_model=HubspotDataSource):
         if limit is not None:
             limit = min(limit, 100)
         while True:
-            page = self._fetch_page(api, properties=properties, after=after, limit=limit)
+            page = self._fetch_page(dataset=dataset, properties=properties, after=after, limit=limit)
             for result in page.results:
                 if max_results is not None and count >= max_results:
                     return
@@ -140,11 +131,9 @@ class HubspotConnector(ToucanConnector, data_source_model=HubspotDataSource):
             df = self._retrieve_data(data_source)[offset:].reset_index(drop=True)
 
         else:
-            api = self._api_for_dataset(data_source.dataset)
-            page_api = _page_api_for(api, data_source.dataset)
             results = []
             result_iterator = self._result_iterator(
-                page_api,
+                dataset=data_source.dataset,
                 properties=data_source.properties,
                 max_results=offset + (limit or 0),
                 limit=limit,
@@ -161,3 +150,7 @@ class HubspotConnector(ToucanConnector, data_source_model=HubspotDataSource):
             df=df,
             pagination_info=build_pagination_info(offset=offset, limit=limit, retrieved_rows=len(df), total_rows=None),
         )
+
+    def get_custom_objects(self) -> list[str]:
+        client = HubSpot(access_token=self.access_token.get_secret_value())
+        return [obj.fully_qualified_name for obj in client.crm.schemas.core_api.get_all().results]

--- a/toucan_connectors/hubspot_private_app/hubspot_connector.py
+++ b/toucan_connectors/hubspot_private_app/hubspot_connector.py
@@ -70,13 +70,13 @@ class _HubSpotObject(Protocol):  # pragma: no cover
     def to_dict(self) -> _RawHubSpotResult: ...
 
 
-def _get_all(client: HubSpot, dataset: str) -> list[_HubSpotObject]:
+def _get_all(client: HubSpot, dataset: str) -> list[_HubSpotObject]:  # pragma: no cover
     return client.crm.objects.get_all(dataset)
 
 
 def _get_page(
     client: HubSpot, dataset: str, after: str | None, limit: int | None, properties: list[str]
-) -> _HubSpotObject:
+) -> _HubSpotObject:  # pragma: no cover
     return client.crm.objects.basic_api.get_page(dataset, after=after, limit=limit, properties=properties)
 
 
@@ -151,6 +151,6 @@ class HubspotConnector(ToucanConnector, data_source_model=HubspotDataSource):
             pagination_info=build_pagination_info(offset=offset, limit=limit, retrieved_rows=len(df), total_rows=None),
         )
 
-    def get_custom_objects(self) -> list[str]:
+    def get_custom_objects(self) -> list[str]:  # pragma: no cover
         client = HubSpot(access_token=self.access_token.get_secret_value())
         return [obj.fully_qualified_name for obj in client.crm.schemas.core_api.get_all().results]


### PR DESCRIPTION
Add ability to list and select custom datasets.
I slightly refactored the api so "classic" datasets are handled the same way as custom datasets (using `client.crm.objects`).