### PR TITLE
feat: add pagination configs for HTTP API Connector (TCTC-9227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- HTTP API: Add a `PaginationConfig` to `HttpAPIDataSource` in order to handle API pagination and fetch all data. It supports the following kinds of pagination: page-based, cursor-based, offset-limit and hypermedia.
+
 ## [7.0.3] 2024-10-04
 
 ### Fix

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -152,7 +152,7 @@ def test_get_df_with_offset_pagination(
         ],
     )
 
-    connector.http_pagination_config = offset_pagination
+    data_source.http_pagination_config = offset_pagination
     df = connector.get_df(data_source)
     assert df.shape == (12, 2)
     assert len(responses.calls) == 3
@@ -191,7 +191,7 @@ def test_get_df_with_page_pagination(
     )
 
     data_source.filter = ".content"
-    connector.http_pagination_config = page_pagination
+    data_source.http_pagination_config = page_pagination
     df = connector.get_df(data_source)
     assert df.shape == (4, 1)
     assert len(responses.calls) == 2
@@ -236,7 +236,7 @@ def test_get_df_with_page_pagination_which_can_raise(
     )
 
     data_source.filter = ".content"
-    connector.http_pagination_config = page_pagination
+    data_source.http_pagination_config = page_pagination
     df = connector.get_df(data_source)
     assert df.shape == (4, 1)
     assert len(responses.calls) == 3
@@ -271,7 +271,7 @@ def test_get_df_with_cursor_pagination(
             "metadata": {"number_of_results": 4},
         },
     )
-    connector.http_pagination_config = cursor_pagination
+    data_source.http_pagination_config = cursor_pagination
     data_source.filter = ".content"
     df = connector.get_df(data_source)
     assert df.shape == (4, 1)
@@ -310,7 +310,7 @@ def test_get_df_with_hyper_media_pagination(
             "metadata": {"number_of_results": 4},
         },
     )
-    connector.http_pagination_config = hyper_media_pagination
+    data_source.http_pagination_config = hyper_media_pagination
     data_source.filter = ".content"
     data_source.params = {"custom": "yes"}
     df = connector.get_df(data_source)
@@ -338,7 +338,7 @@ def test_hyper_media_pagination_raise_if_bad_next_link(
         },
     )
 
-    connector.http_pagination_config = hyper_media_pagination
+    data_source.http_pagination_config = hyper_media_pagination
     data_source.filter = ".content"
     data_source.params = {"custom": "yes"}
     with pytest.raises(ValueError) as exc:
@@ -362,7 +362,7 @@ def test_ignore_if_cant_parse_next_pagination_info(
         ],
     )
 
-    connector.http_pagination_config = hyper_media_pagination  # needs a 'metadata' field to retrieve the next link
+    data_source.http_pagination_config = hyper_media_pagination  # needs a 'metadata' field to retrieve the next link
     # Ok even if 'metadata' is missing in the API response
     df = connector.get_df(data_source)
     assert df.shape == (2, 1)
@@ -770,7 +770,7 @@ def test_get_cache_key(connector, auth, data_source):
     data_source.parameters = {"first_name": "raphael"}
     key = connector.get_cache_key(data_source)
 
-    assert key == "96f415db-63dc-37e4-96df-cb346942c815"
+    assert key == "9ef95981-2aab-3f7f-89d1-b0a300d16f14"
 
     data_source.headers = {"name": "{{ first_name }}"}  # change the templating style
     key2 = connector.get_cache_key(data_source)

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -7,7 +7,7 @@ from pytest_mock import MockFixture
 
 from toucan_connectors.common import transform_with_jq
 from toucan_connectors.http_api.http_api_connector import Auth, HttpAPIConnector, HttpAPIDataSource
-from toucan_connectors.http_api.pagination_configs import OffsetLimitPaginationConfig, CursorBasedPaginationConfig
+from toucan_connectors.http_api.pagination_configs import CursorBasedPaginationConfig, OffsetLimitPaginationConfig
 from toucan_connectors.json_wrapper import JsonWrapper
 
 
@@ -94,21 +94,13 @@ def test_get_df_with_auth(connector, data_source, auth):
 
 @responses.activate
 def test_get_df_with_offset_pagination(
-    connector: HttpAPIConnector,
-    data_source: HttpAPIDataSource,
-    offset_pagination: OffsetLimitPaginationConfig
+    connector: HttpAPIConnector, data_source: HttpAPIDataSource, offset_pagination: OffsetLimitPaginationConfig
 ) -> None:
     # first page
     responses.add(
         responses.GET,
         "https://jsonplaceholder.typicode.com/comments?super_offset=0&super_limit=5",
-        json=[
-            {"a": 1},
-            {"a": 2},
-            {"a": 3},
-            {"a": 4},
-            {"a": 5}
-        ]
+        json=[{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}],
     )
 
     # second page
@@ -121,7 +113,7 @@ def test_get_df_with_offset_pagination(
             {"a": 8},
             {"b": 9},
             {"b": 10},
-        ]
+        ],
     )
 
     # last page
@@ -131,7 +123,7 @@ def test_get_df_with_offset_pagination(
         json=[
             {"b": 11},
             {"b": 12},
-        ]
+        ],
     )
 
     connector.pagination_config = offset_pagination
@@ -142,9 +134,7 @@ def test_get_df_with_offset_pagination(
 
 @responses.activate
 def test_get_df_with_cursor_pagination(
-    connector: HttpAPIConnector,
-    data_source: HttpAPIDataSource,
-    cursor_pagination: CursorBasedPaginationConfig
+    connector: HttpAPIConnector, data_source: HttpAPIDataSource, cursor_pagination: CursorBasedPaginationConfig
 ) -> None:
     # first page
     responses.add(
@@ -155,11 +145,8 @@ def test_get_df_with_cursor_pagination(
                 {"a": 1},
                 {"a": 2},
             ],
-            "metadata": {
-                "next_cursor": "super_cursor_22222",
-                "number_of_results": 4
-            }
-        }
+            "metadata": {"next_cursor": "super_cursor_22222", "number_of_results": 4},
+        },
     )
 
     # next page
@@ -171,10 +158,8 @@ def test_get_df_with_cursor_pagination(
                 {"a": 3},
                 {"a": 4},
             ],
