### PR TITLE
feat: improve performance of DiscoverableConnector.format_db_model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- DiscoverableConnector: `format_db_model` is now roughly 3x faster, resulting in performance gains in `get_model`
+
 ## [6.5.0] 2024-07-31
 
 ### Changed

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -480,7 +480,7 @@ class DiscoverableConnector(ABC):
             pass
         return (
             df.groupby(by=["schema", "database", "type", "name"])["columns"]  # type: ignore[return-value]
-            .apply(sum)
+            .sum()
             .reset_index()
             .to_dict("records")
         )


### PR DESCRIPTION
Rather than using python's `sum` built-in with `apply`, directly rely on pandas' `sum` to concatenate Series.

Results in a ~3x speed-up of the format_db_model method
