### PR TITLE
fix(mongo): correctly type the aggreation pipeline case TCTC-9713

### DIFF
--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -118,7 +118,7 @@ def validate_collection(client, database: str, collection: str):
 class MongoDataSource(ToucanDataSource):
     database: str = Field(..., description="The name of the database you want to query")
     collection: str = Field(..., description="The name of the collection you want to query")
-    query: Union[dict, list] = Field(
+    query: Union[dict, list[dict]] = Field(
         {},
         description="A mongo query. See more details on the Mongo " "Aggregation Pipeline in the MongoDB documentation",
     )


### PR DESCRIPTION
Otherwise, the list has no items schema, which causes the form to be empty.

After:
![image](https://github.com/user-attachments/assets/148e37e7-d226-45d2-aa27-78bbbefe3f60)