-            "metadata": {
-                "number_of_results": 4
-            }
-        }
+            "metadata": {"number_of_results": 4},
+        },
     )
     connector.pagination_config = cursor_pagination
     data_source.filter = ".content"

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -764,7 +764,7 @@ def test_get_cache_key(connector, auth, data_source):
     data_source.parameters = {"first_name": "raphael"}
     key = connector.get_cache_key(data_source)
 
-    assert key == "4144192b-8b40-3664-aa10-e14484938b23"
+    assert key == "96f415db-63dc-37e4-96df-cb346942c815"
 
     data_source.headers = {"name": "{{ first_name }}"}  # change the templating style
     key2 = connector.get_cache_key(data_source)

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -62,22 +62,28 @@ def auth():
 
 @pytest.fixture(scope="function")
 def offset_pagination() -> OffsetLimitPaginationConfig:
-    return OffsetLimitPaginationConfig(offset_name="super_offset", limit_name="super_limit", limit=5)
+    return OffsetLimitPaginationConfig(
+        kind="OffsetLimitPaginationConfig", offset_name="super_offset", limit_name="super_limit", limit=5
+    )
 
 
 @pytest.fixture(scope="function")
 def page_pagination() -> PageBasedPaginationConfig:
-    return PageBasedPaginationConfig(page_name="my_page", per_page_name="my_per_page", per_page=2, page=1)
+    return PageBasedPaginationConfig(
+        kind="PageBasedPaginationConfig", page_name="my_page", per_page_name="my_per_page", per_page=2, page=1
+    )
 
 
 @pytest.fixture(scope="function")
 def cursor_pagination() -> CursorBasedPaginationConfig:
-    return CursorBasedPaginationConfig(cursor_name="my_cursor", cursor_filter=".metadata.next_cursor")
+    return CursorBasedPaginationConfig(
+        kind="CursorBasedPaginationConfig", cursor_name="my_cursor", cursor_filter=".metadata.next_cursor"
+    )
 
 
 @pytest.fixture(scope="function")
 def hyper_media_pagination() -> HyperMediaPaginationConfig:
-    return HyperMediaPaginationConfig(next_link_filter=".metadata.next_link")
+    return HyperMediaPaginationConfig(kind="HyperMediaPaginationConfig", next_link_filter=".metadata.next_link")
 
 
 def test_transform_with_jq():

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -278,7 +278,6 @@ XpathSchema = Field(
 )
 
 UI_HIDDEN: dict[str, Any] = {"ui.hidden": True}
-UI_REQUIRED: dict[str, Any] = {"ui.required": True}
 
 
 def get_loop():

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -259,11 +259,15 @@ def transform_with_jq(data: object, jq_filter: str) -> list:
     return data
 
 
+FilterSchemaDescription: str = (
+    "You can apply filters to json response if data is nested. As we rely on a "
+    "library called jq, we suggest the refer to the dedicated "
+    '<a href="https://stedolan.github.io/jq/manual/">documentation</a>'
+)
+
 FilterSchema = Field(
     ".",
-    description="You can apply filters to json response if data is nested. As we rely on a "
-    "library called jq, we suggest the refer to the dedicated "
-    '<a href="https://stedolan.github.io/jq/manual/">documentation</a>',
+    description=FilterSchemaDescription,
 )
 
 XpathSchema = Field(
@@ -272,6 +276,8 @@ XpathSchema = Field(
     "For reference visit: "
     '<a href="https://developer.mozilla.org/en-US/docs/Web/XPath">documentation</a>',
 )
+
+UI_HIDDEN: dict[str, Any] = {"ui.hidden": True}
 
 
 def get_loop():

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -278,6 +278,7 @@ XpathSchema = Field(
 )
 
 UI_HIDDEN: dict[str, Any] = {"ui.hidden": True}
+UI_REQUIRED: dict[str, Any] = {"ui.required": True}
 
 
 def get_loop():

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -8,7 +8,7 @@ from pydantic import AnyHttpUrl, BaseModel, Field, FilePath
 from requests.exceptions import HTTPError
 
 from toucan_connectors.http_api.http_api_data_souce import HttpAPIDataSource
-from toucan_connectors.http_api.pagination_configs import PaginationConfig
+from toucan_connectors.http_api.pagination_configs import HttpPagination, PaginationConfig
 
 try:
     import pandas as pd
@@ -70,7 +70,7 @@ class HttpAPIConnector(ToucanConnector, data_source_model=HttpAPIDataSource):
         None,
         description="You can provide a custom template that will be used for every HTTP request",
     )
