### PR TITLE
test(mssql): discard login errors while waiting for the db to start

### DIFF
--- a/tests/mssql/test_mssql.py
+++ b/tests/mssql/test_mssql.py
@@ -45,7 +45,7 @@ def mssql_server(service_container: ServiceContainerStarter, request: pytest.Fix
 
                 cur.close()
 
-    return service_container(request.param, check_and_feed, OperationalError | InterfaceError)
+    return service_container(request.param, check_and_feed, (OperationalError, InterfaceError))
 
 
 @pytest.fixture

--- a/tests/mssql/test_mssql.py
+++ b/tests/mssql/test_mssql.py
@@ -7,7 +7,7 @@ import pydantic
 import pytest
 from pandas.testing import assert_frame_equal
 from pytest_mock import MockerFixture
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import InterfaceError, OperationalError
 from sqlalchemy.orm import Session
 
 from tests.conftest import DockerContainer, ServiceContainerStarter
@@ -45,7 +45,7 @@ def mssql_server(service_container: ServiceContainerStarter, request: pytest.Fix
 
                 cur.close()
 
-    return service_container(request.param, check_and_feed, OperationalError)
+    return service_container(request.param, check_and_feed, OperationalError | InterfaceError)
 
 
 @pytest.fixture

--- a/toucan_connectors/mssql/mssql_connector.py
+++ b/toucan_connectors/mssql/mssql_connector.py
@@ -142,6 +142,8 @@ class MSSQLConnector(ToucanConnector, data_source_model=MSSQLDataSource):
 
         connect_args = {"timeout": connect_timeout} if connect_timeout else None
 
+        if connect_timeout:
+            query_params["timeout"] = str(connect_timeout)
         if self.trust_server_certificate:
             query_params["TrustServerCertificate"] = "yes"
 


### PR DESCRIPTION
While the MSSQL database is booting up, the login may fail. This was introducing flakyness in the tests cases.


## Change Summary

- discard `InterfaceError` as well as `OperationError`. If login is indeed broken (which should be rare), it will end up in a timeout error instead, which is fine.

## Related

https://github.com/ToucanToco/toucan-connectors/actions/runs/14832515032/job/41636596419

## Checklist

* [x] Unit tests for the changes exist
* [x] Tests pass on CI and coverage remains at 100%
* [ ] ~~Documentation reflects the changes where applicable~~
