### PR TITLE
fix: can instantiate oauth2 connectors without oauth backend fields (TCTC-10138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed 
 
-- Github & Snowflake & OneDrive & Salesforce: can instantiate connectors in light mode (without backend fields or secrets keeper)
+- Github & Snowflake & OneDrive & Salesforce connectors can now be instantiated without backend fields or a secrets keeper
 
 ## [7.7.5] 2025-02-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed 
+
+- Github & Snowflake & OneDrive & Salesforce: can instantiate connectors in light mode (without backend fields or secrets keeper)
+
 ## [7.7.5] 2025-02-07
 
 ### Fixed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,20 +149,21 @@ def service_container(unused_port, container_starter):
     return f
 
 
+class SimpleSecretsKeeper(SecretsKeeper):
+    def __init__(self):
+        self.store = {}
+
+    def load(self, key: str, **kwargs) -> Any:
+        if key not in self.store:
+            return None
+        return self.store[key]
+
+    def save(self, key: str, value: Any, **kwargs):
+        self.store[key] = value
+
+
 @pytest.fixture
-def secrets_keeper():
-    class SimpleSecretsKeeper(SecretsKeeper):
-        def __init__(self):
-            self.store = {}
-
-        def load(self, key: str) -> Any:
-            if key not in self.store:
-                return None
-            return self.store[key]
-
-        def save(self, key: str, value: Any):
-            self.store[key] = value
-
+def secrets_keeper() -> SimpleSecretsKeeper:
     return SimpleSecretsKeeper()
 
 

--- a/tests/github/test_github.py
+++ b/tests/github/test_github.py
@@ -557,3 +557,8 @@ def test_get_rate_limit_exhausted(
     )
     assert mockedsleep.call_count == 3
     assert mockedsleep.call_args_list[1][0][0] == 48
+
+
+def test_instantiate_github_connector_without_oauth_parameters() -> None:
+    github = GithubConnector(name="github", auth_flow_id="uuid-1234")
+    assert github.auth_flow_id == "uuid-1234"

--- a/tests/oauth2_connector/test_oauth2connector.py
+++ b/tests/oauth2_connector/test_oauth2connector.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from tests.conftest import SimpleSecretsKeeper
 from toucan_connectors.http_api.http_api_connector import HttpAPIConnector
 from toucan_connectors.json_wrapper import JsonWrapper
 from toucan_connectors.oauth2_connector.oauth2connector import (
@@ -11,6 +12,7 @@ from toucan_connectors.oauth2_connector.oauth2connector import (
     NoOAuth2RefreshToken,
     OAuth2Connector,
     OAuth2ConnectorConfig,
+    OAuth2ConnectorConfigMissingError,
     SecretKeeperMissingError,
 )
 from toucan_connectors.snowflake_oauth2.snowflake_oauth2_connector import SnowflakeoAuth2Connector
@@ -264,3 +266,15 @@ def test_raises_exception_if_secret_keeper_not_set(oauth2_connector_without_secr
 
     with pytest.raises(SecretKeeperMissingError):
         oauth2_connector_without_secret_keeper.get_refresh_token()
+
+
+def test_raises_exception_if_config_not_set(secrets_keeper: SimpleSecretsKeeper):
+    oauth2_connector_without_config = OAuth2Connector(
+        auth_flow_id="test",
+        authorization_url=FAKE_AUTHORIZATION_URL,
+        scope=SCOPE,
+        token_url=FAKE_TOKEN_URL,
+        secrets_keeper=secrets_keeper,
+    )
+    with pytest.raises(OAuth2ConnectorConfigMissingError):
+        oauth2_connector_without_config._oauth_config()

--- a/tests/one_drive/test_one_drive.py
+++ b/tests/one_drive/test_one_drive.py
@@ -629,3 +629,11 @@ def test__run_fetch_failed(con, mocker, ds_with_site):
     mocker.patch.object(OneDriveConnector, "_run_fetch", side_effect=requests.exceptions.HTTPError)
     df = con._retrieve_data(ds_with_site)
     assert df.empty
+
+
+def test_instantiate_light_one_drive_connector():
+    light_connector = OneDriveConnector(
+        name="my one drive", auth_flow_id="uuid", scope="scope", client_id="client_id", tenant="tenant"
+    )
+    assert light_connector.auth_flow_id == "uuid"
+    assert light_connector._oauth2_connector.secrets_keeper is None

--- a/tests/salesforce/test_salesforce.py
+++ b/tests/salesforce/test_salesforce.py
@@ -174,3 +174,11 @@ def test__retrieve_data_no_secret(sc, ds, remove_secrets):
     """Checks that we have an exception as we secret was removed"""
     with pytest.raises(NoOAuth2RefreshToken):
         sc._retrieve_data(sc)
+
+
+def test_can_instantiate_light_salesforce_connector() -> None:
+    light_connector = SalesforceConnector(name="salesforce", auth_flow_id="auth-flow-id", instance_url="super_url")
+
+    assert light_connector.auth_flow_id == "auth-flow-id"
+    assert light_connector._oauth2_connector.secrets_keeper is None
+    assert light_connector._oauth2_connector.config is None

--- a/tests/snowflake_oauth2/test_snowflake_oauth2.py
+++ b/tests/snowflake_oauth2/test_snowflake_oauth2.py
@@ -596,3 +596,16 @@ def test_get_model_exception(
         snowflake_oauth2_connector.get_model()
     mocked_common_get_databases.assert_called_once()
     cm.force_clean()
+
+
+def test_can_instantiate_light_snowflake_connector() -> None:
+    light_connector = SnowflakeoAuth2Connector(
+        name="snowflake_oauth2",
+        scope="scope",
+        role="super_role",
+        account="my_account",
+        default_warehouse="my_warehouse",
+    )
+
+    assert light_connector.scope == "scope"
+    assert light_connector._oauth2_connector.secrets_keeper is None

--- a/toucan_connectors/github/github_connector.py
+++ b/toucan_connectors/github/github_connector.py
@@ -114,17 +114,21 @@ class GithubConnector(ToucanConnector, data_source_model=GithubDataSource):
 
     def __init__(self, **kwargs):
         super().__init__(**{k: v for k, v in kwargs.items() if k not in OAuth2Connector.init_params})
+        oauth_config = None
+        if "client_id" in kwargs and "client_secret" in kwargs:
+            oauth_config = OAuth2ConnectorConfig(
+                client_id=kwargs["client_id"],
+                client_secret=kwargs["client_secret"],
+            )
+
         self._oauth2_connector = OAuth2Connector(
             auth_flow_id=self.auth_flow_id,
             authorization_url=AUTHORIZATION_URL,
             scope=SCOPE,
             token_url=TOKEN_URL,
-            secrets_keeper=kwargs["secrets_keeper"],
-            redirect_uri=kwargs["redirect_uri"],
-            config=OAuth2ConnectorConfig(
-                client_id=kwargs["client_id"],
-                client_secret=kwargs["client_secret"],
-            ),
+            secrets_keeper=kwargs.get("secrets_keeper", None),
+            redirect_uri=kwargs.get("redirect_uri", None),
+            config=oauth_config,
         )
 
     def build_authorization_url(self, **kwargs):

--- a/toucan_connectors/one_drive/one_drive_connector.py
+++ b/toucan_connectors/one_drive/one_drive_connector.py
@@ -82,9 +82,10 @@ class OneDriveConnector(ToucanConnector, data_source_model=OneDriveDataSource):
     oauth2_version: str = Field("1", **{"ui.hidden": True})
     auth_flow_id: str | None = None
 
+    # Set by backend during oauth2 dance
     authorization_url: str = Field(None, **{"ui.hidden": True})
     token_url: str = Field(None, **{"ui.hidden": True})
-    redirect_uri: str = Field(None, **{"ui.hidden": True})
+    redirect_uri: str | None = Field(None, **{"ui.hidden": True})
     _oauth2_connector: OAuth2Connector = PrivateAttr()
 
     client_id: str = Field(
@@ -132,7 +133,7 @@ class OneDriveConnector(ToucanConnector, data_source_model=OneDriveDataSource):
                 client_id=self.client_id,
                 client_secret=self.client_secret,
             ),
-            secrets_keeper=kwargs["secrets_keeper"],
+            secrets_keeper=kwargs.get("secrets_keeper", None),
         )
 
     def build_authorization_url(self, **kwargs):

--- a/toucan_connectors/salesforce/salesforce_connector.py
+++ b/toucan_connectors/salesforce/salesforce_connector.py
@@ -76,17 +76,21 @@ class SalesforceConnector(ToucanConnector, data_source_model=SalesforceDataSourc
 
     def __init__(self, **kwargs):
         super().__init__(**{k: v for k, v in kwargs.items() if k not in OAuth2Connector.init_params})
+        oauth_config = None
+        if "client_id" in kwargs and "client_secret" in kwargs:
+            oauth_config = OAuth2ConnectorConfig(
+                client_id=kwargs["client_id"],
+                client_secret=kwargs["client_secret"],
+            )
+
         self._oauth2_connector = OAuth2Connector(
             auth_flow_id=self.auth_flow_id,
             authorization_url=AUTHORIZATION_URL_SANDBOX if self.type == "SalesforceSandbox" else AUTHORIZATION_URL_PROD,
             scope=SCOPE,
             token_url=TOKEN_URL_SANDBOX if self.type == "SalesforceSandbox" else TOKEN_URL_PROD,
-            secrets_keeper=kwargs["secrets_keeper"],
-            redirect_uri=kwargs["redirect_uri"],
-            config=OAuth2ConnectorConfig(
-                client_id=kwargs["client_id"],
-                client_secret=kwargs["client_secret"],
-            ),
+            secrets_keeper=kwargs.get("secrets_keeper", None),
+            redirect_uri=kwargs.get("redirect_uri", None),
+            config=oauth_config,
         )
 
     def build_authorization_url(self, **kwargs):

--- a/toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py
+++ b/toucan_connectors/snowflake_oauth2/snowflake_oauth2_connector.py
@@ -90,7 +90,7 @@ class SnowflakeoAuth2Connector(ToucanConnector, data_source_model=SnowflakeoAuth
     _auth_flow = "oauth2"
     _oauth_trigger = "connector"
     oauth2_version: str = Field("1", **{"ui.hidden": True})  # type: ignore[call-overload]
-    redirect_uri: str = Field(None, **{"ui.hidden": True})  # type: ignore[call-overload]
+    redirect_uri: str | None = Field(None, **{"ui.hidden": True})  # type: ignore[call-overload]
     _oauth2_connector: OAuth2Connector = PrivateAttr()
 
     role: str = Field(  # type: ignore[call-overload]
@@ -124,7 +124,7 @@ class SnowflakeoAuth2Connector(ToucanConnector, data_source_model=SnowflakeoAuth
                 client_id=self.client_id,
                 client_secret=self.client_secret,
             ),
-            secrets_keeper=kwargs["secrets_keeper"],
+            secrets_keeper=kwargs.get("secrets_keeper", None),
         )
 
     def build_authorization_url(self, **kwargs):


### PR DESCRIPTION
### Why

We want to be able to instantiate connectors without backend fields or secrets keeper.
Oauth2 connector configs can be saved without their secrets and without the fields set by the backend for oauth2 dance.
