### PR TITLE
fix(mongo): igore index when concatenating chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+### Fixed
+
+- Mongo: when reading data by chunk, ignore each individual chunk index when concatenating them.
+
 ## [7.3.1] 2024-11-14
 
 ### Fixed
 
 - Mongo: correctly type the aggregation pipeline, expected when `query` is a `list`
-
 
 ## [7.3.0] 2024-11-13
 

--- a/toucan_connectors/mongo/mongo_connector.py
+++ b/toucan_connectors/mongo/mongo_connector.py
@@ -269,7 +269,7 @@ class MongoConnector(ToucanConnector, VersionableEngineConnector, data_source_mo
             chunks = []
             while (chunk := list(itertools.islice(data, chunk_size))):
                 chunks.append(pd.DataFrame.from_records(chunk))
-            return pd.concat(chunks) if chunks else pd.DataFrame()
+            return pd.concat(chunks, ignore_index=True) if chunks else pd.DataFrame()
         else:
             return pd.DataFrame.from_records(data)
 


### PR DESCRIPTION
https://github.com/ToucanToco/toucan-connectors/pull/1813 introduced an error because each chunk has an index starting at 0 so further transformation lead to
```
ValueError: cannot reindex on an axis with duplicate labels
```
and weird behaviour like 
![image](https://github.com/user-attachments/assets/bc870797-68b8-4e8c-b973-ef1d19ac3caa)
:upside_down_face: 

