### PR TITLE
fix: jinja templates containing parentheses or curly braces are not limited to output strings anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+- jinja templates :: expressions containing parentheses or curly braces are not limited to output
+  strings anymore.
+
 ## [7.0.1] 2024-09-10
 
 ### Fix

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -252,6 +252,16 @@ def test_apply_parameter_to_query_do_nothing():
             {"city": "Paris"},
             {"domain": "Test"},
         ),
+        (
+            {"answer": "{{ foo + bar }}"},
+            {"foo": 40, "bar": 2},
+            {"answer": 42},
+        ),
+        (
+            {"value": "{{ (user or dict()).get('attributes', dict()).get('LABEL', 250) }}"},
+            {},
+            {"value": 250},
+        ),
     ],
 )
 def test_nosql_apply_parameters_to_query(query, params, expected):

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -53,7 +53,13 @@ def is_jinja_alone(s: str) -> bool:
 
     In the 2nd case, we will always render the result as a string.
     """
-    return re.match(RE_JINJA_ALONE, s) or (s.startswith("{%") and s.endswith("%}"))
+    if s.startswith("{{") and s.endswith("}}"):
+        inside = s[2:-2]
+        return "{{" not in inside and "}}" not in inside
+    elif s.startswith("{%") and s.endswith("%}"):
+        return True
+    else:
+        return False
 
 
 def _has_parameters(query: dict | list[dict] | tuple | str) -> bool:
@@ -155,10 +161,9 @@ def _render_query(query: dict | list[dict] | tuple | str, parameters: dict | Non
 
         # Add quotes to string parameters to keep type if not complex
         clean_p = deepcopy(parameters)
-        if re.match(RE_JINJA_ALONE, query):
-            clean_p = _prepare_parameters(clean_p)
 
         if is_jinja_alone(query):
+            clean_p = _prepare_parameters(clean_p)
             env = NativeEnvironment()
         else:
             env = Environment()  # noqa: S701


### PR DESCRIPTION
For example this expression  

```
{{ {}.get('LABEL', 250) }}
```
now outputs `250` instead of `"250"`