### PR TITLE
feat: add token_header_name option to http connectors (TCTC-8945)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- HTTP connectors with `CustomTokenServer` authentication accept `token_header_name` kwargs. It allows to override the default `Authorization` header.  
+
 ## [6.6.0] 2024-08-23
 
 ### Changed

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -60,6 +60,27 @@ def test_custom_token_server_custom_auth_scheme():
 
 
 @responses.activate
+def test_custom_token_server_custom_auth_scheme_and_header_name():
+    auth = Auth(
+        type="custom_token_server",
+        args=["POST", "https://example.com"],
+        kwargs={
+            "data": {"user": "u", "password ": "p"},
+            "filter": '"CustomScheme \(.data.toucan_token)"',  # noqa: W605
+            "token_header_name": "CustomAuthorization",
+        },
+    )
+
+    session = auth.get_session()
+    assert isinstance(session.auth, CustomTokenServer)
+
+    responses.add(responses.POST, "https://example.com", json={"data": {"toucan_token": "1234567"}})
+
+    session.auth(DummyRequest())
+    assert DummyRequest.headers["CustomAuthorization"] == "CustomScheme 1234567"
+
+
+@responses.activate
 def test_custom_token_server_initial_basic():
     """
     Custom_token_server with its own auth class for the initial request

--- a/toucan_connectors/auth.py
+++ b/toucan_connectors/auth.py
@@ -54,7 +54,18 @@ class CustomTokenServer(AuthBase):
     Get a token from a request to a custom token server.
     """
 
-    def __init__(self, method, url, params=None, data=None, headers=None, auth=None, json=None, filter="."):
+    def __init__(
+        self,
+        method,
+        url,
+        params=None,
+        data=None,
+        headers=None,
+        auth=None,
+        json=None,
+        filter=".",
+        token_header_name: str = "Authorization",  # noqa: S107
+    ):
         self.request_kwargs = {
             "method": method,
             "url": url,
@@ -65,6 +76,7 @@ class CustomTokenServer(AuthBase):
         }
         self.auth = auth
         self.filter = filter
+        self.token_header_name = token_header_name
 
     def __call__(self, r):
         if self.auth:
@@ -77,10 +89,11 @@ class CustomTokenServer(AuthBase):
 
         # If a single string is returned by the filter default
         # on OAuth "Bearer" auth-scheme.
+
         if len(f"{token}".split(maxsplit=2)) == 1:
             token = f"Bearer {token}"
 
-        r.headers["Authorization"] = token
+        r.headers[self.token_header_name] = token
         return r
 
 

--- a/toucan_connectors/auth.py
+++ b/toucan_connectors/auth.py
@@ -89,7 +89,6 @@ class CustomTokenServer(AuthBase):
 
         # If a single string is returned by the filter default
         # on OAuth "Bearer" auth-scheme.
-
         if len(f"{token}".split(maxsplit=2)) == 1:
             token = f"Bearer {token}"
 


### PR DESCRIPTION
## Change Summary

- Adds `token_header_name` option to `CustomServerToken` authentication method.