-    pagination_config: PaginationConfig = Field(PaginationConfig(), title="Pagination configuration")
+    http_pagination: HttpPagination = Field(HttpPagination(), title="Pagination configuration")
 
     def do_request(self, query, session):
         """
@@ -155,7 +155,9 @@ class HttpAPIConnector(ToucanConnector, data_source_model=HttpAPIDataSource):
         try:
             results = pd.DataFrame(
                 self.perform_requests(
-                    data_source=data_source, session=session, pagination_config=self.pagination_config
+                    data_source=data_source,
+                    session=session,
+                    pagination_config=self.http_pagination.get_pagination_config(),
                 )
             )
         except HTTPError as exc:

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -26,6 +26,7 @@ except ImportError as exc:  # pragma: no cover
 
 from toucan_connectors.auth import Auth
 from toucan_connectors.common import (
+    HttpError,
     nosql_apply_parameters_to_query,
     transform_with_jq,
 )
@@ -37,6 +38,10 @@ TOO_MANY_REQUESTS = 429
 
 class HttpAPIConnectorError(Exception):
     """Raised when an error occurs while fetching data from an HTTP API"""
+
+    def __init__(self, message: str, original_exc: HttpError) -> None:
+        super().__init__(message)
+        self.original_exc = original_exc
 
 
 class ResponseType(str, Enum):
@@ -182,8 +187,9 @@ class HttpAPIConnector(ToucanConnector, data_source_model=HttpAPIDataSource):
         except HTTPError as exc:
             if exc.response.status_code == TOO_MANY_REQUESTS:
                 raise HttpAPIConnectorError(
-                    "Failed to retrieve data: the connector tried to perform too many requests."
-                    " Please check your API call limitations."
+                    message="Failed to retrieve data: the connector tried to perform too many requests."
+                    " Please check your API call limitations.",
+                    original_exc=exc,
                 ) from exc
             else:
                 raise

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -3,9 +3,9 @@ from enum import Enum
 from logging import getLogger
 from typing import Any, List
 from xml.etree.ElementTree import ParseError, fromstring, tostring
-from requests.exceptions import HTTPError
 
 from pydantic import AnyHttpUrl, BaseModel, Field, FilePath
+from requests.exceptions import HTTPError
 
 from toucan_connectors.http_api.http_api_data_souce import HttpAPIDataSource
 from toucan_connectors.http_api.pagination_configs import PaginationConfig
@@ -27,7 +27,6 @@ from toucan_connectors.common import (
 )
 from toucan_connectors.toucan_connector import ToucanConnector, ToucanDataSource
 from toucan_connectors.utils.json_to_table import json_to_table
-
 
 TOO_MANY_REQUESTS = 429
 
@@ -119,10 +118,7 @@ class HttpAPIConnector(ToucanConnector, data_source_model=HttpAPIDataSource):
         return data
 
     def perform_requests(
-        self,
-        data_source: HttpAPIDataSource,
-        session: Session,
-        pagination_config: PaginationConfig
+        self, data_source: HttpAPIDataSource, session: Session, pagination_config: PaginationConfig
     ) -> list[Any]:
         data_source = pagination_config.apply_pagination_to_data_source(data_source)
         query = self._render_query(data_source)
@@ -141,13 +137,10 @@ class HttpAPIConnector(ToucanConnector, data_source_model=HttpAPIDataSource):
 
         results = []
         if next_pagination_config := pagination_config.get_next_pagination_config(
-            result=parsed_result,
-            pagination_info=parsed_pagination_info
+            result=parsed_result, pagination_info=parsed_pagination_info
         ):
             results += self.perform_requests(
-                data_source=data_source,
-                session=session,
-                pagination_config=next_pagination_config
+                data_source=data_source, session=session, pagination_config=next_pagination_config
             )
 
         results += parsed_result
@@ -162,9 +155,7 @@ class HttpAPIConnector(ToucanConnector, data_source_model=HttpAPIDataSource):
         try:
             results = pd.DataFrame(
                 self.perform_requests(
-                    data_source=data_source,
-                    session=session,
-                    pagination_config=self.pagination_config
+                    data_source=data_source, session=session, pagination_config=self.pagination_config
                 )
             )
         except HTTPError as exc:

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -83,9 +83,7 @@ class HttpAPIConnector(ToucanConnector, data_source_model=HttpAPIDataSource):
         None,
         description="You can provide a custom template that will be used for every HTTP request",
     )
-    http_pagination_config: HttpPaginationConfig = Field(
-        default_factory=NoopPaginationConfig, title="Pagination configuration"
-    )
+    http_pagination_config: HttpPaginationConfig | None = Field(None, title="Pagination configuration")
 
     def do_request(self, query, session):
         """
@@ -181,7 +179,7 @@ class HttpAPIConnector(ToucanConnector, data_source_model=HttpAPIDataSource):
                 self.perform_requests(
                     data_source=data_source,
                     session=session,
-                    pagination_config=self.http_pagination_config,
+                    pagination_config=self.http_pagination_config or NoopPaginationConfig(),
                 )
             )
         except HTTPError as exc:

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -83,7 +83,9 @@ class HttpAPIConnector(ToucanConnector, data_source_model=HttpAPIDataSource):
         None,
         description="You can provide a custom template that will be used for every HTTP request",
     )
-    http_pagination_config: HttpPaginationConfig | None = Field(None, title="Pagination configuration")
+    http_pagination_config: HttpPaginationConfig | None = Field(
+        None, title="Pagination configuration", discriminator="kind"
+    )
 
     def do_request(self, query, session):
         """

--- a/toucan_connectors/http_api/http_api_data_souce.py
+++ b/toucan_connectors/http_api/http_api_data_souce.py
@@ -1,0 +1,81 @@
+from toucan_connectors import ToucanDataSource
+from typing import Any
+from enum import Enum
+from pydantic import Field
+from pydantic.json_schema import DEFAULT_REF_TEMPLATE, GenerateJsonSchema, JsonSchemaMode
+
+from toucan_connectors.common import (
+    FilterSchema,
+    XpathSchema,
+)
+
+
+class Method(str, Enum):
+    GET = "GET"
+    POST = "POST"
+    PUT = "PUT"
+
+
+class HttpAPIDataSource(ToucanDataSource):
+    url: str = Field(
+        ...,
+        title="Endpoint URL",
+        description="The URL path that will be appended to your baseroute URL. " 'For example "geo/countries"',
+    )
+    method: Method = Field(Method.GET, title="HTTP Method")
+    headers: dict | None = Field(
+        None,
+        description="You can also setup headers in the Template section of your Connector see: <br/>"
+        "https://docs.toucantoco.com/concepteur/tutorials/connectors/3-http-connector.html#template",
+        examples=['{ "content-type": "application/xml" }'],
+    )
+    params: dict | None = Field(
+        None,
+        title="URL params",
+        description="JSON object of parameters to send in the query string of this HTTP request "
+        '(e.g. "offset" and "limit" in https://www/api-aseroute/data&offset=100&limit=50)',
+        examples=['{ "offset": 100, "limit": 50 }'],
+    )
+    json_: dict | None = Field(
+        None,
+        alias="json",
+        title="Body",
+        description="JSON object of parameters to send in the body of every HTTP request",
+        examples=['{ "offset": 100, "limit": 50 }'],
+    )
+    proxies: dict | None = Field(
+        None,
+        description="JSON object expressing a mapping of protocol or host to corresponding proxy",
+        examples=['{"http": "foo.bar:3128", "http://host.name": "foo.bar:4012"}'],
+    )
+    data: str | dict | None = Field(None, description="JSON object to send in the body of the HTTP request")
+    xpath: str = XpathSchema
+    filter: str = FilterSchema
+    flatten_column: str | None = Field(None, description="Column containing nested rows")
+
+    @classmethod
+    def model_json_schema(
+        cls,
+        by_alias: bool = True,
+        ref_template: str = DEFAULT_REF_TEMPLATE,
+        schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema,
+        mode: JsonSchemaMode = "validation",
+    ) -> dict[str, Any]:
+        schema = super().model_json_schema(
+            by_alias=by_alias,
+            ref_template=ref_template,
+            schema_generator=schema_generator,
+            mode=mode,
+        )
+        keys = schema["properties"].keys()
+        last_keys = [
+            "proxies",
+            "flatten_column",
+            "data",
+            "xpath",
+            "filter",
+            "validation",
+        ]
+        new_keys = [k for k in keys if k not in last_keys] + last_keys
+        schema["properties"] = {k: schema["properties"].get(k) for k in new_keys}
+        return schema

--- a/toucan_connectors/http_api/http_api_data_souce.py
+++ b/toucan_connectors/http_api/http_api_data_souce.py
@@ -1,9 +1,10 @@
-from toucan_connectors import ToucanDataSource
-from typing import Any
 from enum import Enum
+from typing import Any
+
 from pydantic import Field
 from pydantic.json_schema import DEFAULT_REF_TEMPLATE, GenerateJsonSchema, JsonSchemaMode
 
+from toucan_connectors import ToucanDataSource
 from toucan_connectors.common import (
     FilterSchema,
     XpathSchema,

--- a/toucan_connectors/http_api/pagination_configs.py
+++ b/toucan_connectors/http_api/pagination_configs.py
@@ -5,7 +5,7 @@ from urllib.parse import parse_qs, urlparse
 
 from pydantic import BaseModel, Field
 
-from toucan_connectors.common import UI_HIDDEN, FilterSchemaDescription
+from toucan_connectors.common import UI_HIDDEN, UI_REQUIRED, FilterSchemaDescription
 from toucan_connectors.http_api.http_api_data_souce import HttpAPIDataSource
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,8 +38,6 @@ class NoopPaginationConfig(PaginationConfig):
     Useful for connectors that can return all results at once.
     """
 
