### PR TITLE
fix: merge api results after their transformations (TCTC-9634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fix
+
+- HTTP API: Extract API results dataframes separately and merge them after.
+- HTTP API: Add `data_length_filter` offset pagination config field to determine which part of data must be used to compute the data length.
+
 ## [7.1.1] 2024-10-28
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### Fix
 
-- HTTP API: Extract API results dataframes separately and merge them after.
-- HTTP API: Add `data_length_filter` offset pagination config field to determine which part of data must be used to compute the data length.
+- HTTP API: API results are now correctly merged even if they need to be filtered or flattened. 
+
+### Added
+
+- HTTP API: Add `data_filter` offset pagination config field to determine which part of data must be used to compute the data length.
 
 ## [7.1.1] 2024-10-28
 

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -215,7 +215,7 @@ def test_get_df_with_offset_pagination_and_flatten_option(
             },
         },
     )
-    offset_pagination.data_length_filter = ".items.products"
+    offset_pagination.data_filter = ".items.products"
     data_source.filter = ".items"
     data_source.flatten_column = "products"
     data_source.http_pagination_config = offset_pagination

--- a/tests/http_api/test_http_api.py
+++ b/tests/http_api/test_http_api.py
@@ -159,6 +159,72 @@ def test_get_df_with_offset_pagination(
 
 
 @responses.activate
+def test_get_df_with_offset_pagination_and_flatten_option(
+    connector: HttpAPIConnector, data_source: HttpAPIDataSource, offset_pagination: OffsetLimitPaginationConfig
+) -> None:
+    # first page
+    responses.add(
+        responses.GET,
+        "https://jsonplaceholder.typicode.com/comments?super_offset=0&super_limit=5",
+        json={
+            "totalItems": 12,
+            "items": {
+                "product_category": "sofa",
+                "products": [
+                    {"name": "p1", "price": 1},
+                    {"name": "p2", "price": 1},
+                    {"name": "p3", "price": 1},
+                    {"name": "p4", "price": 1},
+                    {"name": "p5", "price": 1},
+                ],
+            },
+        },
+    )
+
+    # second page
+    responses.add(
+        responses.GET,
+        "https://jsonplaceholder.typicode.com/comments?super_offset=5&super_limit=5",
+        json={
+            "totalItems": 12,
+            "items": {
+                "product_category": "kitchen",
+                "products": [
+                    {"name": "p6", "price": 1},
+                    {"name": "p7", "price": 1},
+                    {"name": "p8", "price": 1},
+                    {"name": "p9", "price": 1},
+                    {"name": "p10", "price": 1},
+                ],
+            },
+        },
+    )
+
+    # last page
+    responses.add(
+        responses.GET,
+        "https://jsonplaceholder.typicode.com/comments?super_offset=10&super_limit=5",
+        json={
+            "totalItems": 12,
+            "items": {
+                "product_category": "bedroom",
+                "products": [
+                    {"name": "p11", "price": 1},
+                    {"name": "p12", "price": 1},
+                ],
+            },
+        },
+    )
+    offset_pagination.data_length_filter = ".items.products"
+    data_source.filter = ".items"
+    data_source.flatten_column = "products"
+    data_source.http_pagination_config = offset_pagination
+    df = connector.get_df(data_source)
+    assert df.shape == (12, 4)
+    assert len(responses.calls) == 3
+
+
+@responses.activate
 def test_get_df_with_page_pagination(
     connector: HttpAPIConnector, data_source: HttpAPIDataSource, page_pagination: PageBasedPaginationConfig
 ) -> None:

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -20,6 +20,7 @@ try:
         NoopPaginationConfig,
         extract_pagination_info_from_result,
     )
+    from toucan_connectors.utils.dataframe import append_dataframes
 
     CONNECTOR_OK = True
 except ImportError as exc:  # pragma: no cover
@@ -194,7 +195,7 @@ class HttpAPIConnector(ToucanConnector, data_source_model=HttpAPIDataSource):
                 raise
         if data_source.flatten_column:
             dfs = [json_to_table(df, columns=[data_source.flatten_column]) for df in dfs]
-        return functools.reduce(lambda df, df_second: df.append(df_second), dfs)
+        return functools.reduce(append_dataframes, dfs)
 
     def _render_query(self, data_source):
         query = nosql_apply_parameters_to_query(

--- a/toucan_connectors/http_api/http_api_connector.py
+++ b/toucan_connectors/http_api/http_api_connector.py
@@ -1,4 +1,3 @@
-import functools
 import json
 from enum import Enum
 from logging import getLogger
@@ -20,7 +19,6 @@ try:
         NoopPaginationConfig,
         extract_pagination_info_from_result,
     )
