### PR TITLE
fix(mssql): use sqlalchemy engine for get_form as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- MSSQL: fixed the get_form route by using the same method as data retrieval
+
 ## [8.0.0] 2025-04-09
 
 ### Added


### PR DESCRIPTION
Time out on `get_form`. I suspect this is because the way we execute queries in this function bypasses `sqlalchemy`.
This new proposal uses the same execution route as data, which works.

```
(pyodbc.OperationalError) ('HYT00', '[HYT00] [Microsoft][ODBC Driver 18 for SQL Server]Login timeout expired (0) (SQLDriverConnect)') (Background on this error at: https://sqlalche.me/e/20/e3q8)
```