-    kind: Literal["NoopPaginationConfig"] = Field("NoopPaginationConfig", **UI_HIDDEN)
-
     def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
         return data_source
 
@@ -54,7 +52,7 @@ class NoopPaginationConfig(PaginationConfig):
 
 
 class OffsetLimitPaginationConfig(PaginationConfig):
-    kind: Literal["OffsetLimitPaginationConfig"] = Field("OffsetLimitPaginationConfig", **UI_HIDDEN)
+    kind: Literal["OffsetLimitPaginationConfig"] = Field("OffsetLimitPaginationConfig", **UI_HIDDEN, **UI_REQUIRED)
     offset_name: str = "offset"
     offset: int = Field(0, **UI_HIDDEN)
     limit_name: str = "limit"
@@ -84,7 +82,7 @@ class OffsetLimitPaginationConfig(PaginationConfig):
 
 
 class PageBasedPaginationConfig(PaginationConfig):
-    kind: Literal["PageBasedPaginationConfig"] = Field("PageBasedPaginationConfig", **UI_HIDDEN)
+    kind: Literal["PageBasedPaginationConfig"] = Field("PageBasedPaginationConfig", **UI_HIDDEN, **UI_REQUIRED)
     page_name: str = "page"
     page: int = 0
     per_page_name: str | None = None
@@ -131,7 +129,7 @@ class PageBasedPaginationConfig(PaginationConfig):
 
 
 class CursorBasedPaginationConfig(PaginationConfig):
-    kind: Literal["CursorBasedPaginationConfig"] = Field("CursorBasedPaginationConfig", **UI_HIDDEN)
+    kind: Literal["CursorBasedPaginationConfig"] = Field("CursorBasedPaginationConfig", **UI_HIDDEN, **UI_REQUIRED)
     cursor_name: str = "cursor"
     cursor: str | None = Field(None, **UI_HIDDEN)
     cursor_filter: str = Field(..., description=FilterSchemaDescription)
@@ -165,7 +163,7 @@ class CursorBasedPaginationConfig(PaginationConfig):
 
 
 class HyperMediaPaginationConfig(PaginationConfig):
-    kind: Literal["HyperMediaPaginationConfig"] = Field("HyperMediaPaginationConfig", **UI_HIDDEN)
+    kind: Literal["HyperMediaPaginationConfig"] = Field("HyperMediaPaginationConfig", **UI_HIDDEN, **UI_REQUIRED)
     next_link_filter: str = Field(..., description=FilterSchemaDescription)
     next_link: str | None = None
 

--- a/toucan_connectors/http_api/pagination_configs.py
+++ b/toucan_connectors/http_api/pagination_configs.py
@@ -5,7 +5,7 @@ from urllib.parse import parse_qs, urlparse
 
 from pydantic import BaseModel, Field
 
-from toucan_connectors.common import UI_HIDDEN, UI_REQUIRED, FilterSchemaDescription
+from toucan_connectors.common import UI_HIDDEN, FilterSchemaDescription
 from toucan_connectors.http_api.http_api_data_souce import HttpAPIDataSource
 
 _LOGGER = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ class NoopPaginationConfig(PaginationConfig):
 
 
 class OffsetLimitPaginationConfig(PaginationConfig):
-    kind: Literal["OffsetLimitPaginationConfig"] = Field("OffsetLimitPaginationConfig", **UI_HIDDEN, **UI_REQUIRED)
+    kind: Literal["OffsetLimitPaginationConfig"]
     offset_name: str = "offset"
     offset: int = Field(0, **UI_HIDDEN)
     limit_name: str = "limit"
@@ -82,7 +82,7 @@ class OffsetLimitPaginationConfig(PaginationConfig):
 
 
 class PageBasedPaginationConfig(PaginationConfig):
-    kind: Literal["PageBasedPaginationConfig"] = Field("PageBasedPaginationConfig", **UI_HIDDEN, **UI_REQUIRED)
+    kind: Literal["PageBasedPaginationConfig"]
     page_name: str = "page"
     page: int = 0
     per_page_name: str | None = None
@@ -129,7 +129,7 @@ class PageBasedPaginationConfig(PaginationConfig):
 
 
 class CursorBasedPaginationConfig(PaginationConfig):
-    kind: Literal["CursorBasedPaginationConfig"] = Field("CursorBasedPaginationConfig", **UI_HIDDEN, **UI_REQUIRED)
+    kind: Literal["CursorBasedPaginationConfig"]
     cursor_name: str = "cursor"
     cursor: str | None = Field(None, **UI_HIDDEN)
     cursor_filter: str = Field(..., description=FilterSchemaDescription)
