### PR TITLE
chore: bigquery faster getmodel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - jinja templates :: expressions containing parentheses or curly braces are not limited to output
   strings anymore.
+- Google BigQuery :: increase limits when fetching db tree structure
 
 ## [7.0.1] 2024-09-10
 

--- a/toucan_connectors/google_big_query/google_big_query_connector.py
+++ b/toucan_connectors/google_big_query/google_big_query_connector.py
@@ -61,8 +61,8 @@ except ImportError as exc:  # pragma: no cover
     CONNECTOR_OK = False
 
 
-_PAGE_SIZE = 50
-_MAXIMUM_RESULTS_FETCHED = 2000
+_PAGE_SIZE = 500
+_MAXIMUM_RESULTS_FETCHED = 20_000
 _GBQ_TIMEOUT_HTTP_REQUEST = 30  # in seconds
 
 


### PR DESCRIPTION
Now it's both faster and returns more results (it used to truncate results when the db has a lot of tables / columns).