### PR TITLE
fix(mysql): get_model now supports extra kwargs so it doesnt crash [TCTC-9223]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fix
+
+- MySQL / Redshift / Snowflake oAuth2 :: `get_model` now supports extra kwargs so it doesn't crash
+
 ## [7.0.0] 2024-09-06
 
 ### Changed

--- a/poetry.lock
+++ b/poetry.lock
@@ -3872,6 +3872,17 @@ files = [
 ]
 
 [[package]]
+name = "types-pymysql"
+version = "1.1.0.20240524"
+description = "Typing stubs for PyMySQL"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "types-PyMySQL-1.1.0.20240524.tar.gz", hash = "sha256:93058fef2077c407e29bdcd1a7dfbbf06a59324a5440df30dd002f572199ac17"},
+    {file = "types_PyMySQL-1.1.0.20240524-py3-none-any.whl", hash = "sha256:8be5be228bf6376f9055ec03bec0dfa6f1a84163f9a89305db446f0b31f87be3"},
+]
+
+[[package]]
 name = "types-pyopenssl"
 version = "24.1.0.20240722"
 description = "Typing stubs for pyOpenSSL"
@@ -3970,7 +3981,7 @@ files = [
 name = "tzdata"
 version = "2022.2"
 description = "Provider of IANA time zone data"
-optional = true
+optional = false
 python-versions = ">=2"
 files = [
     {file = "tzdata-2022.2-py2.py3-none-any.whl", hash = "sha256:c3119520447d68ef3eb8187a55a4f44fa455f30eb1b4238fa5691ba094f2b05b"},
@@ -4372,4 +4383,4 @@ soap = ["lxml", "pandas", "pandas", "zeep"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "b70cce022f3884fe363ce3f9fa5d1984d7fe4be664e35b189831850ba5363eb9"
+content-hash = "520cd51c1b5b998ed15401ec869500fae3638f6efdf346fb64b44ea461d599e1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ types-pyopenssl = "^24.1.0.20240722"
 types-python-slugify = "^8.0.2.20240310"
 types-requests = "^2.31.0.6"
 types-simplejson = "^3.19.0.20240801"
+types-pymysql = "^1.1.0.20240524"
 
 [tool.poetry.extras]
 awsathena = ["awswrangler", "pandas"]
@@ -166,6 +167,7 @@ files = [
     "toucan_connectors/mongo/mongo_connector.py",
     "toucan_connectors/peakina/peakina_connector.py",
     "toucan_connectors/postgres/postgresql_connector.py",
+    "toucan_connectors/mysql/mysql_connector.py",
     "toucan_connectors/snowflake/snowflake_connector.py",
     "toucan_connectors/toucan_connector.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,8 @@ files = [
     "toucan_connectors/postgres/postgresql_connector.py",
     "toucan_connectors/mysql/mysql_connector.py",
     "toucan_connectors/snowflake/snowflake_connector.py",
+    "toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py",
+    "toucan_connectors/redshift/redshift_database_connector.py",
     "toucan_connectors/toucan_connector.py",
 ]
 

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -68,25 +68,25 @@ class MySQLDataSource(ToucanDataSource):
     """
 
     database: str = Field(..., description="The name of the database you want to query")
-    follow_relations: bool | None = Field(
+    follow_relations: bool | None = Field(  # type: ignore[pydantic-field]
         None,
-        **{"ui.hidden": True},
+        **{"ui.hidden": True},  # type: ignore[arg-type]
         description="Deprecated, kept for compatibility purpose with old data sources configs",
-    )  # Deprecated
-    table: str | None = Field(None, **{"ui.hidden": True})  # To avoid previous config migrations, won't be used
-    query: Annotated[str, StringConstraints(min_length=1)] | None = Field(
+    )
+    table: str | None = Field(None, **{"ui.hidden": True})  # type: ignore[pydantic-field,arg-type]
+    query: Annotated[str, StringConstraints(min_length=1)] | None = Field(  # type: ignore[call-arg]
         None,
         description="You can write a custom query against your "
         "database here. It will take precedence over "
         'the "table" parameter',
         widget="sql",
     )
-    query_object: dict | None = Field(
+    query_object: dict | None = Field(  # type: ignore[pydantic-field]
         None,
         description="An object describing a simple select query" "This field is used internally",
-        **{"ui.hidden": True},
+        **{"ui.hidden": True},  # type: ignore[arg-type]
     )
-    language: str = Field("sql", **{"ui.hidden": True})
+    language: str = Field("sql", **{"ui.hidden": True})  # type: ignore[pydantic-field,arg-type]
 
     @classmethod
     def get_form(cls, connector: "MySQLConnector", current_config: dict[str, Any]) -> dict:

--- a/toucan_connectors/mysql/mysql_connector.py
+++ b/toucan_connectors/mysql/mysql_connector.py
@@ -384,7 +384,13 @@ class MySQLConnector(
 
         return ConnectorStatus(status=True, details=self._get_details(3, True), error=None)
 
-    def get_model(self, db_name: str | None = None) -> list[Any]:
+    def get_model(
+        self,
+        db_name: str | None = None,
+        schema_name: str | None = None,
+        table_name: str | None = None,
+        exclude_columns: bool = False,
+    ) -> list[TableInfo]:
         """Retrieves the database tree structure using current connection"""
         return DiscoverableConnector.format_db_model(self.project_tree(db_name=db_name))
 

--- a/toucan_connectors/redshift/redshift_database_connector.py
+++ b/toucan_connectors/redshift/redshift_database_connector.py
@@ -3,7 +3,7 @@ import re
 from contextlib import suppress
 from enum import Enum
 from functools import cached_property
-from typing import Any
+from typing import Any, Type
 
 from pydantic import (
     ConfigDict,
@@ -85,19 +85,19 @@ class AuthenticationMethodError(str, Enum):
 
 class RedshiftDataSource(ToucanDataSource):
     database: str = Field(DEFAULT_DATABASE, description="The name of the database you want to query")
-    query: Annotated[str, StringConstraints(min_length=1)] = Field(
+    query: Annotated[str, StringConstraints(min_length=1)] = Field(  # type: ignore[call-arg,assignment]
         None,
         description="You can write a custom query against your "
         "database here. It will take precedence over "
         "the table parameter",
         widget="sql",
     )
-    query_object: dict[str, Any] = Field(
+    query_object: dict[str, Any] = Field(  # type: ignore[pydantic-field]
         None,
         description="An object describing a simple select query, this field is used internally",
-        **{"ui.hidden": True},
+        **{"ui.hidden": True},  # type: ignore[arg-type]
     )
-    language: str = Field("sql", **{"ui.hidden": True})
+    language: str = Field("sql", **{"ui.hidden": True})  # type: ignore[pydantic-field,arg-type]
 
     @classmethod
     def get_form(cls, connector: "RedshiftConnector", current_config: dict[str, Any]):
@@ -114,11 +114,11 @@ class RedshiftDataSource(ToucanDataSource):
 
 
 class RedshiftConnector(ToucanConnector, DiscoverableConnector, data_source_model=RedshiftDataSource):
-    authentication_method: AuthenticationMethod = Field(
+    authentication_method: AuthenticationMethod = Field(  # type: ignore[pydantic-field]
         None,
         title="Authentication Method",
         description="The authentication mechanism that will be used to connect to your redshift data source",
-        **{"ui": {"checkbox": False}},
+        **{"ui": {"checkbox": False}},  # type: ignore[arg-type]
     )
     host: str = Field(..., description="The hostname of the Amazon Redshift cluster")
     port: int = Field(5439, description="The listening port of your Redshift Database")
@@ -160,7 +160,7 @@ class RedshiftConnector(ToucanConnector, DiscoverableConnector, data_source_mode
         cls,
         by_alias: bool = True,
         ref_template: str = DEFAULT_REF_TEMPLATE,
-        schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema,
+        schema_generator: Type[GenerateJsonSchema] = GenerateJsonSchema,
         mode: JsonSchemaMode = "validation",
     ) -> dict[str, Any]:
         schema = super().model_json_schema(
@@ -271,7 +271,7 @@ class RedshiftConnector(ToucanConnector, DiscoverableConnector, data_source_mode
         permissions: dict[str, Any] | None = None,
         offset: int = 0,
         limit: int | None = None,
-        get_row_count: bool = False,
+        get_row_count: bool | None = False,
     ) -> DataSlice:
         """
         Method to retrieve a part of the data as a pandas dataframe
@@ -350,9 +350,9 @@ class RedshiftConnector(ToucanConnector, DiscoverableConnector, data_source_mode
             )
             return cursor.fetchall()
 
-    def _db_tables_info(self, database: str) -> list[tuple[str, str, str, str, str]]:
+    def _db_tables_info(self, database: str) -> list[TableInfo]:
         """Get rows of (database, schema, table name, column name, column type)"""
-        table_infos = []
+        table_infos: list[Any] = []
         for schema, table_name, column_name, column_type in self._db_table_info_rows(database):
             for row in table_infos[::-1]:
                 if row["schema"] == schema and row["name"] == table_name:
@@ -386,7 +386,13 @@ class RedshiftConnector(ToucanConnector, DiscoverableConnector, data_source_mode
 
         return tables_info
 
-    def get_model_with_info(self, db_name: str | None = None) -> tuple[list[TableInfo], dict]:
+    def get_model_with_info(
+        self,
+        db_name: str | None = None,
+        schema_name: str | None = None,
+        table_name: str | None = None,
+        exclude_columns: bool = False,
+    ) -> tuple[list[TableInfo], dict]:
         """Retrieves the database tree structure using current connection"""
         databases_tree = []
         failed_databases = []
@@ -413,6 +419,6 @@ class RedshiftConnector(ToucanConnector, DiscoverableConnector, data_source_mode
             return [db_name for (db_name,) in cursor.fetchall()]
 
     def _list_tables_info(self, database: str) -> list[tuple]:
-        with self._get_cursor(database) as cursor:
+        with self._get_connection(database=database).cursor() as cursor:
             cursor.execute(build_database_model_extraction_query())
             return cursor.fetchall()

--- a/toucan_connectors/redshift/redshift_database_connector.py
+++ b/toucan_connectors/redshift/redshift_database_connector.py
@@ -370,7 +370,13 @@ class RedshiftConnector(ToucanConnector, DiscoverableConnector, data_source_mode
                 )
         return table_infos
 
-    def get_model(self, db_name: str | None = None) -> list[TableInfo]:
+    def get_model(
+        self,
+        db_name: str | None = None,
+        schema_name: str | None = None,
+        table_name: str | None = None,
+        exclude_columns: bool = False,
+    ) -> list[TableInfo]:
         """Retrieves the database tree structure using current connection"""
         tables_info = []
         dbs = self.available_dbs if db_name is None else [db_name]

--- a/toucan_connectors/redshift/redshift_database_connector.py
+++ b/toucan_connectors/redshift/redshift_database_connector.py
@@ -418,7 +418,7 @@ class RedshiftConnector(ToucanConnector, DiscoverableConnector, data_source_mode
             )
             return [db_name for (db_name,) in cursor.fetchall()]
 
-    def _list_tables_info(self, database: str) -> list[tuple]:
+    def _list_tables_info(self, database: str) -> list[tuple]:  # pragma: no cover
         with self._get_connection(database=database).cursor() as cursor:
             cursor.execute(build_database_model_extraction_query())
             return cursor.fetchall()

--- a/toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py
+++ b/toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py
@@ -24,6 +24,7 @@ from toucan_connectors.toucan_connector import (
     DataSlice,
     DiscoverableConnector,
     PlainJsonSecretStr,
+    TableInfo,
     ToucanConnector,
     strlist_to_enum,
 )
@@ -287,7 +288,13 @@ class SnowflakeoAuth2Connector(ToucanConnector, data_source_model=SnowflakeoAuth
         with self._get_connection(database=database, warehouse=self.default_warehouse) as connection:
             db_contents += SnowflakeCommon().get_db_content(connection).to_dict("records")
 
-    def get_model(self, db_name: str | None = None):
+    def get_model(
+        self,
+        db_name: str | None = None,
+        schema_name: str | None = None,
+        table_name: str | None = None,
+        exclude_columns: bool = False,
+    ) -> list[TableInfo]:
         with self._get_connection() as connection:
             databases = SnowflakeCommon().get_databases(connection=connection)
         content_queries = []

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -494,7 +494,7 @@ class DiscoverableConnector(ABC):
     @staticmethod
     def format_db_model(
         # db, schema, type, name, columns as dict or json string
-        unformatted_db_tree: list[tuple[str, str, str, str, list[dict[str, str]] | str]],
+        unformatted_db_tree: list[TableInfo] | list[tuple[str, str, str, str, list[dict[str, str]] | str]],
     ) -> list[TableInfo]:
         import pandas as pd
 


### PR DESCRIPTION
Laputa now calls get_model with some extra parameters, but these parameters were not added for 3 sql connector's `get_model` method : 
- mysql
- redshift
- snowflake oauth2

When get_model fails, the screen supposed to list db tree structure loads forever (cf. jira card https://toucantoco.atlassian.net/browse/TCTC-9223)