@@ -163,7 +163,7 @@ class CursorBasedPaginationConfig(PaginationConfig):
 
 
 class HyperMediaPaginationConfig(PaginationConfig):
-    kind: Literal["HyperMediaPaginationConfig"] = Field("HyperMediaPaginationConfig", **UI_HIDDEN, **UI_REQUIRED)
+    kind: Literal["HyperMediaPaginationConfig"]
     next_link_filter: str = Field(..., description=FilterSchemaDescription)
     next_link: str | None = None
 

--- a/toucan_connectors/http_api/pagination_configs.py
+++ b/toucan_connectors/http_api/pagination_configs.py
@@ -38,6 +38,8 @@ class NoopPaginationConfig(PaginationConfig):
     Useful for connectors that can return all results at once.
     """
 
+    kind: Literal["NoopPaginationConfig"] = Field("NoopPaginationConfig", **UI_HIDDEN)
+
     def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
         return data_source
 
@@ -52,7 +54,7 @@ class NoopPaginationConfig(PaginationConfig):
 
 
 class OffsetLimitPaginationConfig(PaginationConfig):
-    kind: Literal["OffsetLimitPaginationConfig"] = "OffsetLimitPaginationConfig"
+    kind: Literal["OffsetLimitPaginationConfig"] = Field("OffsetLimitPaginationConfig", **UI_HIDDEN)
     offset_name: str = "offset"
     offset: int = Field(0, **UI_HIDDEN)
     limit_name: str = "limit"
@@ -82,7 +84,7 @@ class OffsetLimitPaginationConfig(PaginationConfig):
 
 
 class PageBasedPaginationConfig(PaginationConfig):
-    kind: Literal["PageBasedPaginationConfig"] = "PageBasedPaginationConfig"
+    kind: Literal["PageBasedPaginationConfig"] = Field("PageBasedPaginationConfig", **UI_HIDDEN)
     page_name: str = "page"
     page: int = 0
     per_page_name: str | None = None
@@ -129,7 +131,7 @@ class PageBasedPaginationConfig(PaginationConfig):
 
 
 class CursorBasedPaginationConfig(PaginationConfig):
-    kind: Literal["CursorBasedPaginationConfig"] = "CursorBasedPaginationConfig"
+    kind: Literal["CursorBasedPaginationConfig"] = Field("CursorBasedPaginationConfig", **UI_HIDDEN)
     cursor_name: str = "cursor"
     cursor: str | None = Field(None, **UI_HIDDEN)
     cursor_filter: str = Field(..., description=FilterSchemaDescription)
@@ -163,7 +165,7 @@ class CursorBasedPaginationConfig(PaginationConfig):
 
 
 class HyperMediaPaginationConfig(PaginationConfig):
-    kind: Literal["HyperMediaPaginationConfig"] = "HyperMediaPaginationConfig"
+    kind: Literal["HyperMediaPaginationConfig"] = Field("HyperMediaPaginationConfig", **UI_HIDDEN)
     next_link_filter: str = Field(..., description=FilterSchemaDescription)
     next_link: str | None = None
 

--- a/toucan_connectors/http_api/pagination_configs.py
+++ b/toucan_connectors/http_api/pagination_configs.py
@@ -12,6 +12,7 @@ class PaginationConfig(BaseModel):
     Config applied for connectors without pagination configured.
     Useful for connectors that can return all results at once.
     """
+
     def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
         """Apply pagination to data source and return it"""
         return data_source
@@ -32,10 +33,7 @@ class OffsetLimitPaginationConfig(PaginationConfig):
     limit: int
 
     def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
-        offset_limit_params = {
-            self.offset_name: self.offset,
-            self.limit_name: self.limit
-        }
+        offset_limit_params = {self.offset_name: self.offset, self.limit_name: self.limit}
         if data_source.params is None:
             data_source.params = offset_limit_params
         else:

--- a/toucan_connectors/http_api/pagination_configs.py
+++ b/toucan_connectors/http_api/pagination_configs.py
@@ -51,7 +51,7 @@ class NoopPaginationConfig(PaginationConfig):
 
 
 class OffsetLimitPaginationConfig(PaginationConfig):
-    kind: Literal["OffsetLimitPaginationConfig"]
+    kind: Literal["OffsetLimitPaginationConfig"] = Field(..., **UI_HIDDEN)
     offset_name: str = "offset"
     offset: int = Field(0, **UI_HIDDEN)
     limit_name: str = "limit"
@@ -81,7 +81,7 @@ class OffsetLimitPaginationConfig(PaginationConfig):
 
 
 class PageBasedPaginationConfig(PaginationConfig):
-    kind: Literal["PageBasedPaginationConfig"]
+    kind: Literal["PageBasedPaginationConfig"] = Field(..., **UI_HIDDEN)
     page_name: str = "page"
     page: int = 0
     per_page_name: str | None = None
@@ -128,7 +128,7 @@ class PageBasedPaginationConfig(PaginationConfig):
 
 
 class CursorBasedPaginationConfig(PaginationConfig):
-    kind: Literal["CursorBasedPaginationConfig"]
+    kind: Literal["CursorBasedPaginationConfig"] = Field(..., **UI_HIDDEN)
     cursor_name: str = "cursor"
     cursor: str | None = Field(None, **UI_HIDDEN)
     cursor_filter: str = Field(..., description=FilterSchemaDescription)
@@ -162,7 +162,7 @@ class CursorBasedPaginationConfig(PaginationConfig):
 
 
 class HyperMediaPaginationConfig(PaginationConfig):
-    kind: Literal["HyperMediaPaginationConfig"]
+    kind: Literal["HyperMediaPaginationConfig"] = Field(..., **UI_HIDDEN)
     next_link_filter: str = Field(..., description=FilterSchemaDescription)
     next_link: str | None = None
 

