### PR TITLE
fix(common): prevent injection during jinja templating (v2.23)

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -267,7 +267,7 @@ def test_nosql_apply_parameters_to_query_unsafe():
             {'var': 'plop'},
         )
     with pytest.raises(jinja2.exceptions.SecurityError):
-        nosql_apply_parameters_to_query({'test': "{{ var.__class__.mro()[-1] }}"}, {'var': 'plop'})
+        nosql_apply_parameters_to_query({'test': '{{ var.__class__.mro()[-1] }}'}, {'var': 'plop'})
 
 
 def test_nosql_apply_parameters_to_query_dot():

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -11,7 +11,7 @@ from typing import Any, Callable
 import jq
 import pandas as pd
 from aiohttp import ClientSession
-from jinja2 import Environment, StrictUndefined, Template, meta
+from jinja2 import StrictUndefined, Template, meta
 from jinja2.nativetypes import NativeEnvironment
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 from pydantic import Field

--- a/toucan_connectors/common.py
+++ b/toucan_connectors/common.py
@@ -13,8 +13,14 @@ import pandas as pd
 from aiohttp import ClientSession
 from jinja2 import Environment, StrictUndefined, Template, meta
 from jinja2.nativetypes import NativeEnvironment
+from jinja2.sandbox import ImmutableSandboxedEnvironment
 from pydantic import Field
 from toucan_data_sdk.utils.helpers import slugify
+
+
+class NativeImmutableSandboxedEnvironment(NativeEnvironment, ImmutableSandboxedEnvironment):
+    ...
+
 
 # Query interpolation
 
@@ -62,7 +68,7 @@ def is_jinja_alone(s: str) -> bool:
 
 
 def _has_parameters(query: dict | list[dict] | tuple | str) -> bool:
-    t = Environment().parse(query)
+    t = ImmutableSandboxedEnvironment().parse(query)
     return bool(meta.find_undeclared_variables(t) or re.search(RE_PARAM, query))
 
 
@@ -129,9 +135,9 @@ def _render_query(query: dict | list[dict] | tuple | str, parameters: dict):
             clean_p = _prepare_parameters(clean_p)
 
         if is_jinja_alone(query):
-            env = NativeEnvironment()
+            env = NativeImmutableSandboxedEnvironment()
         else:
-            env = Environment()
+            env = ImmutableSandboxedEnvironment()
 
         res = env.from_string(query).render(clean_p)
         # NativeEnvironment's render() isn't recursive, so we need to

--- a/toucan_connectors/snowflake/snowflake_connector.py
+++ b/toucan_connectors/snowflake/snowflake_connector.py
@@ -11,7 +11,7 @@ import jwt
 import pandas as pd
 import requests
 import snowflake
-from jinja2 import Template
+from jinja2.sandbox import ImmutableSandboxedEnvironment
 from pydantic import Field, SecretStr, create_model
 from snowflake.connector import SnowflakeConnection
 
@@ -220,7 +220,7 @@ class SnowflakeConnector(ToucanConnector):
 
     def get_connection_params(self):
         params = {
-            'user': Template(self.user).render(),
+            'user': ImmutableSandboxedEnvironment().from_string(self.user).render(),
             'account': self.account,
             'authenticator': self.authentication_method,
             # hard Snowflake params


### PR DESCRIPTION
Security issue: some users could inject malicious code in jinja templates in queries if we don't use the sandboxed environment