-    from toucan_connectors.utils.dataframe import append_dataframes
 
     CONNECTOR_OK = True
 except ImportError as exc:  # pragma: no cover
@@ -195,7 +193,7 @@ class HttpAPIConnector(ToucanConnector, data_source_model=HttpAPIDataSource):
                 raise
         if data_source.flatten_column:
             dfs = [json_to_table(df, columns=[data_source.flatten_column]) for df in dfs]
-        return functools.reduce(append_dataframes, dfs)
+        return pd.concat(dfs)
 
     def _render_query(self, data_source):
         query = nosql_apply_parameters_to_query(

--- a/toucan_connectors/http_api/pagination_configs.py
+++ b/toucan_connectors/http_api/pagination_configs.py
@@ -56,6 +56,13 @@ class OffsetLimitPaginationConfig(PaginationConfig):
     offset: int = Field(0, **UI_HIDDEN)
     limit_name: str = "limit"
     limit: int
+    data_length_filter: str = Field(
+        ".",
+        description=(
+            "Filter to determine the data length and compare it to the limit value. "
+            "It must point to a list of results. " + FilterSchemaDescription
+        ),
+    )
 
     def plan_pagination_updates_to_data_source(self, request_params: dict[str, Any] | None) -> dict[str, Any]:
         offset_limit_params = {self.offset_name: self.offset, self.limit_name: self.limit}
@@ -68,7 +75,7 @@ class OffsetLimitPaginationConfig(PaginationConfig):
     def get_next_pagination_config(
         self, result: Any, pagination_info: Any | None
     ) -> Optional["OffsetLimitPaginationConfig"]:
-        if len(result) < self.limit:
+        if len(pagination_info) < self.limit:
             return None
         else:
             return self.model_copy(update={"offset": self.offset + self.limit})
@@ -77,7 +84,7 @@ class OffsetLimitPaginationConfig(PaginationConfig):
         return None
 
     def get_pagination_info_filter(self) -> str | None:
-        return None
+        return self.data_length_filter
 
 
 class PageBasedPaginationConfig(PaginationConfig):

--- a/toucan_connectors/http_api/pagination_configs.py
+++ b/toucan_connectors/http_api/pagination_configs.py
@@ -56,10 +56,10 @@ class OffsetLimitPaginationConfig(PaginationConfig):
     offset: int = Field(0, **UI_HIDDEN)
     limit_name: str = "limit"
     limit: int
-    data_length_filter: str = Field(
+    data_filter: str = Field(
         ".",
         description=(
-            "Filter to determine the data length and compare it to the limit value. "
+            "Filter to access the received data. Allows to compare its length to the limit value. "
             "It must point to a list of results. " + FilterSchemaDescription
         ),
     )
@@ -84,7 +84,7 @@ class OffsetLimitPaginationConfig(PaginationConfig):
         return None
 
     def get_pagination_info_filter(self) -> str | None:
-        return self.data_length_filter
+        return self.data_filter
 
 
 class PageBasedPaginationConfig(PaginationConfig):

--- a/toucan_connectors/utils/dataframe.py
+++ b/toucan_connectors/utils/dataframe.py
@@ -1,0 +1,8 @@
+import pandas as pd
+
+
+def append_dataframes(df: "pd.DataFrame", second_df: "pd.DataFrame") -> "pd.DataFrame":
+    if pd.__version__[0] == "2":
+        return df.concat(second_df)
+    else:
+        return df.append(second_df)

--- a/toucan_connectors/utils/dataframe.py
+++ b/toucan_connectors/utils/dataframe.py
@@ -1,8 +1,0 @@
-import pandas as pd
-
-
-def append_dataframes(df: "pd.DataFrame", second_df: "pd.DataFrame") -> "pd.DataFrame":
-    if pd.__version__[0] == "2":
-        return df.concat(second_df)
-    else:
-        return df.append(second_df)


### PR DESCRIPTION
## Why

API results where appended before any user's configured transformations (filters, flatten). We have to append resulted dataframes.
Moreover, APIs can return directly json objects, which created invalid results merging.
In addition, we have to add a data_length_filter to offset_limit pagination in case of the data result isn't relevant to compute the data length.