--- a/toucan_connectors/http_api/pagination_configs.py
+++ b/toucan_connectors/http_api/pagination_configs.py
@@ -1,0 +1,100 @@
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+from toucan_connectors.common import FilterSchema
+from toucan_connectors.http_api.http_api_data_souce import HttpAPIDataSource
+
+
+class PaginationConfig(BaseModel):
+    """Base class for pagination configs.
+
+    Config applied for connectors without pagination configured.
+    Useful for connectors that can return all results at once.
+    """
+    def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
+        """Apply pagination to data source and return it"""
+        return data_source
+
+    def get_next_pagination_config(self, result: Any, pagination_info: Any | None) -> Optional["PaginationConfig"]:
+        """Computes next pagination config based on the parsed API responses"""
+        return None
+
+    def get_pagination_info_filter(self) -> str | None:
+        """Returns the JQ filter that must be applied to the raw API result to retrieve pagination info"""
+        return None
+
+
+class OffsetLimitPaginationConfig(PaginationConfig):
+    offset_name: str = "offset"
+    offset: int = 0
+    limit_name: str = "limit"
+    limit: int
+
+    def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
+        offset_limit_params = {
+            self.offset_name: self.offset,
+            self.limit_name: self.limit
+        }
+        if data_source.params is None:
+            data_source.params = offset_limit_params
+        else:
+            data_source.params |= offset_limit_params
+        return data_source
+
+    def get_next_pagination_config(
+        self, result: Any, pagination_info: Any | None
+    ) -> Optional["OffsetLimitPaginationConfig"]:
+        if len(result) < self.limit:
+            return None
+        else:
+            return self.model_copy(update={"offset": self.offset + self.limit})
+
+
+class PageBasedPaginationConfig(PaginationConfig):
+    page_name: str = "page"
+    page: int = 0
+
+    def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
+        page_based_params = {self.page_name: self.page}
+        if data_source.params is None:
+            data_source.params = page_based_params
+        else:
+            data_source.params |= page_based_params
+        return data_source
+
+    def get_next_pagination_config(
+        self, result: Any, pagination_info: Any | None
+    ) -> Optional["PageBasedPaginationConfig"]:
+        if len(result) < 1:
+            return None
+        else:
+            return self.model_copy(update={"page": self.page + 1})
+
+
+class CursorBasedPaginationConfig(PaginationConfig):
+    cursor_name: str = "cursor"
+    cursor: str | None = None
+    cursor_filter: str = FilterSchema
+
+    def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
+        if self.cursor:
+            cursor_params = {self.cursor_name: self.cursor}
+            if data_source.params is None:
+                data_source.params = cursor_params
+            else:
+                data_source.params |= cursor_params
+        return data_source
+
+    def get_next_pagination_config(
+        self, result: Any, pagination_info: Any | None
+    ) -> Optional["CursorBasedPaginationConfig"]:
+        if pagination_info is None:
+            return None
+        if isinstance(pagination_info, str):
+            return self.model_copy(update={"cursor": pagination_info})
+        else:
+            raise ValueError(f"Invalid next cursor value. Cursor value must be a string, got: {pagination_info}")
+
+    def get_pagination_info_filter(self) -> str:
+        return self.cursor_filter

--- a/toucan_connectors/http_api/pagination_configs.py
+++ b/toucan_connectors/http_api/pagination_configs.py
@@ -1,10 +1,13 @@
-from enum import Enum
+import logging
 from typing import Any, Optional
+from urllib.parse import parse_qs, urlparse
 
 from pydantic import BaseModel, Field
 
 from toucan_connectors.common import FilterSchema
 from toucan_connectors.http_api.http_api_data_souce import HttpAPIDataSource
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class PaginationConfig(BaseModel):
@@ -16,14 +19,29 @@ class PaginationConfig(BaseModel):
 
     def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
         """Apply pagination to data source and return it"""
-        return data_source
+        pass
 
     def get_next_pagination_config(self, result: Any, pagination_info: Any | None) -> Optional["PaginationConfig"]:
         """Computes next pagination config based on the parsed API responses"""
-        return None
+        pass
 
     def get_pagination_info_filter(self) -> str | None:
         """Returns the JQ filter that must be applied to the raw API result to retrieve pagination info"""
+        pass
+
+    def get_error_status_whitelist(self) -> list[str] | None:
+        """Returns the list of the error statuses which means the end of data fetching, and so to ignore"""
+        pass
+
+
+class NoopPaginationConfig(PaginationConfig):
+    def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
+        return data_source
+
+    def get_next_pagination_config(self, result: Any, pagination_info: Any | None) -> Optional["PaginationConfig"]:
+        return None
+
+    def get_pagination_info_filter(self) -> str | None:
         return None
 
 
@@ -36,10 +54,10 @@ class OffsetLimitPaginationConfig(PaginationConfig):
     def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
         offset_limit_params = {self.offset_name: self.offset, self.limit_name: self.limit}
         if data_source.params is None:
-            data_source.params = offset_limit_params
+            data_source_params = offset_limit_params
         else:
-            data_source.params |= offset_limit_params
-        return data_source
+            data_source_params = data_source.params | offset_limit_params
+        return data_source.model_copy(update={"params": data_source_params})
 
     def get_next_pagination_config(
         self, result: Any, pagination_info: Any | None
@@ -53,22 +71,47 @@ class OffsetLimitPaginationConfig(PaginationConfig):
 class PageBasedPaginationConfig(PaginationConfig):
     page_name: str = "page"
     page: int = 0
+    per_page_name: str | None = None
+    per_page: int | None = None
+    max_page_filter: str | None = None
+    can_raise_not_found: bool = Field(
+        False,
+        description="Some APIs can raise a not found error (404) when requesting the next page.",
+    )
 
     def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
         page_based_params = {self.page_name: self.page}
+        if self.per_page_name:
+            page_based_params |= {self.per_page_name: self.per_page}
         if data_source.params is None:
-            data_source.params = page_based_params
+            data_source_params = page_based_params
         else:
-            data_source.params |= page_based_params
-        return data_source
+            data_source_params = data_source.params | page_based_params
+        return data_source.model_copy(update={"params": data_source_params})
 
     def get_next_pagination_config(
         self, result: Any, pagination_info: Any | None
     ) -> Optional["PageBasedPaginationConfig"]:
+        if self.max_page_filter:
+            if pagination_info is None:
+                return None
+            if self.page >= int(pagination_info):
+                return None
+        if self.per_page:
+            if len(result) < self.per_page:
+                return None
         if len(result) < 1:
             return None
         else:
             return self.model_copy(update={"page": self.page + 1})
+
+    def get_pagination_info_filter(self) -> str:
+        return self.max_page_filter
+
+    def get_error_status_whitelist(self) -> list[int] | None:
+        if self.can_raise_not_found:
+            return [404]
+        return None
 
 
 class CursorBasedPaginationConfig(PaginationConfig):
@@ -80,49 +123,71 @@ class CursorBasedPaginationConfig(PaginationConfig):
         if self.cursor:
             cursor_params = {self.cursor_name: self.cursor}
             if data_source.params is None:
-                data_source.params = cursor_params
+                data_source_params = cursor_params
             else:
-                data_source.params |= cursor_params
-        return data_source
+                data_source_params = data_source.params | cursor_params
+            return data_source.model_copy(update={"params": data_source_params})
+        else:
+            return data_source
 
     def get_next_pagination_config(
         self, result: Any, pagination_info: Any | None
     ) -> Optional["CursorBasedPaginationConfig"]:
         if pagination_info is None:
             return None
-        if isinstance(pagination_info, str):
-            return self.model_copy(update={"cursor": pagination_info})
+        if isinstance(pagination_info, dict) or isinstance(pagination_info, list):
+            raise ValueError(f"Invalid next cursor value. Cursor can't be a complex value, got: {pagination_info}")
         else:
-            raise ValueError(f"Invalid next cursor value. Cursor value must be a string, got: {pagination_info}")
+            return self.model_copy(update={"cursor": str(pagination_info)})
 
     def get_pagination_info_filter(self) -> str:
         return self.cursor_filter
 
 
-class PaginationType(str, Enum):
-    nothing = "nothing"
-    offset_limit = "offset_limit"
-    cursor = "cursor"
-    page = "page"
+class HyperMediaPaginationConfig(PaginationConfig):
+    next_link_filter: str
+    next_link: str | None = None
+
+    def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
+        if self.next_link:
+            try:
+                url_chunks = urlparse(self.next_link)
+                url_parameters = parse_qs(url_chunks.query) | (data_source.params or {})
+                return data_source.model_copy(update={"url": url_chunks.path, "params": url_parameters})
+            except ValueError:
+                _LOGGER.error(f"Can't parse next link pagination='{self.next_link}'")
+                raise
+        else:
+            return data_source
+
+    def get_next_pagination_config(
+        self, result: Any, pagination_info: Any | None
+    ) -> Optional["HyperMediaPaginationConfig"]:
+        if pagination_info is None:
+            return None
+        if isinstance(pagination_info, dict) or isinstance(pagination_info, list):
+            raise ValueError(f"Invalid next link value. Link can't be a complex value, got: {pagination_info}")
+        else:
+            return self.model_copy(update={"next_link": str(pagination_info)})
+
+    def get_pagination_info_filter(self) -> str:
+        return self.next_link_filter
 
 
-class HttpPagination(BaseModel):
-    type: PaginationType = Field(
-        PaginationType.nothing,
-        description="The kind of pagination that corresponds to your API pagination system",
-    )
-    kwargs: dict = Field(
-        default_factory=dict,
-        title="Named arguments",
-        description="A JSON object with argument name as key and corresponding value as value",
-    )
+HttpPaginationConfig = (
+    CursorBasedPaginationConfig
+    | PageBasedPaginationConfig
+    | OffsetLimitPaginationConfig
+    | NoopPaginationConfig
+    | HyperMediaPaginationConfig
+)
 
-    def get_pagination_config(self) -> PaginationConfig:
-        auth_class = {
-            PaginationType.nothing: PaginationConfig,
-            PaginationType.offset_limit: OffsetLimitPaginationConfig,
-            PaginationType.cursor: CursorBasedPaginationConfig,
-            PaginationType.page: PageBasedPaginationConfig,
-        }[self.type]
-        pagination_config = auth_class(**self.kwargs)
-        return pagination_config
+
+def extract_pagination_info_from_result(api_response: dict | list, jq_pagination_filter: str):
+    import jq
+
+    try:
+        return jq.first(jq_pagination_filter, api_response)
+    except ValueError:
+        _LOGGER.info(f"Could not extract pagination info with filter '{jq_pagination_filter}' on {api_response}")
+        return None

--- a/toucan_connectors/http_api/pagination_configs.py
+++ b/toucan_connectors/http_api/pagination_configs.py
@@ -150,13 +150,9 @@ class HyperMediaPaginationConfig(PaginationConfig):
 
     def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
         if self.next_link:
-            try:
-                url_chunks = urlparse(self.next_link)
-                url_parameters = parse_qs(url_chunks.query) | (data_source.params or {})
-                return data_source.model_copy(update={"url": url_chunks.path, "params": url_parameters})
-            except ValueError:
-                _LOGGER.error(f"Can't parse next link pagination='{self.next_link}'")
-                raise
+            url_chunks = urlparse(self.next_link)
+            url_parameters = parse_qs(url_chunks.query) | (data_source.params or {})
+            return data_source.model_copy(update={"url": url_chunks.path, "params": url_parameters})
         else:
             return data_source
 

--- a/toucan_connectors/http_api/pagination_configs.py
+++ b/toucan_connectors/http_api/pagination_configs.py
@@ -38,8 +38,6 @@ class NoopPaginationConfig(PaginationConfig):
     Useful for connectors that can return all results at once.
     """
 
-    kind: Literal["NoopPaginationConfig"] = Field("NoopPaginationConfig", **UI_HIDDEN)
-
     def apply_pagination_to_data_source(self, data_source: HttpAPIDataSource) -> HttpAPIDataSource:
         return data_source
 
@@ -54,7 +52,7 @@ class NoopPaginationConfig(PaginationConfig):
 
 
 class OffsetLimitPaginationConfig(PaginationConfig):
-    kind: Literal["OffsetLimitPaginationConfig"] = Field("OffsetLimitPaginationConfig", **UI_HIDDEN)
+    kind: Literal["OffsetLimitPaginationConfig"] = "OffsetLimitPaginationConfig"
     offset_name: str = "offset"
     offset: int = Field(0, **UI_HIDDEN)
     limit_name: str = "limit"
@@ -84,7 +82,7 @@ class OffsetLimitPaginationConfig(PaginationConfig):
 
 
 class PageBasedPaginationConfig(PaginationConfig):
-    kind: Literal["PageBasedPaginationConfig"] = Field("PageBasedPaginationConfig", **UI_HIDDEN)
+    kind: Literal["PageBasedPaginationConfig"] = "PageBasedPaginationConfig"
     page_name: str = "page"
     page: int = 0
     per_page_name: str | None = None
@@ -131,7 +129,7 @@ class PageBasedPaginationConfig(PaginationConfig):
 
 
 class CursorBasedPaginationConfig(PaginationConfig):
-    kind: Literal["CursorBasedPaginationConfig"] = Field("CursorBasedPaginationConfig", **UI_HIDDEN)
+    kind: Literal["CursorBasedPaginationConfig"] = "CursorBasedPaginationConfig"
     cursor_name: str = "cursor"
     cursor: str | None = Field(None, **UI_HIDDEN)
     cursor_filter: str = Field(..., description=FilterSchemaDescription)
@@ -165,7 +163,7 @@ class CursorBasedPaginationConfig(PaginationConfig):
 
 
 class HyperMediaPaginationConfig(PaginationConfig):
-    kind: Literal["HyperMediaPaginationConfig"] = Field("HyperMediaPaginationConfig", **UI_HIDDEN)
+    kind: Literal["HyperMediaPaginationConfig"] = "HyperMediaPaginationConfig"
     next_link_filter: str = Field(..., description=FilterSchemaDescription)
     next_link: str | None = None
 

--- a/toucan_connectors/snowflake/snowflake_connector.py
+++ b/toucan_connectors/snowflake/snowflake_connector.py
@@ -7,7 +7,7 @@ from typing import Any, ContextManager, Generator, Literal, overload
 from pydantic import Field, create_model
 from pydantic.json_schema import DEFAULT_REF_TEMPLATE, GenerateJsonSchema, JsonSchemaMode
 
-from toucan_connectors.common import ConnectorStatus
+from toucan_connectors.common import UI_HIDDEN, ConnectorStatus
 from toucan_connectors.pagination import build_pagination_info
 from toucan_connectors.sql_query_helper import SqlQueryHelper
 from toucan_connectors.toucan_connector import (
@@ -49,9 +49,6 @@ except ImportError as exc:  # pragma: no cover
     CONNECTOR_OK = False
 
 
-_UI_HIDDEN: dict[str, Any] = {"ui.hidden": True}
-
-
 class SnowflakeDataSource(ToucanDataSource["SnowflakeConnector"]):
     database: str = Field(..., description="The name of the database you want to query")
     warehouse: str | None = Field(None, description="The name of the warehouse you want to query")
@@ -63,16 +60,16 @@ class SnowflakeDataSource(ToucanDataSource["SnowflakeConnector"]):
         widget="sql",  # type:ignore[call-arg]
     )
 
-    # Pydantic sees **_UI_HIDDEN as the third argument (the default factory) and raises an error
+    # Pydantic sees **UI_HIDDEN as the third argument (the default factory) and raises an error
     query_object: dict | None = Field(  # type: ignore[pydantic-field]
         None,
         description="An object describing a simple select query"
         "For example "
         '{"schema": "SHOW_SCHEMA", "table": "MY_TABLE", "columns": ["col1", "col2"]}'
         "This field is used internally",
-        **_UI_HIDDEN,
+        **UI_HIDDEN,
     )
-    language: str = Field("sql", **_UI_HIDDEN)  # type: ignore[pydantic-field]
+    language: str = Field("sql", **UI_HIDDEN)  # type: ignore[pydantic-field]
 
     @classmethod
     def _get_databases(cls, connector: "SnowflakeConnector"):

--- a/toucan_connectors/toucan_connector.py
+++ b/toucan_connectors/toucan_connector.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ConfigDict, Field, PlainSerializer, SecretStr
 from pydantic.fields import ModelPrivateAttr
 
 from toucan_connectors.common import (
+    UI_HIDDEN,
     ConnectorStatus,
     apply_query_parameters,
     nosql_apply_parameters_to_query,
@@ -263,8 +264,6 @@ def get_connector_secrets_form(cls) -> ConnectorSecretsForm | None:
     return None
 
 
-_UI_HIDDEN: dict[str, Any] = {"ui.hidden": True}
-
 DS = TypeVar("DS", bound=ToucanDataSource)
 
 PlainJsonSecretStr = Annotated[
@@ -301,7 +300,7 @@ class ToucanConnector(BaseModel, Generic[DS], metaclass=ABCMeta):
     retry_policy: RetryPolicy | None = RetryPolicy()
     _retry_on: Iterable[Type[BaseException]] = ()
     type: str | None = None
-    secrets_storage_version: str = Field("1", **_UI_HIDDEN)  # type:ignore[pydantic-field]
+    secrets_storage_version: str = Field("1", **UI_HIDDEN)  # type:ignore[pydantic-field]
 
     # Default ttl for all connector's queries (overridable at the data_source level)
     # /!\ cache ttl is used by the caching system which is not implemented in toucan_connectors.
@@ -312,7 +311,7 @@ class ToucanConnector(BaseModel, Generic[DS], metaclass=ABCMeta):
     )
 
     # Used to defined the connection
-    identifier: str | None = Field(None, **_UI_HIDDEN)  # type:ignore[pydantic-field]
+    identifier: str | None = Field(None, **UI_HIDDEN)  # type:ignore[pydantic-field]
     model_config = ConfigDict(extra="forbid", validate_assignment=True)
 
     @property


### PR DESCRIPTION
## Proposal pagination v0: 

Add a `http_Pagination` attribute to `HttpAPIConnector` which works like the `auth` configuration:
 - the user can activate pagination in its interface and then choose the kind of pagination he wants.
 - each pagination type must have its default configuration, which will be displayed to the user once its selected
 
 That `http_pagination` is transformed to a `PaginationConfig`. 
 All PaginationConfigs works the same : 
  - `apply_pagination_to_data_source` : it transform the data_source in order to add all pagination arguments needed to the API request
  - `get_next_pagination_config`: it computes the next pagination_config for the next API call based on the last API response
  - [optional] `get_pagination_info_filter`: it returns the JQ filter that can be used to extract pagination information from the previous API call
  
## Next steps: 
 - Implement more pagination types
 - Accept other HTTP method / parameter position (ex offset_limit in request headers)
 - Add  http_config form to the front end connector settings
 - Write pagination config documentation section
   
## Limits:
 - All HTTP calls will be performed one after the other, that can produce throttling errors (429). Maybe add an additional config for that in the http_config?
 - HTTP API must be able to return all results in less than 30s. We can only accept small datasets.
 
 ## Front example 
 
![image](https://github.com/user-attachments/assets/e9706b70-b33c-4910-aeee-dfd7b77391c3)
